### PR TITLE
[MRG] Pin PyQT to 4.11 temporarily

### DIFF
--- a/build_tools/circle/install.sh
+++ b/build_tools/circle/install.sh
@@ -30,7 +30,7 @@ popd
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n testenv --yes python pip nose \
-   numpy scipy cython matplotlib
+   numpy scipy cython matplotlib pyqt==4.11.4
 source activate testenv
 pip install git+http://github.com/scikit-learn/scikit-learn.git
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -26,7 +26,7 @@ popd
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
-   numpy scipy cython matplotlib
+   numpy scipy cython matplotlib pyqt==4.11.4
 source activate testenv
 pip install git+http://github.com/scikit-learn/scikit-learn.git
 


### PR DESCRIPTION
This is a takeover from #228. After some digging I found ContinuumIO/anaconda-issues#1068. Seems like @continuumio broke something so waiting for them to fix it after which we should undo this pinning.