### PR TITLE
[WIP] Test return type of Space.rvs()

### DIFF
--- a/skopt/space.py
+++ b/skopt/space.py
@@ -338,7 +338,10 @@ class Space:
             else:
                 columns.append(dim.rvs(n_samples=n_samples, random_state=rng))
 
-        return np.transpose(columns)
+        # Build a mixed type array, we have to name fields but can use
+        # an empty string to have names generated for us
+        dtypes = [('', col.dtype) for col in columns]
+        return np.array(list(zip(*columns)), dtype=dtypes)
 
     def transform(self, X):
         """Transform samples from the original space into a warped space.

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -150,3 +150,16 @@ def test_space_api():
                       [(0.0, 1.0), (-5, 5), (0.0, 1.0), (0.0, 1.0), (0.0, 1.0),
                        (np.log10(1.0), np.log10(5.0))]):
         assert_array_equal(b1, b2)
+
+
+def test_uniform_return_type():
+    s1 = Space([(0.0, 1.0)]).rvs(n_samples=3, random_state=0)
+    s2 = Space([(1, 2)]).rvs(n_samples=3, random_state=0)
+    s3 = Space([(0.0, 1.0), (1, 2)]).rvs(n_samples=3, random_state=0)
+    s4 = Space([(1, 3), ('a', 'b', 'c')]).rvs(n_samples=3, random_state=0)
+
+    assert_equal(s1.dtype, np.float)
+    assert_equal(s2.dtype, np.int)
+    assert_equal(s3.dtype, np.float)
+    # XXX ergh, not clear what this should be, but for sure string isn't ideal
+    assert_equal(s4.dtype, np.float)

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -158,8 +158,7 @@ def test_uniform_return_type():
     s3 = Space([(0.0, 1.0), (1, 2)]).rvs(n_samples=3, random_state=0)
     s4 = Space([(1, 3), ('a', 'b', 'c')]).rvs(n_samples=3, random_state=0)
 
-    assert_equal(s1.dtype, np.float)
-    assert_equal(s2.dtype, np.int)
-    assert_equal(s3.dtype, np.float)
-    # XXX ergh, not clear what this should be, but for sure string isn't ideal
-    assert_equal(s4.dtype, np.float)
+    assert_equal(s1.dtype, np.dtype([('f0', '<f8')]))
+    assert_equal(s2.dtype, np.dtype([('f0', '<i8')]))
+    assert_equal(s3.dtype, np.dtype([('f0', '<f8'), ('f1', '<i8')]))
+    assert_equal(s4.dtype, np.dtype([('f0', '<i8'), ('f1', '<U1')]))


### PR DESCRIPTION
Investigating #86 

So far it seems that `np.transpose` is the bit that causes the return value to acquire the type it does. Trying to find docs on how it makes its decision and if we can influence it. However, `np.array`s need to have one shared dtype for all columns :-/