### PR TITLE
[MRG] fix support for categorical variables

### DIFF
--- a/skopt/benchmarks.py
+++ b/skopt/benchmarks.py
@@ -38,6 +38,17 @@ def bench3(x):
     return np.asscalar(np.sin(5 * x) * (1 - np.tanh(x ** 2)))
 
 
+def bench4(x):
+    """A benchmark function for test purposes.
+
+        f(x) = float(x) ** 2
+
+    where x is a string. It has a single minima with f(x*) = 0 at x* = "0".
+    This benchmark is used for checking support of categorical variables.
+    """
+    return float(x[0]) ** 2
+
+
 def branin(x, a=1, b=5.1 / (4 * np.pi**2), c=5. / np.pi,
            r=6, s=10, t=1. / (8 * np.pi)):
     """Branin-Hoo function is defined on the square x1 ∈ [-5, 10], x2 ∈ [0, 15].

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -10,6 +10,7 @@ from skopt.gp_opt import gp_minimize
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
+from skopt.benchmarks import bench4
 from skopt.benchmarks import branin
 from skopt.benchmarks import hart6
 
@@ -25,6 +26,8 @@ def test_gp_minimize():
         yield (check_minimize, bench1, 0., [(-2.0, 2.0)], search, acq, 0.05, 75)
         yield (check_minimize, bench2, -5, [(-6.0, 6.0)], search, acq, 0.05, 75)
         yield (check_minimize, bench3, -0.9, [(-2.0, 2.0)], search, acq, 0.05, 75)
+        yield (check_minimize, bench4, 0.0,
+               [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
         yield (check_minimize, branin, 0.39, [(-5.0, 10), (0.0, 15.)],
                search, acq, 0.1, 100)
         yield (check_minimize, hart6, -3.32, np.tile((0., 1.), (6, 1)),

--- a/skopt/tests/test_tree_opt.py
+++ b/skopt/tests/test_tree_opt.py
@@ -12,6 +12,7 @@ from sklearn.utils.testing import assert_raise_message
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
+from skopt.benchmarks import bench4
 from skopt.benchmarks import branin
 from skopt.benchmarks import hart6
 from skopt.tree_opt import gbrt_minimize
@@ -99,6 +100,8 @@ def test_tree_based_minimize():
         yield (check_minimize, minimizer, bench1, 0., [(-2.0, 2.0)], 0.05, 75)
         yield (check_minimize, minimizer, bench2, -5, [(-6.0, 6.0)], 0.05, 75)
         yield (check_minimize, minimizer, bench3, -0.9, [(-2.0, 2.0)], 0.05, 75)
+        yield (check_minimize, minimizer, bench4, 0.0,
+               [("-2", "-1", "0", "1", "2")], 0.05, 10)
         yield (check_minimize, minimizer, branin, 0.39,
                [(-5.0, 10.0), (0.0, 15.0)], 0.1, 100)
         yield (check_minimize, minimizer, hart6, -3.32,

--- a/skopt/tree_opt.py
+++ b/skopt/tree_opt.py
@@ -53,7 +53,7 @@ def _tree_minimize(func, dimensions, base_estimator, maxiter,
         # for the moment.
         X = space.transform(space.rvs(n_samples=n_points,
                                       random_state=rng))
-        values = gaussian_ei(X, rgr, np.min(yi))
+        values = -gaussian_ei(X, rgr, np.min(yi))
         next_x = X[np.argmin(values)]
 
         next_x = space.inverse_transform(next_x.reshape((1, -1)))[0]

--- a/skopt/tree_opt.py
+++ b/skopt/tree_opt.py
@@ -6,7 +6,6 @@ from scipy.optimize import OptimizeResult
 
 from sklearn.base import clone
 from sklearn.base import is_regressor
-from sklearn.base import RegressorMixin
 from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.utils import check_random_state
 
@@ -23,11 +22,6 @@ def _tree_minimize(func, dimensions, base_estimator, maxiter,
     rng = check_random_state(random_state)
     space = Space(dimensions)
 
-    # Record the points and function values evaluated as part of
-    # the minimization
-    Xi = np.zeros((maxiter, space.n_dims))
-    yi = np.zeros(maxiter)
-
     # Initialize with random points
     if n_start == 0:
         raise ValueError("Need at least one starting point.")
@@ -39,38 +33,39 @@ def _tree_minimize(func, dimensions, base_estimator, maxiter,
         raise ValueError("Total number of iterations set by maxiter has to"
                          " be larger or equal to n_start.")
 
-    Xi[:n_start] = space.rvs(n_samples=n_start, random_state=rng)
-    yi[:n_start] = [func(xi) for xi in Xi[:n_start]]
-    i = np.argmin(yi[:n_start])
-    best_y = yi[i]
-    best_x = Xi[i]
+    Xi = space.rvs(n_samples=n_start, random_state=rng)
+    yi = [func(x) for x in Xi]
+    if np.ndim(yi) != 1:
+        raise ValueError(
+            "The function to be optimized should return a scalar")
 
+    # Tree-based optimization loop
     models = []
 
     for i in range(n_start, maxiter):
         rgr = clone(base_estimator)
-        # only the first i points are meaningful
-        rgr.fit(space.transform(Xi[:i]), yi[:i])
+        rgr.fit(space.transform(Xi), yi)
         models.append(rgr)
 
         # `rgr` predicts constants for each leaf which means that the EI
         # has zero gradient over large distances. As a result we can not
         # use gradient based optimisers like BFGS, so using random sampling
         # for the moment.
-        x0 = space.transform(space.rvs(n_samples=n_points, random_state=rng))
-        best = np.argmax(gaussian_ei(x0, rgr, best_y))
+        X = space.transform(space.rvs(n_samples=n_points,
+                                      random_state=rng))
+        values = gaussian_ei(X, rgr, np.min(yi))
+        next_x = X[np.argmin(values)]
 
-        Xi[i] = space.inverse_transform(x0[best:best+1])[0]
-        yi[i] = func(Xi[i])
-
-        if yi[i] < best_y:
-            best_y = yi[i]
-            best_x = Xi[i]
+        next_x = space.inverse_transform(next_x.reshape((1, -1)))[0]
+        next_y = func(next_x)
+        Xi = np.vstack((Xi, next_x))
+        yi.append(next_y)
 
     res = OptimizeResult()
-    res.x = best_x
-    res.fun = best_y
-    res.func_vals = yi
+    best = np.argmin(yi)
+    res.x = Xi[best]
+    res.fun = yi[best]
+    res.func_vals = np.array(yi)
     res.x_iters = Xi
     res.models = models
 


### PR DESCRIPTION
This fixes #97, modulo the fact that the function to minimize actually returns a float.

The main issue was that `Xi = np.zeros((maxiter, space.n_dims))` was forcing entries to be cast to floats, no matter the type of the dimensions. Samples are now stored in a list instead, as was done in `gp_minimize`. 