### PR TITLE
Dict-like space

### DIFF
--- a/examples/hyperparameter-optimization.ipynb
+++ b/examples/hyperparameter-optimization.ipynb
@@ -65,13 +65,7 @@
     "reg = GradientBoostingRegressor(n_estimators=50, random_state=0)\n",
     "\n",
     "def objective(params):\n",
-    "    max_depth, learning_rate, max_features, min_samples_split, min_samples_leaf = params\n",
-    "\n",
-    "    reg.set_params(max_depth=max_depth,\n",
-    "                   learning_rate=learning_rate,\n",
-    "                   max_features=max_features,\n",
-    "                   min_samples_split=min_samples_split, \n",
-    "                   min_samples_leaf=min_samples_leaf)\n",
+    "    reg.set_params(**params)\n",
     "\n",
     "    return -np.mean(cross_val_score(reg, X, y, cv=5, n_jobs=-1, scoring=\"mean_absolute_error\"))"
    ]
@@ -91,13 +85,21 @@
    },
    "outputs": [],
    "source": [
-    "space  = [(1, 5),                           # max_depth\n",
-    "          (10**-5, 10**-1, \"log-uniform\"),  # learning_rate\n",
-    "          (1, X.shape[1]),                  # max_features\n",
-    "          (2, 30),                          # min_samples_split\n",
-    "          (1, 30)]                          # min_samples_leaf\n",
+    "space = {\n",
+    "    'max_depth': (1, 5),\n",
+    "    'learning_rate': (10**-5, 10**-1, \"log-uniform\"),\n",
+    "    'max_features': (1, X.shape[1]),\n",
+    "    'min_samples_split': (2, 30),\n",
+    "    'min_samples_leaf': (1, 30),\n",
+    "}\n",
     "\n",
-    "x0 = [3, 0.01, 6, 2, 1]"
+    "x0 = {\n",
+    "    'max_depth': 3,\n",
+    "    'learning_rate': 0.01,\n",
+    "    'max_features': 6,\n",
+    "    'min_samples_split': 2,\n",
+    "    'min_samples_leaf': 1,\n",
+    "}"
    ]
   },
   {
@@ -136,7 +138,7 @@
     {
      "data": {
       "text/plain": [
-       "'Best score=2.8879'"
+       "'Best score=2.8572'"
       ]
      },
      "execution_count": 5,
@@ -150,7 +152,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
+   "execution_count": 7,
    "metadata": {
     "collapsed": false
    },
@@ -160,11 +162,11 @@
      "output_type": "stream",
      "text": [
       "Best parameters:\n",
-      "- max_depth=5\n",
-      "- learning_rate=0.099611\n",
-      "- max_features=8\n",
-      "- min_samples_split=15\n",
-      "- min_samples_leaf=5\n"
+      "- max_depth=3\n",
+      "- learning_rate=0.096305\n",
+      "- max_features=6\n",
+      "- min_samples_split=27\n",
+      "- min_samples_leaf=1\n"
      ]
     }
    ],
@@ -174,14 +176,14 @@
     "- learning_rate=%.6f\n",
     "- max_features=%d\n",
     "- min_samples_split=%d\n",
-    "- min_samples_leaf=%d\"\"\" % (res_gp.x[0], res_gp.x[1], \n",
-    "                            res_gp.x[2], res_gp.x[3], \n",
-    "                            res_gp.x[4]))"
+    "- min_samples_leaf=%d\"\"\" % (res_gp.x['max_depth'], res_gp.x['learning_rate'], \n",
+    "                            res_gp.x['max_features'], res_gp.x['min_samples_split'], \n",
+    "                            res_gp.x['min_samples_leaf']))"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
+   "execution_count": 8,
    "metadata": {
     "collapsed": false
    },
@@ -193,7 +195,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 8,
+   "execution_count": 9,
    "metadata": {
     "collapsed": false
    },
