### PR TITLE
[MRG] Space API: always use list of lists of values

### DIFF
--- a/skopt/benchmarks.py
+++ b/skopt/benchmarks.py
@@ -11,7 +11,7 @@ def bench1(x):
 
     It has a single minima with f(x*) = 0 at x* = 0.
     """
-    return np.asscalar(x ** 2)
+    return x[0] ** 2
 
 
 def bench2(x):
@@ -22,10 +22,10 @@ def bench2(x):
 
     It has a global minima with f(x*) = -5 at x* = 5.
     """
-    if x < 0:
-        return np.asscalar(x ** 2)
+    if x[0] < 0:
+        return x[0] ** 2
     else:
-        return np.asscalar((x - 5) ** 2 - 5)
+        return (x[0] - 5) ** 2 - 5
 
 
 def bench3(x):
@@ -35,7 +35,7 @@ def bench3(x):
 
     It has a global minima with f(x*) ~= -0.9 at x* ~= -0.3.
     """
-    return np.asscalar(np.sin(5 * x) * (1 - np.tanh(x ** 2)))
+    return np.sin(5 * x[0]) * (1 - np.tanh(x[0] ** 2))
 
 
 def bench4(x):
@@ -58,8 +58,8 @@ def branin(x, a=1, b=5.1 / (4 * np.pi**2), c=5. / np.pi,
 
     More details: <http://www.sfu.ca/~ssurjano/branin.html>
     """
-    return np.asscalar(a * (x[1] - b * x[0] ** 2 + c * x[0] - r) ** 2 +
-                       s * (1 - t) * np.cos(x[0]) + s)
+    return (a * (x[1] - b * x[0] ** 2 + c * x[0] - r) ** 2 +
+            s * (1 - t) * np.cos(x[0]) + s)
 
 
 def hart6(x,
@@ -79,4 +79,4 @@ def hart6(x,
 
     More details: <http://www.sfu.ca/~ssurjano/hart6.html>
     """
-    return -np.sum(alpha * np.exp(-np.sum(A * (x - P)**2, axis=1)))
+    return -np.sum(alpha * np.exp(-np.sum(A * (np.array(x) - P)**2, axis=1)))

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -325,7 +325,7 @@ class Space:
 
         Returns
         -------
-        * `points`: [array-like, shape=(n_points, n_dims)]
+        * `points`: [list of lists, shape=(n_points, n_dims)]
            Points sampled from the space.
         """
         rng = check_random_state(random_state)
@@ -359,12 +359,12 @@ class Space:
 
         Parameters
         ----------
-        * `X` [array-like, shape=(n_samples, n_dims)]:
+        * `X` [list of lists, shape=(n_samples, n_dims)]:
             The samples to transform.
 
         Returns
         -------
-        * `Xt` [array-like, shape=(n_samples, transformed_n_dims)]
+        * `Xt` [array of floats, shape=(n_samples, transformed_n_dims)]
             The transformed samples.
         """
         # Pack by dimension
@@ -392,12 +392,12 @@ class Space:
 
         Parameters
         ----------
-        * `Xt` [array-like, shape=(n_samples, transformed_n_dims)]:
+        * `Xt` [array of floats, shape=(n_samples, transformed_n_dims)]:
             The samples to inverse transform.
 
         Returns
         -------
-        * `X` [array-like, shape=(n_samples, n_dims)]
+        * `X` [list of lists, shape=(n_samples, n_dims)]
             The original samples.
         """
         # Inverse transform

--- a/skopt/tests/test_dummy_opt.py
+++ b/skopt/tests/test_dummy_opt.py
@@ -29,8 +29,8 @@ def test_dummy_minimize():
 def test_api():
     res = dummy_minimize(
         branin, [(-5.0, 10.0), (0.0, 15.0)], random_state=0, maxiter=100)
-    assert_array_equal(res.x.shape, (2,))
-    assert_array_equal(res.x_iters.shape, (100, 2))
+    assert_array_equal(len(res.x), 2)
+    assert_array_equal((len(res.x_iters), len(res.x_iters[0])), (100, 2))
     assert_array_equal(res.func_vals.shape, (100,))
     assert_array_less(res.x_iters, np.tile([10, 15], (100, 1)))
     assert_array_less(np.tile([-5, 0], (100, 1)), res.x_iters)

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -1,3 +1,4 @@
+import numbers
 import numpy as np
 
 from sklearn.utils.testing import assert_array_equal
@@ -138,10 +139,21 @@ def test_space_api():
     assert_equal(len(samples), 10)
     assert_equal(len(samples[0]), 4)
 
+    assert_true(isinstance(samples[0][0], numbers.Real))
+    assert_true(isinstance(samples[0][1], numbers.Integral))
+    assert_true(isinstance(samples[0][2], str))
+    assert_true(isinstance(samples[0][3], numbers.Real))
+
     samples_transformed = space.transform(samples)
     assert_equal(samples_transformed.shape[0], len(samples))
     assert_equal(samples_transformed.shape[1], 1 + 1 + 3 + 1)
     assert_array_equal(samples, space.inverse_transform(samples_transformed))
+
+    samples = space.inverse_transform(samples_transformed)
+    assert_true(isinstance(samples[0][0], numbers.Real))
+    assert_true(isinstance(samples[0][1], numbers.Integral))
+    assert_true(isinstance(samples[0][2], str))
+    assert_true(isinstance(samples[0][3], numbers.Real))
 
     for b1, b2 in zip(space.bounds,
                       [(0.0, 1.0), (-5, 5),


### PR DESCRIPTION
This is a solution for #86. 

Points (in the original space) are now represented as a list of lists of values, where values are represented in their own original type, without coercion. This is the format expected by `space.transform` and returned by `space.inverse_transform` and `space.rvs`. Also, this means that functions to optimize are assumed to support as input a list of values. 

Points (in the transformed space) are represented as a Numpy array as before, since this is the most convenient for optimisation.

