### PR TITLE
[MRG] Time tests and report coverage

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,0 +1,3 @@
+coverage:
+  ignore:
+    - "skopt/tests/*"

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,10 @@ env:
 install: source build_tools/travis/install.sh
 
 script:
-  nosetests --with-timer --timer-top-n 20
+  - if [ ${COVERAGE} == "true" ];
+    then nosetests --with-coverage --with-timer --timer-top-n 20; else
+    nosetests --with-timer --timer-top-n 20;
+    fi
 
 after_success:
   - if [ ${COVERAGE} == "true" ]; then

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,10 +9,16 @@ cache:
 
 env:
   matrix:
-    - DISTRIB="conda" PYTHON_VERSION="2.7" COVERAGE="true"
+    - DISTRIB="conda" PYTHON_VERSION="2.7" COVERAGE="false"
     - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
 
 install: source build_tools/travis/install.sh
 
 script:
-  nosetests
+  nosetests --with-timer --timer-top-n 20
+
+after_success:
+  - if [ ${COVERAGE} == "true" ]; then
+    pip install codecov;
+    codecov;
+    fi

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -34,6 +34,9 @@ if [[ "$COVERAGE" == "true" ]]; then
     pip install coverage coveralls
 fi
 
+# Enables nosetests --with-timer
+pip install nose-timer
+
 python --version
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"


### PR DESCRIPTION
This prints a list of the slowest tests and uploads the coverage (from py3.5) to codecov so we can actually look at it.

To see if we can speed up the tests we need to see what is slow, otherwise we will never think about it. As we already collect the coverage info it also makes sense to put it somewhere so we can see it -> we might start improving coverage.

* [x] exclude `skopt/tests/` from codecov report