### PR TITLE
Refactor _ei_improvement into gaussian_acquisition

### DIFF
--- a/skopt/acquisition.py
+++ b/skopt/acquisition.py
@@ -5,77 +5,168 @@ import numpy as np
 from scipy.stats import norm
 
 
-def gaussian_acquisition(X, model, y_opt=None, method="LCB",
-                         xi=0.01, kappa=1.96):
+def _gaussian_acquisition(X, model, y_opt=None, method="LCB",
+                          xi=0.01, kappa=1.96):
     """
-    Returns the acquisition function computed at values x0 where the
-    conditional is assumed to be a Gaussian with the mean and std
-    provided by the underlying base estimator.
-
-    Parameters
-    ----------
-    X : array-like
-        Values where the acquisition function should be computed.
-
-    model: sklearn estimator that implements predict with ``return_std``
-        The fit sklearn gaussian process estimator that approximates
-        the function. It should have a ``return_std`` parameter
-        that returns the standard deviation.
-
-    y_opt: float, optional
-        The previous best value over which we want to improve.
-        Useful only when `acq` is set to "EI"
-
-    method: string, "LCB" or "EI"
-        If set to "LCB", then the lower confidence bound is taken.
-        If set to "EI", then the expected improvement condition is taken.
-
-    xi: float, default 0.01
-        Controls how much improvement one wants over the previous best
-        values.
-
-    kappa: float, default 1.96
-        Controls how much of the variance in the predicted values should be
-        taken into account. If set to be very high, then we are favouring
-        exploration over exploitation and vice versa.
-        Useless if acq is set to "EI"
-
-    Returns
-    -------
-    values: array-like, length X
-        Acquisition function values computed at X.
+    Wrapper so that the output of this function can be
+    directly passed to a minimizer.
     """
     # Check inputs
     X = np.asarray(X)
     if X.ndim != 2:
         raise ValueError("X should be 2-dimensional.")
 
+    # Evaluate acquisition function
+    if method == "LCB":
+        return gaussian_lcb(X, model, kappa)
+    elif method == "EI":
+        return -gaussian_ei(X, model, y_opt, xi)
+    elif method == "PI":
+        return -gaussian_pi(X, model, y_opt, xi)
+    else:
+        raise ValueError("Acquisition function not implemented.")
+
+    return values
+
+
+def gaussian_lcb(X, model, kappa=1.96):
+    """
+    Use the lower confidence bound to estimate the acquisition
+    values.
+
+    The trade-off between exploitation and exploration is left to
+    be controlled by the user through the parameter ``kappa``.
+
+    Parameters
+    ----------
+    * `X` [array-like, shape=(n_samples, n_features)]:
+        Values where the acquisition function should be computed.
+
+    * `model` [sklearn estimator that implements predict with ``return_std``]:
+        The fit estimator that approximates the function through the
+        method ``predict``.
+        It should have a ``return_std`` parameter that returns the standard
+        deviation.
+
+    * `kappa`: [float, default 1.96]:
+        Controls how much of the variance in the predicted values should be
+        taken into account. If set to be very high, then we are favouring
+        exploration over exploitation and vice versa.
+        Useless if ``method`` is set to "LCB".
+
+    Returns
+    -------
+    * `values`: [array-like, shape=(X.shape[0],)]:
+        Acquisition function values computed at X.
+    """
     # Compute posterior.
     with warnings.catch_warnings():
         warnings.simplefilter("ignore")
         mu, std = model.predict(X, return_std=True)
 
-    # Evaluate acquisition function
-    if method == "LCB":
-        values = mu - kappa * std
+    return mu - kappa * std
 
-    elif method == "EI":
-        values = np.zeros(len(mu))
-        mask = std > 0
-        improvement = y_opt - xi - mu[mask]
-        exploit = improvement * norm.cdf(improvement / std[mask])
-        explore = std[mask] * norm.pdf(improvement / std[mask])
-        values[mask] = exploit + explore
-        values = -values  # acquisition is minimized
 
