### PR TITLE
[MRG] Add noise attribute to skopt.GaussianProcessRegressor

### DIFF
--- a/skopt/learning/__init__.py
+++ b/skopt/learning/__init__.py
@@ -3,7 +3,9 @@
 from .forest import RandomForestRegressor
 from .forest import ExtraTreesRegressor
 from .gbrt import GradientBoostingQuantileRegressor
+from .gpr import GaussianProcessRegressor
 
 __all__ = ("RandomForestRegressor",
            "ExtraTreesRegressor",
-           "GradientBoostingQuantileRegressor")
+           "GradientBoostingQuantileRegressor",
+           "GaussianProcessRegressor")

--- a/skopt/learning/gpr.py
+++ b/skopt/learning/gpr.py
@@ -30,7 +30,10 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
         # The noise component of this kernel should be set to zero
         # while estimating K(X, X_test) and K(X_test, X_test)
         # Note that the term K(X, X) should include the noise but
-        # this (K(X, X))^-1y is precomputed as the attribute alpha.
+        # this (K(X, X))^-1y is precomputed as the attribute `alpha_`.
+        # (Notice the underscore).
+        # This has been described in Eq 2.24 of
+        # http://www.gaussianprocess.org/gpml/chapters/RW2.pdf
         if isinstance(self.kernel_, WhiteKernel):
             self.kernel_.set_params(noise_level=0.0)
         else:

--- a/skopt/learning/gpr.py
+++ b/skopt/learning/gpr.py
@@ -1,5 +1,4 @@
 from sklearn.gaussian_process import GaussianProcessRegressor as sk_GaussianProcessRegressor
-from sklearn.gaussian_process.kernels import Matern
 from sklearn.gaussian_process.kernels import WhiteKernel
 
 class GaussianProcessRegressor(sk_GaussianProcessRegressor):
@@ -8,10 +7,35 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
     """
 
     def fit(self, X, y):
+        """Fit Gaussian process regression model
+
+        Parameters
+        ----------
+        X : array-like, shape = (n_samples, n_features)
+            Training data
+
+        y : array-like, shape = (n_samples, [n_output_dims])
+            Target values
+
+        Returns
+        -------
+        self : returns an instance of self.
+        """
         super(GaussianProcessRegressor, self).fit(X, y)
         for param, value in self.kernel_.get_params().items():
-            # XXX: Should return this only in the case where a
-            # WhiteKernel is added.
             if param.endswith('noise_level'):
                 self.noise_ = value
                 break
+
+        # The noise component of this kernel should be set to zero
+        # while estimating K(X, X_test) and K(X_test, X_test)
+        # Note that the term K(X, X) should include the noise but
+        # this (K(X, X))^-1y is precomputed as the attribute alpha.
+        if isinstance(self.kernel_, WhiteKernel):
+            self.kernel_.set_params(noise_level=0.0)
+        else:
+            for param, value in self.kernel_.get_params().items():
+                if isinstance(value, WhiteKernel):
+                    self.kernel_.set_params(
+                        **{param:WhiteKernel(noise_level=0.0)})
+        return self

--- a/skopt/learning/gpr.py
+++ b/skopt/learning/gpr.py
@@ -26,6 +26,116 @@ def _param_for_white_kernel_in_Sum(kernel, kernel_str=""):
 class GaussianProcessRegressor(sk_GaussianProcessRegressor):
     """
     GaussianProcessRegressor that allows noise tunability.