@@ -201,10 +203,10 @@
     {
      "data": {
       "text/plain": [
-       "'Best score=2.9195'"
+       "'Best score=2.9746'"
       ]
      },
-     "execution_count": 8,
+     "execution_count": 9,
      "metadata": {},
      "output_type": "execute_result"
     }
@@ -215,7 +217,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 9,
+   "execution_count": 10,
    "metadata": {
     "collapsed": false
    },
@@ -225,11 +227,11 @@
      "output_type": "stream",
      "text": [
       "Best parameters:\n",
-      "- max_depth=4\n",
-      "- learning_rate=0.089097\n",
-      "- max_features=8\n",
-      "- min_samples_split=6\n",
-      "- min_samples_leaf=3\n"
+      "- max_depth=3\n",
+      "- learning_rate=0.094813\n",
+      "- max_features=11\n",
+      "- min_samples_split=2\n",
+      "- min_samples_leaf=1\n"
      ]
     }
    ],
@@ -239,9 +241,9 @@
     "- learning_rate=%.6f\n",
     "- max_features=%d\n",
     "- min_samples_split=%d\n",
-    "- min_samples_leaf=%d\"\"\" % (res_forest.x[0], res_forest.x[1], \n",
-    "                            res_forest.x[2], res_forest.x[3], \n",
-    "                            res_forest.x[4]))"
+    "- min_samples_leaf=%d\"\"\" % (res_forest.x['max_depth'], res_forest.x['learning_rate'], \n",
+    "                            res_forest.x['max_features'], res_forest.x['min_samples_split'], \n",
+    "                            res_forest.x['min_samples_leaf']))"
    ]
   },
   {
@@ -375,7 +377,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.1"
+   "version": "3.4.3"
   }
  },
  "nbformat": 4,

--- a/skopt/dummy_opt.py
+++ b/skopt/dummy_opt.py
@@ -10,7 +10,7 @@ from sklearn.utils import check_random_state
 
 from .callbacks import check_callback
 from .callbacks import VerboseCallback
-from .space import Space
+from .space import make_space
 from .utils import create_result
 
 
