### PR TITLE
[MRG] Log time in VerboseCallback and return callbacks in OptimizeResult instance

### DIFF
--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -41,12 +41,16 @@ class VerboseCallback(object):
     ----------
     * `iter_no`: [int]:
         Number of iterations of the optimization routine.
+
+    * `total_time`: [list]:
+        total_time[n_iter-1] gives the time of that particular iteration.
     """
 
     def __init__(self, n_total, n_init=0, n_random=0):
         self.n_init = n_init
         self.n_random = n_random
         self.n_total = n_total
+        self.total_time = []
         self.iter_no = 1
         self._start_time = time()
         self._print_info(start=True)
@@ -80,6 +84,7 @@ class VerboseCallback(object):
             The optimization as a OptimizeResult object.
         """
         time_taken = time() - self._start_time
+        self.total_time.append(time_taken)
         self._print_info(start=False)
 
         curr_y = res.func_vals[-1]

--- a/skopt/dummy_opt.py
+++ b/skopt/dummy_opt.py
@@ -16,7 +16,7 @@ from .utils import create_result
 
 def dummy_minimize(func, dimensions, n_calls=100,
                    x0=None, y0=None, random_state=None, verbose=False,
-                   callback=None):
+                   callback=None, return_callbacks=False):
     """Random search by uniform sampling within the given bounds.
 
     Parameters
@@ -66,9 +66,15 @@ def dummy_minimize(func, dimensions, n_calls=100,
         Control the verbosity. It is advised to set the verbosity to True
         for long optimization runs.
 
-    * `callback` [callable, list of callables, optional]
+    * `callback` [callable, list of callables, optional]:
         If callable then `callback(res)` is called after each call to `func`.
         If list of callables, then each callable in the list is called.
+
+    * `return_callbacks` [boolean, optional]:
+        If set to True, set `callbacks` attribute to the list of provided callbacks
+        in the returned OptimizeResult instance.
+        If this and `verbose=True`, in addition to the provided `callbacks`, a
+        `VerboseCallback` instance is also included.
 
     Returns
     -------
@@ -158,4 +164,5 @@ def dummy_minimize(func, dimensions, n_calls=100,
                 c(curr_res)
 
     y = np.array(y)
-    return create_result(X, y, space, rng, specs)
+    callbacks = return_callbacks and callbacks
+    return create_result(X, y, space, rng, specs, callbacks=callbacks)

--- a/skopt/forest_opt.py
+++ b/skopt/forest_opt.py
@@ -25,7 +25,7 @@ from .utils import create_result
 def _tree_minimize(func, dimensions, base_estimator, n_calls,
                    n_points, n_random_starts, specs, x0=None, y0=None,
                    random_state=None, acq="EI", xi=0.01, kappa=1.96,
-                   verbose=False, callback=None):
+                   verbose=False, callback=None, return_callbacks=False):
 
     rng = check_random_state(random_state)
     space = Space(dimensions)
@@ -131,13 +131,14 @@ def _tree_minimize(func, dimensions, base_estimator, n_calls,
             for c in callbacks:
                 c(curr_res)
 
-    return create_result(Xi, yi, space, rng, specs, models)
+    callbacks = return_callbacks and callbacks
+    return create_result(Xi, yi, space, rng, specs, models, callbacks=callbacks)
 
 
 def gbrt_minimize(func, dimensions, base_estimator=None, n_calls=100,
                   n_points=1000, n_random_starts=10, x0=None, y0=None,
                   n_jobs=1, random_state=None, acq="EI", xi=0.01, kappa=1.96,
-                  verbose=False, callback=None):
+                  verbose=False, callback=None, return_callbacks=False):
     """Sequential optimization using gradient boosted trees.
 
     Gradient boosted regression trees are used to model the (very)
@@ -233,9 +234,15 @@ def gbrt_minimize(func, dimensions, base_estimator=None, n_calls=100,
         Control the verbosity. It is advised to set the verbosity to True
         for long optimization runs.
 
-    * `callback` [callable, list of callables, optional]
+    * `callback` [callable, list of callables, optional]:
         If callable then `callback(res)` is called after each call to `func`.
         If list of callables, then each callable in the list is called.
+
+    * `return_callbacks` [boolean, optional]:
+        If set to True, set `callbacks` attribute to the list of provided callbacks
+        in the returned OptimizeResult instance.
+        If this and `verbose=True`, in addition to the provided `callbacks`, a
+        `VerboseCallback` instance is also included.
 
     Returns
     -------
@@ -275,13 +282,14 @@ def gbrt_minimize(func, dimensions, base_estimator=None, n_calls=100,
                           n_calls=n_calls,
                           n_points=n_points, n_random_starts=n_random_starts,
                           x0=x0, y0=y0, random_state=random_state, xi=xi,
-                          kappa=kappa, acq=acq, specs=specs, callback=callback)
+                          kappa=kappa, acq=acq, specs=specs, callback=callback,
+                          verbose=verbose, return_callbacks=return_callbacks)
 
 
 def forest_minimize(func, dimensions, base_estimator='et', n_calls=100,
                     n_points=1000, n_random_starts=10, x0=None, y0=None,
                     n_jobs=1, random_state=None, acq="EI", xi=0.01, kappa=1.96,
-                    verbose=False, callback=None):
+                    verbose=False, callback=None, return_callbacks=False):
     """Sequential optimisation using decision trees.
 
     A tree based regression model is used to model the expensive to evaluate
@@ -386,8 +394,15 @@ def forest_minimize(func, dimensions, base_estimator='et', n_calls=100,
         Control the verbosity. It is advised to set the verbosity to True
         for long optimization runs.
 
-    * `callback` [callable, optional]
-        If provided, then `callback(res)` is called after call to func.
+    * `callback` [callable, list of callables, optional]:
+        If callable then `callback(res)` is called after each call to `func`.
+        If list of callables, then each callable in the list is called.
+
+    * `return_callbacks` [boolean, optional]:
+        If set to True, set `callbacks` attribute to the list of provided callbacks
+        in the returned OptimizeResult instance.
+        If this and `verbose=True`, in addition to the provided `callbacks`, a
+        `VerboseCallback` instance is also included.
 
     Returns
     -------
@@ -444,4 +459,4 @@ def forest_minimize(func, dimensions, base_estimator='et', n_calls=100,
                           n_points=n_points, n_random_starts=n_random_starts,
                           specs=specs, x0=x0, y0=y0, random_state=random_state,
                           acq=acq, xi=xi, kappa=kappa, verbose=verbose,
-                          callback=callback)
+                          callback=callback, return_callbacks=return_callbacks)

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -2,7 +2,7 @@ import numpy as np
 from scipy.optimize import OptimizeResult
 
 
-def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
+def create_result(Xi, yi, space=None, rng=None, specs=None, models=None, callbacks=False):
     """
     Return an instance of OptimizeResult() with the required
     information.
@@ -27,6 +27,9 @@ def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
     * `models` [list, optional]:
         List of fit surrogate models.
 
+    * `callbacks` [list, optional]:
+        List of callbacks.
+
     Returns
     -------
     * `res` [`OptimizeResult`, scipy object]:
@@ -43,4 +46,5 @@ def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
     res.space = space
     res.random_state = rng
     res.specs = specs
+    res.callbacks = callbacks
     return res


### PR DESCRIPTION
- [x] Introduce attribute `total_time` in `VerboseCallback`
- [x] Allow `return_callbacks` argument that sets the attribute callbacks in the returned `OptimizeResult` instance.