### PR TITLE
Squashing warnings

### DIFF
--- a/skopt/tests/test_dummy_opt.py
+++ b/skopt/tests/test_dummy_opt.py
@@ -23,7 +23,7 @@ def test_dummy_minimize():
     yield (check_minimize, bench2, -5, [(-6.0, 6.0)], 0.05, 10000)
     yield (check_minimize, bench3, -0.9, [(-2.0, 2.0)], 0.05, 10000)
     yield (check_minimize, branin, 0.39, [(-5.0, 10.0), (0.0, 15.0)], 0.1, 10000)
-    yield (check_minimize, hart6, -3.32, np.tile((0.0, 1.0), (6.0, 1.0)), 0.5, 10000)
+    yield (check_minimize, hart6, -3.32, np.tile((0.0, 1.0), (6, 1)), 0.5, 10000)
 
 
 def test_api():

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -27,7 +27,7 @@ def test_gp_minimize():
         yield (check_minimize, bench3, -0.9, [(-2.0, 2.0)], search, acq, 0.05, 75)
         yield (check_minimize, branin, 0.39, [(-5.0, 10), (0.0, 15.)],
                search, acq, 0.1, 100)
-        yield (check_minimize, hart6, -3.32, np.tile((0., 1.), (6., 1.)),
+        yield (check_minimize, hart6, -3.32, np.tile((0., 1.), (6, 1)),
                search, acq, 1.0, 150)
 
 


### PR DESCRIPTION
Squashing some warnings. I added

```python
import traceback
import warnings
import sys

def warn_with_traceback(message, category, filename, lineno, file=None, line=None):
    traceback.print_stack()
    log = file if hasattr(file,'write') else sys.stderr
    log.write(warnings.formatwarning(message, category, filename, lineno, line))
    raise RuntimeError

warnings.showwarning = warn_with_traceback
```

to `skopt/__init__.py` and then ran `nosetest --pdb`. Is there a way to
get the same effect via env variable or commandline argument for nose?