-    elif method == "PI":
-        values = np.zeros(len(mu))
-        mask = std > 0
-        improvement = y_opt - xi - mu[mask]
-        values[mask] = norm.cdf(improvement / std[mask])
-        values = -values  # acquisition is minimized
+def gaussian_pi(X, model, y_opt=0.0, xi=0.01):
+    """
+    Use the probability of improvement to calculate the acquisition values.
 
-    else:
-        raise ValueError("Acquisition function not implemented.")
+    The conditional probability `P(y=f(x) | x)`form a gaussian with a
+    certain mean and standard deviation approximated by the model.
 
+    The PI condition is derived by computing ``E[u(f(x))]``
+    where ``u(f(x)) = 1``, if ``f(x) > y_opt`` and ``u(f(x)) = 1``,
+    if``f(x) < y_opt``.
+
+    This means that the PI condition does not care about how "better" the
+    predictions are than the previous values, since it gives an equal reward
+    to all of them.
+
+    Note that the value returned by this function should be maximized to
+    obtain the ``X`` with maximum improvement.
+
+    Parameters
+    ----------
+    * `X` [array-like, shape=(n_samples, n_features)]:
+        Values where the acquisition function should be computed.
+
+    * `model` [sklearn estimator that implements predict with ``return_std``]:
+        The fit estimator that approximates the function through the
+        method ``predict``.
+        It should have a ``return_std`` parameter that returns the standard
+        deviation.
+
+    * `y_opt` [float, default 0]:
+        Previous minimum value which we would like to improve upon.
+
+    * `xi`: [float, default=0.01]:
+        Controls how much improvement one wants over the previous best
+        values. Useful only when ``method`` is set to "EI"
+
+    Returns
+    -------
+    * `values`: [array-like, shape=(X.shape[0],)]:
+        Acquisition function values computed at X.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mu, std = model.predict(X, return_std=True)
+
+    values = np.zeros_like(mu)
+    mask = std > 0
+    improvement = y_opt - xi - mu[mask]
+    values[mask] = norm.cdf(improvement / std[mask])
+    return values
+
+
+def gaussian_ei(X, model, y_opt=0.0, xi=0.01):
+    """
+    Use the expected improvement to calculate the acquisition values.
+
+    The conditional probability `P(y=f(x) | x)`form a gaussian with a certain
+    mean and standard deviation approximated by the model.
+
+    The EI condition is derived by computing ``E[u(f(x))]``
+    where ``u(f(x)) = 0``, if ``f(x) > y_opt`` and ``u(f(x)) = y_opt - f(x)``,
+    if``f(x) < y_opt``.
+
+    This solves one of the issues of the PI condition by giving a reward
+    proportional to the amount of improvement got.
+
+    Note that the value returned by this function should be maximized to
+    obtain the ``X`` with maximum improvement.
+
+    Parameters
+    ----------
+    * `X` [array-like, shape=(n_samples, n_features)]:
+        Values where the acquisition function should be computed.
+
+    * `model` [sklearn estimator that implements predict with ``return_std``]:
+        The fit estimator that approximates the function through the
+        method ``predict``.
+        It should have a ``return_std`` parameter that returns the standard
+        deviation.
+
+    * `y_opt` [float, default 0]:
+        Previous minimum value which we would like to improve upon.
+
+    * `xi`: [float, default=0.01]:
+        Controls how much improvement one wants over the previous best
+        values. Useful only when ``method`` is set to "EI"
+
+    Returns
+    -------
+    * `values`: [array-like, shape=(X.shape[0],)]:
+        Acquisition function values computed at X.
+    """
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mu, std = model.predict(X, return_std=True)
+
+    values = np.zeros_like(mu)
+    mask = std > 0
+    improvement = y_opt - xi - mu[mask]
+    exploit = improvement * norm.cdf(improvement / std[mask])
+    explore = std[mask] * norm.pdf(improvement / std[mask])
+    values[mask] = exploit + explore
     return values

--- a/skopt/acquisition.py
+++ b/skopt/acquisition.py
@@ -1,0 +1,81 @@
+import warnings
+
+import numpy as np
+
+from scipy.stats import norm
+
+
+def gaussian_acquisition(X, model, y_opt=None, method="LCB",
+                         xi=0.01, kappa=1.96):
+    """
+    Returns the acquisition function computed at values x0 where the
+    conditional is assumed to be a Gaussian with the mean and std
+    provided by the underlying base estimator.
+
+    Parameters
+    ----------
+    X : array-like
+        Values where the acquisition function should be computed.
+
+    model: sklearn estimator that implements predict with ``return_std``
+        The fit sklearn gaussian process estimator that approximates
+        the function. It should have a ``return_std`` parameter
+        that returns the standard deviation.
+
+    y_opt: float, optional
+        The previous best value over which we want to improve.
+        Useful only when `acq` is set to "EI"
+
+    method: string, "LCB" or "EI"
+        If set to "LCB", then the lower confidence bound is taken.
+        If set to "EI", then the expected improvement condition is taken.
+
+    xi: float, default 0.01
+        Controls how much improvement one wants over the previous best
+        values.
+
+    kappa: float, default 1.96
+        Controls how much of the variance in the predicted values should be
+        taken into account. If set to be very high, then we are favouring
+        exploration over exploitation and vice versa.
+        Useless if acq is set to "EI"
+
+    Returns
+    -------
+    values: array-like, length X
+        Acquisition function values computed at X.
+    """
+    # Check inputs
+    X = np.asarray(X)
+    if X.ndim != 2:
+        raise ValueError("X should be 2-dimensional.")
+
+    # Compute posterior.
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore")
+        mu, std = model.predict(X, return_std=True)
+
+    # Evaluate acquisition function
+    if method == "LCB":
+        values = mu - kappa * std
+
+    elif method == "EI":
+        values = np.zeros(len(mu))
+        mask = std > 0
+        improvement = y_opt - xi - mu[mask]
+        exploit = improvement * norm.cdf(improvement / std[mask])
+        explore = std[mask] * norm.pdf(improvement / std[mask])
+        values[mask] = exploit + explore
+        values = -values  # acquisition is minimized
+
+    elif method == "PI":
+        values = np.zeros(len(mu))
+        mask = std > 0
+        improvement = y_opt - xi - mu[mask]
+        values[mask] = norm.cdf(improvement / std[mask])
+        values = -values  # acquisition is minimized
+
+    else:
+        raise ValueError("Acquisition function not implemented.")
+
+    return values

--- a/skopt/gbrt_opt.py
+++ b/skopt/gbrt_opt.py
@@ -10,42 +10,7 @@ from sklearn.utils import check_random_state
 
 from .learning import GradientBoostingQuantileRegressor
 from .utils import extract_bounds
-
-
-def _expected_improvement(X, surrogate, y_opt, xi=0.01):
-    """Evaluate expected improvement for `surrogate` model at `x`
-
-    Parameters
-    ----------
-    X : array-like
-        Values at which to evaluate the acquisition function.
-
-    y_opt: float, optional
-        The previous best value on which we want to improve.
-
-    xi: float, default 0.01
-        By how much must a new point improve over the previous best
-        value.
-    """
-    X = np.asarray(X)
-    if X.ndim == 1:
-        X = np.expand_dims(X, axis=0)
-
-    # low and high are assumed to be the 16% and 84% quantiles
-    low, mu, high = surrogate.predict(X).T
-    # approximate the std dev, if the pdf is gaussian this is exact
-    std = (high - low) / 2.
-
-    ei = np.zeros(len(mu))
-
-    mask = std > 0
-    improvement = y_opt - xi - mu[mask]
-    exploit = improvement * stats.norm.cdf(improvement / std[mask])
-    explore = std[mask] * stats.norm.pdf(improvement / std[mask])
-    ei[mask] = exploit + explore
-
-    ei = -ei # we are being used in a minimizer
-    return ei
+from .acquisition import gaussian_acquisition
 
 
 def _random_points(lower, upper, n_points=1, random_state=None):
@@ -158,7 +123,7 @@ def gbrt_minimize(func, bounds, base_estimator=None, maxiter=100,
         x0 = _random_points(lower_bounds, upper_bounds,
                             n_points=n_points,
                             random_state=rng)
-        aq = _expected_improvement(x0, rgr, best_y)
+        aq = gaussian_acquisition(x0, rgr, best_y, method="EI")
         best = np.argmin(aq)
 
         Xi[i] = x0[best].ravel()

--- a/skopt/gbrt_opt.py
+++ b/skopt/gbrt_opt.py
@@ -10,7 +10,7 @@ from sklearn.utils import check_random_state
 
 from .learning import GradientBoostingQuantileRegressor
 from .utils import extract_bounds
-from .acquisition import gaussian_acquisition
+from .acquisition import gaussian_ei
 
 
 def _random_points(lower, upper, n_points=1, random_state=None):
@@ -123,8 +123,7 @@ def gbrt_minimize(func, bounds, base_estimator=None, maxiter=100,
         x0 = _random_points(lower_bounds, upper_bounds,
                             n_points=n_points,
                             random_state=rng)
-        aq = gaussian_acquisition(x0, rgr, best_y, method="EI")
-        best = np.argmin(aq)
+        best = np.argmax(gaussian_ei(x0, rgr, best_y))
 
         Xi[i] = x0[best].ravel()
         yi[i] = func(x0[best])

--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -10,6 +10,7 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern, ConstantKernel
 from sklearn.utils import check_random_state
 
+from .acquisition import gaussian_acquisition
 from .utils import extract_bounds
 
 
@@ -20,81 +21,7 @@ def _acquisition(X, model, y_opt=None, method="LCB", xi=0.01, kappa=1.96):
     This is because lbfgs allows only 1-D input.
     """
     X = np.expand_dims(X, axis=0)
