### PR TITLE
[MRG] Two fixes to Categorical dimension of space

### DIFF
--- a/skopt/space.py
+++ b/skopt/space.py
@@ -43,8 +43,8 @@ class _CategoricalEncoder:
         """Convert labeled categories into one-hot encoded features."""
         self._lb = LabelBinarizer()
         NONE_ = '__None__'
-        self._Xin = np.vectorize(lambda a: a if a is not None else NONE_)
-        self._Xout = np.vectorize(lambda a: a if a is not NONE_ else None)
+        self.encode_none = np.vectorize(lambda a: a if a is not None else NONE_)
+        self.decode_none = np.vectorize(lambda a: a if a != NONE_ else None)
 
     def fit(self, X):
         """Fit a list or array of categories.
@@ -54,7 +54,7 @@ class _CategoricalEncoder:
         * `X` [array-like, shape=(n_categories,)]:
             List of categories.
         """
-        self._lb.fit(self._Xin(X))
+        self._lb.fit(self.encode_none(X))
         self.n_classes = len(self._lb.classes_)
 
         return self
@@ -72,7 +72,7 @@ class _CategoricalEncoder:
         * `Xt` [array-like, shape=(n_samples, n_categories)]:
             The one-hot encoded categories.
         """
-        return self._lb.transform(self._Xin(X))
+        return self._lb.transform(self.encode_none(X))
 
     def inverse_transform(self, Xt):
         """Inverse transform one-hot encoded categories back to their original
@@ -89,7 +89,7 @@ class _CategoricalEncoder:
             The original categories.
         """
         Xt = np.asarray(Xt)
-        return self._Xout(self._lb.inverse_transform(Xt))
+        return self.decode_none(self._lb.inverse_transform(Xt))
 
 
 class Dimension(object):
@@ -258,8 +258,8 @@ class Categorical(Dimension):
 
     @property
     def transformed_size(self):
-        l = len(self.categories)
-        return l if l != 2 else 1
+        size = len(self.categories)
+        return size if size != 2 else 1
 
     @property
     def bounds(self):

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -42,6 +42,9 @@ class _CategoricalEncoder:
     def __init__(self):
         """Convert labeled categories into one-hot encoded features."""
         self._lb = LabelBinarizer()
+        NONE_ = '__None__'
+        self._Xin = np.vectorize(lambda a: a if a is not None else NONE_)
+        self._Xout = np.vectorize(lambda a: a if a is not NONE_ else None)
 
     def fit(self, X):
         """Fit a list or array of categories.
@@ -51,7 +54,7 @@ class _CategoricalEncoder:
         * `X` [array-like, shape=(n_categories,)]:
             List of categories.
         """
-        self._lb.fit(X)
+        self._lb.fit(self._Xin(X))
         self.n_classes = len(self._lb.classes_)
 
         return self
@@ -69,7 +72,7 @@ class _CategoricalEncoder:
         * `Xt` [array-like, shape=(n_samples, n_categories)]:
             The one-hot encoded categories.
         """
-        return self._lb.transform(X)
+        return self._lb.transform(self._Xin(X))
 
     def inverse_transform(self, Xt):
         """Inverse transform one-hot encoded categories back to their original
@@ -86,7 +89,7 @@ class _CategoricalEncoder:
             The original categories.
         """
         Xt = np.asarray(Xt)
-        return self._lb.inverse_transform(Xt)
+        return self._Xout(self._lb.inverse_transform(Xt))
 
 
 class Dimension(object):
@@ -255,7 +258,8 @@ class Categorical(Dimension):
 
     @property
     def transformed_size(self):
-        return len(self.categories)
+        l = len(self.categories)
+        return l if l != 2 else 1
 
     @property
     def bounds(self):

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -10,6 +10,16 @@ from sklearn.utils import check_random_state
 from sklearn.utils.fixes import sp_version
 
 
+@np.vectorize
+def encode_none(a):
+    return a if a is not None else '__None__'
+
+
+@np.vectorize
+def decode_none(a):
+    return a if a != '__None__' else None
+
+
 class _Identity:
     """Identity transform."""
 
