### PR TITLE
x axis tick labels, log scale and zi.T

### DIFF
--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -239,7 +239,7 @@ def partial_dependence(space, model, i, j=None, sample_points=None,
 
 
 def plot_objective(result, levels=10, n_points=40, n_samples=250,
-                   z_scale='linear'):
+                   zscale='linear'):
     """Pairwise partial dependence plot of the objective function.
 
     The diagonal shows the partial dependence for dimension `i` with
@@ -272,7 +272,7 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250,
         Number of random samples to use for averaging the model function
         at each of the `n_points`.
 
-    * `z_scale` [str, default='linear']
+    * `zscale` [str, default='linear']
         Scale to use for the z axis of the contour plots. Either 'linear'
         or 'log'.
 
@@ -285,13 +285,13 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250,
     samples = np.asarray(result.x_iters)
     rvs_transformed = space.transform(space.rvs(n_samples=n_samples))
 
-    if z_scale == 'log':
+    if zscale == 'log':
         locator = LogLocator()
-    elif z_scale == 'linear':
+    elif zscale == 'linear':
         locator = None
     else:
-        raise ValueError("Valid values for z_scale are 'linear' and 'log',"
-                         " not '%s'." % z_scale)
+        raise ValueError("Valid values for zscale are 'linear' and 'log',"
+                         " not '%s'." % zscale)
 
     fig, ax = plt.subplots(space.n_dims, space.n_dims, figsize=(8, 8))
 

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -4,6 +4,7 @@ import numpy as np
 
 import matplotlib.pyplot as plt
 from matplotlib.pyplot import cm
+from matplotlib.ticker import LogLocator
 from matplotlib.ticker import MaxNLocator
 
 from scipy.interpolate import griddata
@@ -118,6 +119,15 @@ def _format_scatter_plot_axes(ax, space, ylabel):
                     ax_.set_yticklabels([])
                 else:
                     ax_.set_ylabel("$X_{%i}$" % i)
+
+                # for all rows except ...
+                if i < space.n_dims - 1:
+                    ax_.set_xticklabels([])
+                # ... the bottom row
+                else:
+                    [l.set_rotation(45) for l in ax_.get_xticklabels()]
+                    ax_.set_xlabel("$X_{%i}$" % j)
+
             else:
                 ax_.set_ylim(*diagonal_ylim)
                 ax_.yaxis.tick_right()
@@ -125,16 +135,11 @@ def _format_scatter_plot_axes(ax, space, ylabel):
                 ax_.yaxis.set_ticks_position('both')
                 ax_.set_ylabel(ylabel)
 
+                ax_.xaxis.tick_top()
+                ax_.set_xlabel("$X_{%i}$" % j)
+
             ax_.xaxis.set_major_locator(MaxNLocator(6, prune='both'))
             ax_.yaxis.set_major_locator(MaxNLocator(6, prune='both'))
-
-            # for all rows except ...
-            if i < space.n_dims - 1:
-                ax_.set_xticklabels([])
-            # ... the bottom row
-            else:
-                [l.set_rotation(45) for l in ax_.get_xticklabels()]
-                ax_.set_xlabel("$X_{%i}$" % j)
 
     return ax
 
@@ -191,7 +196,7 @@ def partial_dependence(space, model, i, j=None, sample_points=None,
         The points at which the partial dependence was evaluated.
     * `yi`: [np.array, shape=n_points]:
         The points at which the partial dependence was evaluated.
-    * `zi`: [list of lists, n_points by n_points]:
+    * `zi`: [np.array, shape=(n_points, n_points)]:
         The value of the model at each point `(xi, yi)`.
     """
     if sample_points is None:
@@ -230,10 +235,11 @@ def partial_dependence(space, model, i, j=None, sample_points=None,
                 row.append(np.mean(model.predict(rvs_)))
             zi.append(row)
 
-        return xi, yi, zi
+        return xi, yi, np.array(zi).T
 
 
-def plot_objective(result, levels=10, n_points=40, n_samples=250):
+def plot_objective(result, levels=10, n_points=40, n_samples=250,
+                   z_scale='linear'):
     """Pairwise partial dependence plot of the objective function.
 
     The diagonal shows the partial dependence for dimension `i` with
@@ -266,6 +272,10 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250):
         Number of random samples to use for averaging the model function
         at each of the `n_points`.
 
+    * `z_scale` [str, default='linear']
+        Scale to use for the z axis of the contour plots. Either 'linear'
+        or 'log'.
+
     Returns
     -------
     * `ax`: [`Axes`]:
@@ -274,6 +284,14 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250):
     space = result.space
     samples = np.asarray(result.x_iters)
     rvs_transformed = space.transform(space.rvs(n_samples=n_samples))
+
+    if z_scale == 'log':
+        locator = LogLocator()
+    elif z_scale == 'linear':
+        locator = None
+    else:
+        raise ValueError("Valid values for z_scale are 'linear' and 'log',"
+                         " not '%s'." % z_scale)
 
     fig, ax = plt.subplots(space.n_dims, space.n_dims, figsize=(8, 8))
 
@@ -297,8 +315,10 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250):
                                                 i, j,
                                                 rvs_transformed, n_points)
 
-                ax[i, j].contour(xi, yi, zi, levels, linewidths=0.5, colors='k')
-                ax[i, j].contourf(xi, yi, zi, levels, cmap='viridis_r')
+                cs = ax[i, j].contour(xi, yi, zi, levels, locator=locator,
+                                      linewidths=0.5, colors='k')
+                ax[i, j].contourf(xi, yi, zi, levels,
+                                  locator=locator, cmap='viridis_r')
                 ax[i, j].scatter(samples[:, j], samples[:, i], c='k', s=10, lw=0.)
                 ax[i, j].scatter(result.x[j], result.x[i], c=['r'], s=20, lw=0.)
 


### PR DESCRIPTION
All changed are related to plotting.

Add `x` axis tick labels for plots on the diagonal

Add option to switch between `linear` and `log` scale for
contour plots.

Switching to log scale for `branin` revealed that we
also need to transpose the `zi` for the contour plots. After the fix
in #167 and seeing `branin` in log-scale it was obvious we needed to also transpose it.

Before:
<img width="599" alt="screen shot 2016-07-29 at 13 45 16" src="https://cloud.githubusercontent.com/assets/1448859/17247335/ccdb1a54-5592-11e6-8cf2-9d159f546272.png">

After:
<img width="620" alt="screen shot 2016-07-29 at 13 46 25" src="https://cloud.githubusercontent.com/assets/1448859/17247349/e1e76b78-5592-11e6-9057-3fe472c8a7f2.png">
