### PR TITLE
[MRG] Python 2.7 Support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ cache:
 
 env:
   matrix:
-    - DISTRIB="conda" PYTHON_VERSION="3.4" COVERAGE="true"
+    - DISTRIB="conda" PYTHON_VERSION="2.7" COVERAGE="true"
     - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
 
 install: source ci_scripts/install.sh

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -89,7 +89,7 @@ class _CategoricalEncoder:
         return self._lb.inverse_transform(Xt)
 
 
-class Dimension:
+class Dimension(object):
     """Base class for search space dimensions."""
 
     def rvs(self, n_samples=1, random_state=None):
@@ -227,7 +227,7 @@ class Integer(Dimension):
 
 
 class Categorical(Dimension):
-    def __init__(self, *categories, prior=None):
+    def __init__(self, categories, prior=None):
         """Search space dimension that can take on categorical values.
 
         Parameters
@@ -247,7 +247,6 @@ class Categorical(Dimension):
             prior = np.tile(1. / len(self.categories), len(self.categories))
 
         # XXX check that sum(prior) == 1
-
         self._rvs = rv_discrete(values=(range(len(self.categories)), prior))
 
     def rvs(self, n_samples=None, random_state=None):
@@ -299,7 +298,7 @@ class Space:
                 _dimensions.append(Real(*dim))
 
             elif len(dim) > 2 or isinstance(dim[0], str):
-                _dimensions.append(Categorical(*dim))
+                _dimensions.append(Categorical(dim))
 
             elif isinstance(dim[0], numbers.Integral):
                 _dimensions.append(Integer(*dim))

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -16,15 +16,17 @@ def check_dimension(Dimension, vals, random_val):
     x = Dimension(*vals)
     assert_equal(x.rvs(random_state=1), random_val)
 
+def check_categorical(vals, random_val):
+    x = Categorical(vals)
+    assert_equal(x.rvs(random_state=1), random_val)
 
 def test_dimensions():
     yield (check_dimension, Real, (1., 4.), 2.251066014107722)
     yield (check_dimension, Real, (1, 4), 2.251066014107722)
     yield (check_dimension, Integer, (1, 4), 2)
     yield (check_dimension, Integer, (1., 4.), 2)
-    yield (check_dimension, Categorical, ('a', 'b', 'c', 'd'), 'b')
-    yield (check_dimension, Categorical, (1., 2., 3., 4.), 2.)
-
+    yield (check_categorical, (('a', 'b', 'c', 'd')), 'b')
+    yield (check_categorical, ((1., 2., 3., 4.)), 2.)
 
 def check_limits(value, lower_bound, upper_bound):
     assert_less_equal(lower_bound, value)
@@ -64,7 +66,7 @@ def test_integer():
 
 def test_categorical_transform():
     categories = ["apple", "orange", "banana"]
-    cat = Categorical(*categories)
+    cat = Categorical(categories)
 
     apple = [1.0, 0.0, 0.0]
     banana = [0., 1., 0.]
@@ -117,8 +119,8 @@ def test_space_consistency():
     assert_array_equal(s1, s3)
 
     # Categoricals
-    s1 = Space([Categorical("a", "b", "c")]).rvs(n_samples=10, random_state=0)
-    s2 = Space([Categorical("a", "b", "c")]).rvs(n_samples=10, random_state=0)
+    s1 = Space([Categorical(["a", "b", "c"])]).rvs(n_samples=10, random_state=0)
+    s2 = Space([Categorical(["a", "b", "c"])]).rvs(n_samples=10, random_state=0)
     assert_array_equal(s1, s2)
 
 


### PR DESCRIPTION
Fixes https://github.com/scikit-optimize/scikit-optimize/issues/87
This was easier than I thought. Just a minor change.

```python
Categorical(1, 2, 3, 4)
```

becomes
```python
Categorical((1, 2, 3, 4))
```

This does not affect the public API of the `minimize` functions in any way except if the user explicitly provides a dimension as an instance of Categorical.