+
+    The implementation is based on Algorithm 2.1 of Gaussian Processes
+    for Machine Learning (GPML) by Rasmussen and Williams.
+
+    In addition to standard scikit-learn estimator API,
+    GaussianProcessRegressor:
+
+       * allows prediction without prior fitting (based on the GP prior)
+       * provides an additional method sample_y(X), which evaluates samples
+         drawn from the GPR (prior or posterior) at given inputs
+       * exposes a method log_marginal_likelihood(theta), which can be used
+         externally for other ways of selecting hyperparameters, e.g., via
+         Markov chain Monte Carlo.
+
+    Read more in the :ref:`User Guide <gaussian_process>`.
+
+    Parameters
+    ----------
+    kernel : kernel object
+        The kernel specifying the covariance function of the GP. If None is
+        passed, the kernel "1.0 * RBF(1.0)" is used as default. Note that
+        the kernel's hyperparameters are optimized during fitting.
+
+    alpha : float or array-like, optional (default: 1e-10)
+        Value added to the diagonal of the kernel matrix during fitting.
+        Larger values correspond to increased noise level in the observations
+        and reduce potential numerical issue during fitting. If an array is
+        passed, it must have the same number of entries as the data used for
+        fitting and is used as datapoint-dependent noise level. Note that this
+        is equivalent to adding a WhiteKernel with c=alpha. Allowing to specify
+        the noise level directly as a parameter is mainly for convenience and
+        for consistency with Ridge.
+
+    optimizer : string or callable, optional (default: "fmin_l_bfgs_b")
+        Can either be one of the internally supported optimizers for optimizing
+        the kernel's parameters, specified by a string, or an externally
+        defined optimizer passed as a callable. If a callable is passed, it
+        must have the signature::
+
+            def optimizer(obj_func, initial_theta, bounds):
+                # * 'obj_func' is the objective function to be maximized, which
+                #   takes the hyperparameters theta as parameter and an
+                #   optional flag eval_gradient, which determines if the
+                #   gradient is returned additionally to the function value
+                # * 'initial_theta': the initial value for theta, which can be
+                #   used by local optimizers
+                # * 'bounds': the bounds on the values of theta
+                ....
+                # Returned are the best found hyperparameters theta and
+                # the corresponding value of the target function.
+                return theta_opt, func_min
+
+        Per default, the 'fmin_l_bfgs_b' algorithm from scipy.optimize
+        is used. If None is passed, the kernel's parameters are kept fixed.
+        Available internal optimizers are::
+
+            'fmin_l_bfgs_b'
+
+    n_restarts_optimizer: int, optional (default: 0)
+        The number of restarts of the optimizer for finding the kernel's
+        parameters which maximize the log-marginal likelihood. The first run
+        of the optimizer is performed from the kernel's initial parameters,
+        the remaining ones (if any) from thetas sampled log-uniform randomly
+        from the space of allowed theta-values. If greater than 0, all bounds
+        must be finite. Note that n_restarts_optimizer == 0 implies that one
+        run is performed.
+
+    normalize_y: boolean, optional (default: False)
+        Whether the target values y are normalized, i.e., the mean of the
+        observed target values become zero. This parameter should be set to
+        True if the target values' mean is expected to differ considerable from
+        zero. When enabled, the normalization effectively modifies the GP's
+        prior based on the data, which contradicts the likelihood principle;
+        normalization is thus disabled per default.
+
+    copy_X_train : bool, optional (default: True)
+        If True, a persistent copy of the training data is stored in the
+        object. Otherwise, just a reference to the training data is stored,
+        which might cause predictions to change if the data is modified
+        externally.
+
+    random_state : integer or numpy.RandomState, optional
+        The generator used to initialize the centers. If an integer is
+        given, it fixes the seed. Defaults to the global numpy random
+        number generator.
+
+    noise: string, "gaussian", optional
+        If set to "gaussian", then it is assumed that `y` is a noisy
+        estimate of `f(x)` where the noise is gaussian.
+
+    Attributes
+    ----------
+    X_train_ : array-like, shape = (n_samples, n_features)
+        Feature values in training data (also required for prediction)
+
+    y_train_: array-like, shape = (n_samples, [n_output_dims])
+        Target values in training data (also required for prediction)
+
+    kernel_: kernel object
+        The kernel used for prediction. The structure of the kernel is the
+        same as the one passed as parameter but with optimized hyperparameters
+
+    L_: array-like, shape = (n_samples, n_samples)
+        Lower-triangular Cholesky decomposition of the kernel in ``X_train_``
+
+    alpha_: array-like, shape = (n_samples,)
+        Dual coefficients of training data points in kernel space
+
+    log_marginal_likelihood_value_: float
+        The log-marginal-likelihood of ``self.kernel_.theta``
     """
     def __init__(self, kernel=None, alpha=1e-10,
                  optimizer="fmin_l_bfgs_b", n_restarts_optimizer=0,

--- a/skopt/learning/gpr.py
+++ b/skopt/learning/gpr.py
@@ -1,6 +1,7 @@
 from sklearn.gaussian_process import GaussianProcessRegressor as sk_GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import WhiteKernel
 
+
 class GaussianProcessRegressor(sk_GaussianProcessRegressor):
     """
     GaussianProcessRegressor that allows noise tunability.

--- a/skopt/learning/gpr.py
+++ b/skopt/learning/gpr.py
@@ -1,0 +1,17 @@
+from sklearn.gaussian_process import GaussianProcessRegressor as sk_GaussianProcessRegressor
+from sklearn.gaussian_process.kernels import Matern
+from sklearn.gaussian_process.kernels import WhiteKernel
+
+class GaussianProcessRegressor(sk_GaussianProcessRegressor):
+    """
+    GaussianProcessRegressor that allows noise tunability.
+    """
+
+    def fit(self, X, y):
+        super(GaussianProcessRegressor, self).fit(X, y)
+        for param, value in self.kernel_.get_params().items():
+            # XXX: Should return this only in the case where a
+            # WhiteKernel is added.
+            if param.endswith('noise_level'):
+                self.noise_ = value
+                break