@@ -95,7 +95,7 @@ def dummy_minimize(func, dimensions, n_calls=100,
 
     # Check params
     rng = check_random_state(random_state)
-    space = Space(dimensions)
+    space = make_space(dimensions)
 
     if x0 is None:
         x0 = []

--- a/skopt/dummy_opt.py
+++ b/skopt/dummy_opt.py
@@ -99,7 +99,7 @@ def dummy_minimize(func, dimensions, n_calls=100,
 
     if x0 is None:
         x0 = []
-    elif not isinstance(x0[0], list):
+    elif type(x0) is dict or not isinstance(x0[0], list):
         x0 = [x0]
 
     if not isinstance(x0, list):

--- a/skopt/forest_opt.py
+++ b/skopt/forest_opt.py
@@ -33,7 +33,7 @@ def _tree_minimize(func, dimensions, base_estimator, n_calls,
     # Initialize with provided points (x0 and y0) and/or random points
     if x0 is None:
         x0 = []
-    elif not isinstance(x0[0], list):
+    elif type(x0) is dict or not isinstance(x0[0], list):
         x0 = [x0]
 
     if not isinstance(x0, list):

--- a/skopt/forest_opt.py
+++ b/skopt/forest_opt.py
@@ -18,7 +18,7 @@ from .callbacks import VerboseCallback
 from .learning import ExtraTreesRegressor
 from .learning import GradientBoostingQuantileRegressor
 from .learning import RandomForestRegressor
-from .space import Space
+from .space import make_space
 from .utils import create_result
 
 
@@ -28,7 +28,7 @@ def _tree_minimize(func, dimensions, base_estimator, n_calls,
                    verbose=False, callback=None):
 
     rng = check_random_state(random_state)
-    space = Space(dimensions)
+    space = make_space(dimensions)
 
     # Initialize with provided points (x0 and y0) and/or random points
     if x0 is None:

--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -18,7 +18,7 @@ from sklearn.utils import check_random_state
 from .acquisition import _gaussian_acquisition
 from .callbacks import check_callback
 from .callbacks import VerboseCallback
-from .space import Space
+from .space import make_space
 from .utils import create_result
 
 
@@ -190,7 +190,7 @@ def gp_minimize(func, dimensions, base_estimator=None, alpha=10e-10,
 
     # Check params
     rng = check_random_state(random_state)
-    space = Space(dimensions)
+    space = make_space(dimensions)
 
     # Default GP
     if base_estimator is None:

--- a/skopt/gp_opt.py
+++ b/skopt/gp_opt.py
@@ -204,7 +204,7 @@ def gp_minimize(func, dimensions, base_estimator=None, alpha=10e-10,
     # Initialize with provided points (x0 and y0) and/or random points
     if x0 is None:
         x0 = []
-    elif not isinstance(x0[0], list):
+    elif type(x0) is dict or not isinstance(x0[0], list):
         x0 = [x0]
 
     if not isinstance(x0, list):

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -486,3 +486,36 @@ class Space:
                 b.extend(dim.transformed_bounds)
 
         return b
+
+
+class DictSpace(Space):
+
+    def __init__(self, dimensions):
+        self.keys = sorted(list(dimensions.keys()))
+        super(DictSpace, self).__init__([dimensions[k] for k in self.keys])
+
+    def rvs(self, n_samples=1, random_state=None):
+        return [
+            dict(zip(self.keys, sample))
+            for sample in super(DictSpace, self).rvs(n_samples, random_state)
+        ]
+
+    def transform(self, X):
+        return super(DictSpace, self).transform([
+            [sample[k] for k in self.keys] for sample in X
+        ])
+
+    def inverse_transform(self, Xt):
+        return [
+            dict(zip(self.keys, sample))
+            for sample in super(DictSpace, self).inverse_transform(Xt)
+        ]
+
+
+def make_space(dimensions):
+    if isinstance(dimensions, Space):
+        return dimensions
+    elif type(dimensions) in (list, tuple):
+        return Space(dimensions)
+    elif type(dimensions) is dict:
+        return DictSpace(dimensions)

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -515,10 +515,10 @@ class DictSpace(Space):
 def make_space(dimensions):
     if isinstance(dimensions, Space):
         return dimensions
-    elif type(dimensions) in (list, tuple):
+    elif type(dimensions) in (list, tuple, np.ndarray):
         return Space(dimensions)
     elif type(dimensions) is dict:
         return DictSpace(dimensions)
     else:
         raise ValueError(
-            "dimensions must be one of list, tuple, dict, Space, DictSpace")
+            "dimensions must be one of list, tuple, ndarray, dict, Space, DictSpace")

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -519,3 +519,6 @@ def make_space(dimensions):
         return Space(dimensions)
     elif type(dimensions) is dict:
         return DictSpace(dimensions)
+    else:
+        raise ValueError(
+            "dimensions must be one of list, tuple, dict, Space, DictSpace")

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -279,7 +279,7 @@ class Categorical(Dimension):
             return [(0.0, 1.0) for i in range(self.transformed_size)]
 
 
-class Space:
+class Space(object):
     """Search space."""
 
     def __init__(self, dimensions):


### PR DESCRIPTION
this PR adds a dict-like Space class (closes issue #140 )

changes: 
- added `DictSpace` class
- added `make_space` function for turning dimensions passed to `*_minimize` into a Space
- added tests for `DictSpace`
- added tests for `make_space`
- updated hyperparameter optimization example to use a dict space (it's much better for passing parameters to a scikit estimator)

questions:
- do you guys want the `dimensions` property of a dict space to be a dictionary or a list? for now I kept it as a list, let me know if i should change that (whatever is decided for this should will also decide whether `bounds` are a dict or a list)