-    return acquisition(X, model, y_opt, method, xi, kappa)
-
-
-def acquisition(X, model, y_opt=None, method="LCB", xi=0.01, kappa=1.96):
-    """
-    Returns the acquisition function computed at values x0, when the
-    prior of the unknown function is approximated by a Gaussian process.
-
-    Parameters
-    ----------
-    X : array-like
-        Values where the acquisition function should be computed.
-
-    model: sklearn estimator that implements predict with ``return_std``
-        The fit sklearn gaussian process estimator that approximates
-        the function. It should have a ``return_std`` parameter
-        that returns the standard deviation.
-
-    y_opt: float, optional
-        The previous best value over which we want to improve.
-        Useful only when `acq` is set to "EI"
-
-    method: string, "LCB" or "EI"
-        If set to "LCB", then the lower confidence bound is taken.
-        If set to "EI", then the expected improvement condition is taken.
-
-    xi: float, default 0.01
-        Controls how much improvement one wants over the previous best
-        values.
-
-    kappa: float, default 1.96
-        Controls how much of the variance in the predicted values should be
-        taken into account. If set to be very high, then we are favouring
-        exploration over exploitation and vice versa.
-        Useless if acq is set to "EI"
-
-    Returns
-    -------
-    values: array-like, length X
-        Acquisition function values computed at X.
-    """
-    # Check inputs
-    X = np.asarray(X)
-    if X.ndim != 2:
-        raise ValueError("X should be 2-dimensional.")
-
-    # Compute posterior.
-    with warnings.catch_warnings():
-        warnings.simplefilter("ignore")
-        mu, std = model.predict(X, return_std=True)
-
-    # Evaluate acquisition function
-    if method == "LCB":
-        values = mu - kappa * std
-
-    elif method == "EI":
-        values = np.zeros(len(mu))
-        mask = std > 0
-        improvement = y_opt - xi - mu[mask]
-        exploit = improvement * norm.cdf(improvement / std[mask])
-        explore = std[mask] * norm.pdf(improvement / std[mask])
-        values[mask] = exploit + explore
-        values = -values  # acquisition is minimized
-
-    elif method == "PI":
-        values = np.zeros(len(mu))
-        mask = std > 0
-        improvement = y_opt - xi - mu[mask]
-        values[mask] = norm.cdf(improvement / std[mask])
-        values = -values  # acquisition is minimized
-
-    else:
-        raise ValueError("Acquisition function not implemented.")
-
-    return values
+    return gaussian_acquisition(X, model, y_opt, method, xi, kappa)
 
 
 def gp_minimize(func, bounds, base_estimator=None, acq="LCB", xi=0.01,
@@ -228,8 +155,9 @@ def gp_minimize(func, bounds, base_estimator=None, acq="LCB", xi=0.01,
 
         if search == "sampling":
             X = lb + (ub - lb) * rng.rand(n_points, n_params)
-            values = acquisition(X=X, model=gp,  y_opt=np.min(yi), method=acq,
-                                 xi=xi, kappa=kappa)
+            values = gaussian_acquisition(
+                X=X, model=gp,  y_opt=np.min(yi), method=acq,
+                xi=xi, kappa=kappa)
             next_x = X[np.argmin(values)]
 
         elif search == "lbfgs":

--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -10,7 +10,7 @@ from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern, ConstantKernel
 from sklearn.utils import check_random_state
 
-from .acquisition import gaussian_acquisition
+from .acquisition import _gaussian_acquisition
 from .utils import extract_bounds
 
 
@@ -21,7 +21,7 @@ def _acquisition(X, model, y_opt=None, method="LCB", xi=0.01, kappa=1.96):
     This is because lbfgs allows only 1-D input.
     """
     X = np.expand_dims(X, axis=0)
-    return gaussian_acquisition(X, model, y_opt, method, xi, kappa)
+    return _gaussian_acquisition(X, model, y_opt, method, xi, kappa)
 
 
 def gp_minimize(func, bounds, base_estimator=None, acq="LCB", xi=0.01,
@@ -155,7 +155,7 @@ def gp_minimize(func, bounds, base_estimator=None, acq="LCB", xi=0.01,
 
         if search == "sampling":
             X = lb + (ub - lb) * rng.rand(n_points, n_params)
-            values = gaussian_acquisition(
+            values = _gaussian_acquisition(
                 X=X, model=gp,  y_opt=np.min(yi), method=acq,
                 xi=xi, kappa=kappa)
             next_x = X[np.argmin(values)]

--- a/skopt/learning/gbrt.py
+++ b/skopt/learning/gbrt.py
@@ -51,6 +51,31 @@ class GradientBoostingQuantileRegressor(BaseEstimator, RegressorMixin):
 
         return self
 
-    def predict(self, X):
-        """Predict for each quantile."""
-        return np.asarray([rgr.predict(X) for rgr in self.regressors_]).T
+    def predict(self, X, return_std=False):
+        """Predict.
+
+        Predict X at every quantile if ``return_std`` is set to False.
+        If ``return_std`` is set to True, then return the mean
+        and the predicted standard deviation, which is approximated as
+        the (0.84th quantile - 0.16th quantile) divided by 2.0
+
+        Parameters
+        ----------
+        * `X` [array-like, shape=(n_samples, n_features):
+            where `n_samples` is the number of samples
+            and `n_features` is the number of features.
+        """
+        predicted_quantiles = np.asarray(
+            [rgr.predict(X) for rgr in self.regressors_])
+        if not return_std:
+            return predicted_quantiles.T
+        else:
+            std_quantiles = [0.16, 0.5, 0.84]
+            is_present_mask = np.in1d(std_quantiles, self.quantiles)
+            if not np.all(is_present_mask):
+                raise ValueError(
+                    "return_std works only if the quan")
+            low = self.regressors_[self.quantiles.index(0.16)].predict(X)
+            high = self.regressors_[self.quantiles.index(0.84)].predict(X)
+            mean = self.regressors_[self.quantiles.index(0.5)].predict(X)
+            return mean, ((high - low) / 2.0)

--- a/skopt/learning/gbrt.py
+++ b/skopt/learning/gbrt.py
@@ -74,7 +74,8 @@ class GradientBoostingQuantileRegressor(BaseEstimator, RegressorMixin):
             is_present_mask = np.in1d(std_quantiles, self.quantiles)
             if not np.all(is_present_mask):
                 raise ValueError(
-                    "return_std works only if the quan")
+                    "return_std works only if the quantiles during "
+                    "instantiation include 0.16, 0.5 and 0.84")
             low = self.regressors_[self.quantiles.index(0.16)].predict(X)
             high = self.regressors_[self.quantiles.index(0.84)].predict(X)
             mean = self.regressors_[self.quantiles.index(0.5)].predict(X)

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from sklearn.gaussian_process import GaussianProcessRegressor
+from sklearn.utils.testing import assert_array_almost_equal
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_raises
+
+from skopt.acquisition import gaussian_acquisition
+
+class ConstSurrogate:
+    def predict(self, X, return_std=True):
+        return np.zeros(X.shape[0]), np.ones(X.shape[0])
+
+def test_acquisition_ei_correctness():
+    # check that it works with a vector as well
+    ei = gaussian_acquisition(np.array([[10., 10.],
+                                        [10., 10.],
+                                        [10., 10.],
+                                        [10., 10.]]),
+                              ConstSurrogate(),
+                              -0.5,
+                              xi=0., method="EI")
+
+    assert_array_almost_equal(ei, [-0.1977966] * 4)
+
+def test_acquisition_api():
+    rng = np.random.RandomState(0)
+    X = rng.randn(10, 2)
+    y = rng.randn(10)
+    gpr = GaussianProcessRegressor()
+    gpr.fit(X, y)
+
+    assert_array_equal(gaussian_acquisition(X, gpr).shape, 10)
+    assert_raises(ValueError, gaussian_acquisition, rng.rand(10), gpr)

--- a/skopt/tests/test_gbrt.py
+++ b/skopt/tests/test_gbrt.py
@@ -59,3 +59,7 @@ def test_gbrt_with_std():
     l, c, h = model.predict(X_).T
     assert_equal(l.shape, c.shape, h.shape)
     assert_equal(l.shape[0], X_.shape[0])
+
+    mean, std = model.predict(X_, return_std=True)
+    assert_array_equal(mean, c)
+    assert_array_equal(std, (h - l) / 2.0)

--- a/skopt/tests/test_gbrt_opt.py
+++ b/skopt/tests/test_gbrt_opt.py
@@ -7,7 +7,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raise_message
 
-from skopt.acquisition import gaussian_acquisition
+from skopt.acquisition import _gaussian_acquisition
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3

--- a/skopt/tests/test_gbrt_opt.py
+++ b/skopt/tests/test_gbrt_opt.py
@@ -7,6 +7,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raise_message
 
+from skopt.acquisition import gaussian_acquisition
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
@@ -14,36 +15,7 @@ from skopt.benchmarks import branin
 from skopt.benchmarks import hart6
 from skopt.learning import GradientBoostingQuantileRegressor
 from skopt.gbrt_opt import gbrt_minimize
-from skopt.gbrt_opt import _expected_improvement
 from skopt.utils import extract_bounds
-
-
-class ConstSurrogate:
-    def predict(self, X):
-        return np.tile([-1., 0.,1.], (X.shape[0], 1))
-
-def test_ei_fixed_surrogate():
-    # Uses a surrogate model that always returns -1, 0, 1
-    ei = _expected_improvement(np.asarray([10., 10.]),
-                               ConstSurrogate(),
-                               -0.5,
-                               xi=0.)
-
-    assert_almost_equal(ei, -0.1977966)
-
-
-def test_ei_api():
-    # check that it works with a vector as well
-    ei = _expected_improvement(np.array([[10., 10.],
-                                         [10., 10.],
-                                         [10., 10.],
-                                         [10., 10.]]),
-                               ConstSurrogate(),
-                               -0.5,
-                               xi=0.)
-
-    assert_array_almost_equal(ei, [-0.1977966] * 4)
-
 
 def test_no_iterations():
     assert_raise_message(ValueError, "at least one iteration",

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -7,7 +7,6 @@ from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raises
 
-from skopt.gp_opt import acquisition
 from skopt.gp_opt import gp_minimize
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
@@ -42,14 +41,3 @@ def test_api():
     assert_array_less(np.tile([-5, 0], (20, 1)), res.x_iters)
 
     assert_raises(ValueError, gp_minimize, lambda x: x, [[-5, 10]])
-
-
-def test_acquisition_api():
-    rng = np.random.RandomState(0)
-    X = rng.randn(10, 2)
-    y = rng.randn(10)
-    gpr = GaussianProcessRegressor()
-    gpr.fit(X, y)
-
-    assert_array_equal(acquisition(X, gpr).shape, 10)
-    assert_raises(ValueError, acquisition, rng.rand(10), gpr)


### PR DESCRIPTION
Allow `return_std` parameter for GBRT.predict
Move `_ei_improvement` and `acquisition` into `gaussian_acquisition` which suggests that the conditional is a gaussian.