### PR TITLE
[MRG] [BUG] Allow n_random_starts=0, when x0 and y0 is provided

### DIFF
--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -199,6 +199,9 @@ def gp_minimize(func, dimensions, base_estimator=None, alpha=10e-10,
     n_init_func_calls = len(x0) if y0 is None else 0
     n_total_init_calls = n_random_starts + n_init_func_calls
 
+    if n_calls <= 0:
+        raise ValueError("Expected `n_calls` > 0, got %d" % n_calls)
+
     if n_random_starts < 0:
         raise ValueError(
             "Expected `n_random_starts` >= 0, got %d" % n_random_starts)

--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -199,11 +199,12 @@ def gp_minimize(func, dimensions, base_estimator=None, alpha=10e-10,
     n_init_func_calls = len(x0) if y0 is None else 0
     n_total_init_calls = n_random_starts + n_init_func_calls
 
-    if n_total_init_calls <= 0:
-        # if x0 is not provided and n_random_starts is 0 then
-        # it will ask for n_random_starts to be > 0.
+    if n_random_starts < 0:
         raise ValueError(
-            "Expected `n_random_starts` > 0, got %d" % n_random_starts)
+            "Expected `n_random_starts` >= 0, got %d" % n_random_starts)
+
+    if n_random_starts == 0 and not x0:
+        raise ValueError("Either set `n_random_starts` > 0, or provide `x0`")
 
     if n_calls < n_total_init_calls:
         raise ValueError(

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -8,6 +8,7 @@ from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
+from sklearn.utils.testing import assert_raise_message
 
 from skopt.benchmarks import branin
 from skopt.benchmarks import bench4
@@ -152,3 +153,40 @@ def check_init_vals(optimizer, func, space, x0, n_calls):
     # the number of input points and the number of evaluations differ
     assert_raises(ValueError, dummy_minimize, func,
                   space, x0=x0, y0=[1])
+
+
+def test_invalid_n_calls_arguments():
+    for minimizer in MINIMIZERS:
+        assert_raise_message(ValueError,
+                             "Expected `n_calls` > 0",
+                             minimizer,
+                             branin, [(-5.0, 10.0), (0.0, 15.0)], n_calls=0,
+                             random_state=1)
+
+        assert_raise_message(ValueError,
+                             "set `n_random_starts` > 0, or provide `x0`",
+                             minimizer,
+                             branin, [(-5.0, 10.0), (0.0, 15.0)],
+                             n_random_starts=0,
+                             random_state=1)
+
+        # n_calls >= n_random_starts
+        assert_raise_message(ValueError,
+                             "Expected `n_calls` >= 10",
+                             minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
+                             n_calls=1, n_random_starts=10, random_state=1)
+
+        # n_calls >= n_random_starts + len(x0)
+        assert_raise_message(ValueError,
+                             "Expected `n_calls` >= 10",
+                             minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
+                             n_calls=1, x0=[[-1, 2], [-3, 3], [2, 5]],
+                             random_state=1, n_random_starts=7)
+
+        # n_calls >= n_random_starts when x0 and y0 are provided.
+        assert_raise_message(ValueError,
+                             "Expected `n_calls` >= 7",
+                             minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
+                             n_calls=1, x0=[[-1, 2], [-3, 3], [2, 5]],
+                             y0=[2.0, 3.0, 5.0],
+                             random_state=1, n_random_starts=7)

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -86,18 +86,19 @@ def test_minimizer_api():
 
 
 def test_init_vals():
-    n_random_starts = 5
-    optimizers = [
-        dummy_minimize,
-        partial(gp_minimize, n_random_starts=n_random_starts),
-        partial(forest_minimize, n_random_starts=n_random_starts),
-        partial(gbrt_minimize, n_random_starts=n_random_starts)
-    ]
     space = [(-5.0, 10.0), (0.0, 15.0)]
     x0 = [[1, 2], [3, 4], [5, 6]]
     n_calls = 10
-    for optimizer in optimizers:
-        yield (check_init_vals, optimizer, branin, space, x0, n_calls)
+
+    for n_random_starts in [0, 5]:
+        optimizers = [
+            dummy_minimize,
+            partial(gp_minimize, n_random_starts=n_random_starts),
+            partial(forest_minimize, n_random_starts=n_random_starts),
+            partial(gbrt_minimize, n_random_starts=n_random_starts)
+        ]
+        for optimizer in optimizers:
+            yield (check_init_vals, optimizer, branin, space, x0, n_calls)
 
     space = [("-2", "-1", "0", "1", "2")]
     x0 = [["0"], ["1"], ["2"]]

--- a/skopt/tests/test_tree_opt.py
+++ b/skopt/tests/test_tree_opt.py
@@ -21,33 +21,6 @@ MINIMIZERS = [("dt", partial(forest_minimize, base_estimator='dt')),
               ("rf", partial(forest_minimize, base_estimator='rf')),
               ("gbrt", gbrt_minimize)]
 
-
-def check_no_iterations(minimizer):
-    assert_raise_message(ValueError, "Expected `n_calls` > 0",
-                         minimizer,
-                         branin, [(-5.0, 10.0), (0.0, 15.0)], n_calls=0,
-                         random_state=1)
-
-    assert_raise_message(ValueError, "Expected `n_random_starts` > 0",
-                         minimizer,
-                         branin, [(-5.0, 10.0), (0.0, 15.0)],
-                         n_random_starts=0,
-                         random_state=1)
-
-
-def test_no_iterations():
-    for name, minimizer in MINIMIZERS:
-        yield (check_no_iterations, minimizer)
-
-
-def test_one_iteration():
-    for name, minimizer in MINIMIZERS:
-        assert_raise_message(ValueError,
-                             "Expected `n_calls` >= 10",
-                             minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
-                             n_calls=1, random_state=1)
-
-
 def test_forest_minimize_api():
     # invalid string value
     assert_raise_message(ValueError,

--- a/skopt/tree_opt.py
+++ b/skopt/tree_opt.py
@@ -28,10 +28,6 @@ def _tree_minimize(func, dimensions, base_estimator, n_calls,
     space = Space(dimensions)
 
     # Initialize with provided points (x0 and y0) and/or random points
-    if n_calls <= 0:
-        raise ValueError(
-            "Expected `n_calls` > 0, got %d" % n_random_starts)
-
     if x0 is None:
         x0 = []
     elif not isinstance(x0[0], list):
@@ -42,6 +38,9 @@ def _tree_minimize(func, dimensions, base_estimator, n_calls,
 
     n_init_func_calls = len(x0) if y0 is None else 0
     n_total_init_calls = n_random_starts + n_init_func_calls
+
+    if n_calls <= 0:
+        raise ValueError("Expected `n_calls` > 0, got %d" % n_calls)
 
     if n_random_starts < 0:
         raise ValueError(

--- a/skopt/tree_opt.py
+++ b/skopt/tree_opt.py
@@ -43,11 +43,12 @@ def _tree_minimize(func, dimensions, base_estimator, n_calls,
     n_init_func_calls = len(x0) if y0 is None else 0
     n_total_init_calls = n_random_starts + n_init_func_calls
 
-    if n_total_init_calls <= 0:
-        # if x0 is not provided and n_random_starts is 0 then
-        # it will ask for n_random_starts to be > 0.
+    if n_random_starts < 0:
         raise ValueError(
-            "Expected `n_random_starts` > 0, got %d" % n_random_starts)
+            "Expected `n_random_starts` >= 0, got %d" % n_random_starts)
+
+    if n_random_starts == 0 and not x0:
+        raise ValueError("Either set `n_random_starts` > 0, or provide `x0`")
 
     if n_calls < n_total_init_calls:
         raise ValueError(


### PR DESCRIPTION
This fixes a bug that allows `n_random_starts` to be zero, when the initial points are provided.

In master:
```
space = [(-5.0, 10.0), (0.0, 15.0)]                                 
x0 = [[1, 2], [3, 4], [5, 6]]
n_calls = 10
gp_minimize(branin, space, x0=x0, y0=[1,2,3], n_random_starts=0, n_calls=10)
ValueError: Expected `n_random_starts` > 0, got 
```