--- a/skopt/learning/tests/test_gpr.py
+++ b/skopt/learning/tests/test_gpr.py
@@ -1,0 +1,34 @@
+import numpy as np
+
+from sklearn.gaussian_process.kernels import RBF
+from sklearn.gaussian_process.kernels import Matern
+from sklearn.gaussian_process.kernels import WhiteKernel
+from sklearn.utils.testing import assert_false
+from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_array_equal
+
+from skopt.learning.gpr import _param_for_white_kernel_in_Sum
+
+rng = np.random.RandomState(0)
+X = rng.randn(5, 5)
+
+rbf = RBF()
+wk = WhiteKernel()
+mat = Matern()
+kernel1 = rbf
+kernel2 = mat + rbf
+kernel3 = mat * rbf
+kernel4 = wk * rbf
+kernel5 = mat + rbf * wk
+
+
+def test_param_for_white_kernel_in_Sum():
+    for kernel in [kernel1, kernel2, kernel3, kernel4]:
+        kernel_with_noise = kernel + wk
+        wk_present, wk_param = _param_for_white_kernel_in_Sum(kernel + wk)
+        assert_true(wk_present)
+        kernel_with_noise.set_params(
+            **{wk_param: WhiteKernel(noise_level=0.0)})
+        assert_array_equal(kernel_with_noise(X), kernel(X))
+
+    assert_false(_param_for_white_kernel_in_Sum(kernel5)[0])

--- a/skopt/learning/tests/test_gpr.py
+++ b/skopt/learning/tests/test_gpr.py
@@ -3,14 +3,17 @@ import numpy as np
 from sklearn.gaussian_process.kernels import RBF
 from sklearn.gaussian_process.kernels import Matern
 from sklearn.gaussian_process.kernels import WhiteKernel
+from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_array_equal
 
+from skopt.learning import GaussianProcessRegressor
 from skopt.learning.gpr import _param_for_white_kernel_in_Sum
 
 rng = np.random.RandomState(0)
 X = rng.randn(5, 5)
+y = rng.randn(5)
 
 rbf = RBF()
 wk = WhiteKernel()
@@ -32,3 +35,17 @@ def test_param_for_white_kernel_in_Sum():
         assert_array_equal(kernel_with_noise(X), kernel(X))
 
     assert_false(_param_for_white_kernel_in_Sum(kernel5)[0])
+
+
+def test_noise_equals_gaussian():
+    gpr1 = GaussianProcessRegressor(rbf + wk).fit(X, y)
+
+    # gpr2 sets the noise component to zero at predict time.
+    gpr2 = GaussianProcessRegressor(rbf, noise="gaussian").fit(X, y)
+    assert_false(gpr1.noise_)
+    assert_true(gpr2.noise_)
+    assert_equal(gpr1.kernel_.k2.noise_level, gpr2.noise_)
+    mean1, std1 = gpr1.predict(X, return_std=True)
+    mean2, std2 = gpr2.predict(X, return_std=True)
+    assert_array_equal(mean1, mean2)
+    assert_false(np.any(std1 == std2))

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -176,10 +176,9 @@ def gp_minimize(func, dimensions, base_estimator=None,
         matern = Matern(length_scale=np.ones(space.transformed_n_dims),
                         length_scale_bounds=[(0.01, 100)] * space.transformed_n_dims,
                         nu=2.5)
-        noise = WhiteKernel()
         base_estimator = GaussianProcessRegressor(
-            kernel=cov_amplitude * matern + noise,
-            normalize_y=True, random_state=random_state, alpha=0.0)
+            kernel=cov_amplitude * matern,
+            normalize_y=True, random_state=random_state, alpha=0.0, noise="gaussian")
 
     return base_minimize(
         func, dimensions, base_estimator=base_estimator,

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -3,7 +3,7 @@
 import numpy as np
 
 from sklearn.base import clone
-from sklearn.gaussian_process import GaussianProcessRegressor
+from skopt.learning import GaussianProcessRegressor
 from sklearn.gaussian_process.kernels import Matern
 from sklearn.gaussian_process.kernels import ConstantKernel
 from sklearn.gaussian_process.kernels import WhiteKernel


### PR DESCRIPTION
- [x] Adds a noise attribute directly to `skopt.learning.GaussianProcessRegressor`
- [x] At prediction time, to predict `P(f(x) | y)` the kernel `K(X_train, X_new)` and `K(X_new, X_new)`, should not include the noise or white kernel argument, this has been described in Eq, 2.24 of http://www.gaussianprocess.org/gpml/chapters/RW2.pdf . Note that `K(X_train, X_new)` and `K(X_new, X_new)` do not have the `sigma**2` term.