### PR TITLE
Applying the flake8 steamroller

### DIFF
--- a/skopt/acquisition.py
+++ b/skopt/acquisition.py
@@ -26,8 +26,6 @@ def _gaussian_acquisition(X, model, y_opt=None, method="LCB",
     else:
         raise ValueError("Acquisition function not implemented.")
 
-    return values
-
 
 def gaussian_lcb(X, model, kappa=1.96):
     """

--- a/skopt/gbrt_opt.py
+++ b/skopt/gbrt_opt.py
@@ -2,7 +2,6 @@
 
 import numpy as np
 
-from scipy import stats
 from scipy.optimize import OptimizeResult
 
 from sklearn.base import clone

--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -3,7 +3,6 @@ import warnings
 
 from scipy.optimize import fmin_l_bfgs_b
 from scipy.optimize import OptimizeResult
-from scipy.stats import norm
 
 from sklearn.base import clone
 from sklearn.gaussian_process import GaussianProcessRegressor

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -14,11 +14,13 @@ class ConstSurrogate:
     def predict(self, X, return_std=True):
         return np.zeros(X.shape[0]), np.ones(X.shape[0])
 
+
 def test_acquisition_ei_correctness():
     # check that it works with a vector as well
     X = 10 * np.ones((4, 2))
     ei = gaussian_ei(X, ConstSurrogate(), -0.5, xi=0.)
     assert_array_almost_equal(ei, [0.1977966] * 4)
+
 
 def test_acquisition_pi_correctness():
     # check that it works with a vector as well
@@ -26,11 +28,13 @@ def test_acquisition_pi_correctness():
     pi = gaussian_pi(X, ConstSurrogate(), -0.5, xi=0.)
     assert_array_almost_equal(pi, [0.308538] * 4)
 
+
 def test_acquisition_lcb_correctness():
     # check that it works with a vector as well
     X = 10 * np.ones((4, 2))
     lcb = gaussian_lcb(X, ConstSurrogate(), kappa=0.3)
     assert_array_almost_equal(lcb, [-0.3] * 4)
+
 
 def test_acquisition_api():
     rng = np.random.RandomState(0)

--- a/skopt/tests/test_gbrt.py
+++ b/skopt/tests/test_gbrt.py
@@ -12,8 +12,10 @@ from skopt.learning import GradientBoostingQuantileRegressor
 def truth(X):
     return 0.5 * np.sin(1.75*X[:, 0])
 
+
 def constant_noise(X):
     return np.ones_like(X)
+
 
 def sample_noise(X, std=0.2, noise=constant_noise,
                  random_state=None):

--- a/skopt/tests/test_gbrt_opt.py
+++ b/skopt/tests/test_gbrt_opt.py
@@ -3,24 +3,22 @@ import numpy as np
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raise_message
 
-from skopt.acquisition import _gaussian_acquisition
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
 from skopt.benchmarks import branin
 from skopt.benchmarks import hart6
-from skopt.learning import GradientBoostingQuantileRegressor
 from skopt.gbrt_opt import gbrt_minimize
-from skopt.utils import extract_bounds
+
 
 def test_no_iterations():
     assert_raise_message(ValueError, "at least one iteration",
                          gbrt_minimize,
-                         branin, [[-5, 10], [0, 15]], maxiter=0, random_state=1)
+                         branin, [[-5, 10], [0, 15]], maxiter=0,
+                         random_state=1)
 
     assert_raise_message(ValueError, "at least one starting point",
                          gbrt_minimize,

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -1,7 +1,6 @@
 import numpy as np
 from itertools import product
 
-from sklearn.gaussian_process import GaussianProcessRegressor
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_less


### PR DESCRIPTION
Down to to one complaint about a long line in `skopt/__init__.py` don't think
there is much we can do about that if we want to have the badge.

For future use I used `flake8 skopt/*`.