### PR TITLE
Fixed a minor logic fault related to n_random_starts

### DIFF
--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -198,7 +198,7 @@ def gp_minimize(func, dimensions, base_estimator=None, alpha=10e-10,
     if not isinstance(x0, list):
         raise ValueError("`x0` should be a list, but got %s" % type(x0))
 
-    n_init_func_calls = len(x0) if y0 is None else 0
+    n_init_func_calls = len(x0) if y0 is not None else 0
     n_total_init_calls = n_random_starts + n_init_func_calls
 
     if n_total_init_calls <= 0:

--- a/skopt/tree_opt.py
+++ b/skopt/tree_opt.py
@@ -40,7 +40,7 @@ def _tree_minimize(func, dimensions, base_estimator, n_calls,
     if not isinstance(x0, list):
         raise ValueError("`x0` should be a list, but got %s" % type(x0))
 
-    n_init_func_calls = len(x0) if y0 is None else 0
+    n_init_func_calls = len(x0) if y0 is not None else 0
     n_total_init_calls = n_random_starts + n_init_func_calls
 
     if n_total_init_calls <= 0:


### PR DESCRIPTION
When the *_minimize() is fed with x0 and y0, the "n_init_func_calls" should take len(x0) only when y0 is _not_ empty. There was a minor logic fault in the original code.