@@ -42,9 +52,6 @@ class _CategoricalEncoder:
     def __init__(self):
         """Convert labeled categories into one-hot encoded features."""
         self._lb = LabelBinarizer()
-        NONE_ = '__None__'
-        self.encode_none = np.vectorize(lambda a: a if a is not None else NONE_)
-        self.decode_none = np.vectorize(lambda a: a if a != NONE_ else None)
 
     def fit(self, X):
         """Fit a list or array of categories.
@@ -54,7 +61,7 @@ class _CategoricalEncoder:
         * `X` [array-like, shape=(n_categories,)]:
             List of categories.
         """
-        self._lb.fit(self.encode_none(X))
+        self._lb.fit(encode_none(X))
         self.n_classes = len(self._lb.classes_)
 
         return self
@@ -72,7 +79,7 @@ class _CategoricalEncoder:
         * `Xt` [array-like, shape=(n_samples, n_categories)]:
             The one-hot encoded categories.
         """
-        return self._lb.transform(self.encode_none(X))
+        return self._lb.transform(encode_none(X))
 
     def inverse_transform(self, Xt):
         """Inverse transform one-hot encoded categories back to their original
@@ -89,7 +96,7 @@ class _CategoricalEncoder:
             The original categories.
         """
         Xt = np.asarray(Xt)
-        return self.decode_none(self._lb.inverse_transform(Xt))
+        return decode_none(self._lb.inverse_transform(Xt))
 
 
 class Dimension(object):
@@ -259,6 +266,7 @@ class Categorical(Dimension):
     @property
     def transformed_size(self):
         size = len(self.categories)
+        # when len(categories) == 2 CategoricalEncoder outputs a single vector
         return size if size != 2 else 1
 
     @property

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -65,22 +65,40 @@ def test_integer():
     assert_array_equal(a.inverse_transform(random_values), random_values)
 
 
-def test_categorical_transform():
-    categories = ["apple", "orange", "banana"]
+def test_categorical_transform_binary():
+    categories = ["apple", "orange"]
     cat = Categorical(categories)
 
-    apple = [1.0, 0.0, 0.0]
-    banana = [0., 1., 0.]
-    orange = [0., 0., 1]
+    apple = [0.]
+    orange = [1.]
 
-    assert_array_equal(cat.transform(categories), [apple, orange, banana])
+    assert_equal(cat.transform(["apple"]).size, cat.transformed_size)
+    assert_array_equal(cat.transform(categories), [apple, orange])
+    assert_array_equal(cat.transform(["apple", "orange"]), [apple, orange])
+    assert_array_equal(cat.inverse_transform([apple, orange]),
+                       ["apple", "orange"])
+    ent_inverse = cat.inverse_transform([apple, orange])
+    assert_array_equal(ent_inverse, categories)
+
+
+def test_categorical_transform():
+    categories = [None, "apple", "orange", "banana"]
+    cat = Categorical(categories)
+
+    none = [1., 0., 0., 0.]
+    apple = [0., 1., 0., 0.]
+    banana = [0., 0., 1., 0.]
+    orange = [0., 0., 0., 1.]
+
+    assert_equal(cat.transform(["apple"]).size, cat.transformed_size)
+    assert_array_equal(cat.transform(categories), [none, apple, orange, banana])
     assert_array_equal(cat.transform(["apple", "orange"]), [apple, orange])
     assert_array_equal(cat.transform(["apple", "banana"]), [apple, banana])
     assert_array_equal(cat.inverse_transform([apple, orange]),
                        ["apple", "orange"])
     assert_array_equal(cat.inverse_transform([apple, banana]),
                        ["apple", "banana"])
-    ent_inverse = cat.inverse_transform([apple, orange, banana])
+    ent_inverse = cat.inverse_transform([none, apple, orange, banana])
     assert_array_equal(ent_inverse, categories)
 
 


### PR DESCRIPTION
- support 2 classes
  - LabelBinarizer outputs only 1 column for the 2 classes case (see https://github.com/scikit-learn/scikit-learn/blob/51a765a/sklearn/preprocessing/label.py#L423)
- support `None` as a category
  - useful for eg. class_weight of RandomForestClassifier
  - requires transforming None into/from a string value before/after passing/receiving it from LabelBinarizer