### PR TITLE
[WIP] Change default from min_samples_leaf=10 to min_samples_split=10

### DIFF
--- a/skopt/tree_opt.py
+++ b/skopt/tree_opt.py
@@ -236,15 +236,15 @@ def forest_minimize(func, dimensions, base_estimator='rf', maxiter=100,
                              " are: 'rf', 'et' or 'dt', not '%s'" % base_estimator)
 
         if base_estimator == "rf":
-            base_estimator = RandomForestRegressor(min_samples_leaf=10,
+            base_estimator = RandomForestRegressor(min_samples_split=10,
                                                    random_state=rng)
 
         elif base_estimator == "et":
-            base_estimator = ExtraTreesRegressor(min_samples_leaf=10,
+            base_estimator = ExtraTreesRegressor(min_samples_split=10,
                                                  random_state=rng)
 
         elif base_estimator == "dt":
-            base_estimator = DecisionTreeRegressor(min_samples_leaf=10,
+            base_estimator = DecisionTreeRegressor(min_samples_split=10,
                                                    random_state=rng)
 
     else:


### PR DESCRIPTION
Motivation:

For the current defaults, there is a possibility that no split is produced till the number of iterations till the number of iterations are 20 (worst case), which means that the predicted mean and the variance are the same till `n_iter` is 20.

This PR changes this to `min_samples_split` forcing a split when `n_iter` is greater than 10.

Let's see if I can back this up with benchmarks.
(This also ties well with SMAC's benchmarks of n_min described in page 9 of http://www.cs.ubc.ca/~hutter/papers/10-TR-SMAC.pdf)