### PR TITLE
Round off variance in each tree to 0.01 in accordance with SMAC

### DIFF
--- a/skopt/learning/forest.py
+++ b/skopt/learning/forest.py
@@ -34,6 +34,13 @@ def _return_std(X, trees, predictions):
 
     for tree in trees:
         var_tree = tree.tree_.impurity[tree.apply(X)]
+
+        # This rounding off is done in accordance with the
+        # adjustment done in section 4.3.3
+        # of http://arxiv.org/pdf/1211.0906v2.pdf to account
+        # for cases such as leaves with 1 sample in which there
+        # is zero variance.
+        var_tree[var_tree < 0.01] = 0.01
         mean_tree = tree.predict(X)
         std += var_tree + mean_tree ** 2
 

--- a/skopt/learning/tests/test_forest.py
+++ b/skopt/learning/tests/test_forest.py
@@ -56,3 +56,14 @@ def test_variance_no_split():
                       partial(RandomForestRegressor, bootstrap=False),
                       ExtraTreesRegressor]:
         yield check_variance_no_split, Regressor
+
+
+def test_min_variance():
+    rng = np.random.RandomState(0)
+    X = rng.normal(size=(1000, 1))
+    y = np.ones(1000)
+    dt = DecisionTreeRegressor(min_variance=0.0)
+    dt.fit(X, y)
+    mean, std = dt.predict(X, return_std=True)
+    assert_array_equal(mean, y)
+    assert_array_equal(std, np.zeros(1000))

--- a/skopt/learning/tree.py
+++ b/skopt/learning/tree.py
@@ -36,6 +36,8 @@ class DecisionTreeRegressor(sk_DecisionTreeRegressor):
                     "Expected impurity to be 'mse', got %s instead"
                     % self.criterion)
 
-            return mean, self.tree_.impurity[self.apply(X)] ** 0.5
+            var = self.tree_.impurity[self.apply(X)]
+            var[var < 0.01] = 0.01
+            return mean, var**0.5
 
         return mean

--- a/skopt/learning/tree.py
+++ b/skopt/learning/tree.py
@@ -6,6 +6,21 @@ class DecisionTreeRegressor(sk_DecisionTreeRegressor):
     """
     DecisionTreeRegressor that supports `return_std`.
     """
+    def __init__(self, criterion='mse', splitter='best', max_depth=None,
+                 min_samples_split=2, min_samples_leaf=1,
+                 min_weight_fraction_leaf=0.0, max_features=None,
+                 random_state=None, max_leaf_nodes=None, presort=False,
+                 min_variance=0.0):
+        self.min_variance = min_variance
+        super(DecisionTreeRegressor, self).__init__(
+            criterion=criterion, splitter=splitter,
+            max_depth=max_depth,
+            min_samples_split=min_samples_split,
+            min_samples_leaf=min_samples_leaf,
+            min_weight_fraction_leaf=min_weight_fraction_leaf,
+            max_features=max_features, max_leaf_nodes=max_leaf_nodes,
+            presort=presort, random_state=random_state)
+
     def predict(self, X, return_std=False):
         """
         Predict continuous output for `X`.
@@ -37,7 +52,7 @@ class DecisionTreeRegressor(sk_DecisionTreeRegressor):
                     % self.criterion)
 
             var = self.tree_.impurity[self.apply(X)]
-            var[var < 0.01] = 0.01
+            var[var < self.min_variance] = self.min_variance
             return mean, var**0.5
 
         return mean


### PR DESCRIPTION
Described in section 4.3.2 of http://arxiv.org/pdf/1211.0906v2.pdf (`\sigma^2_min` = 0.01)

"To avoid making deterministic predictions for leaves with few data points, we round the stored variance up to `sigma^2_min`=0.01