### PR TITLE
Fix PyQt4 import error

### DIFF
--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -26,7 +26,7 @@ popd
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
-   numpy scipy cython matplotlib
+   numpy scipy cython pyqt matplotlib
 source activate testenv
 pip install git+http://github.com/scikit-learn/scikit-learn.git
 


### PR DESCRIPTION
Travis on master creates a `PyQt4` import error when trying to import matplotlib.pyplot. Not sure what the issue is but checking if this fixes the issue.