### PR TITLE
[MRG] Changing options for base_estimator to uppercase

### DIFF
--- a/examples/strategy-comparison.ipynb
+++ b/examples/strategy-comparison.ipynb
@@ -175,10 +175,10 @@
     "gp_res = run(gp_minimize)\n",
     "\n",
     "# Random forest\n",
-    "rf_res = run(partial(forest_minimize, base_estimator=\"rf\"))\n",
+    "rf_res = run(partial(forest_minimize, base_estimator=\"RF\"))\n",
     "\n",
     "# Extra trees \n",
-    "et_res = run(partial(forest_minimize, base_estimator=\"et\"))"
+    "et_res = run(partial(forest_minimize, base_estimator=\"ET\"))"
    ]
   },
   {

--- a/examples/visualizing-results.ipynb
+++ b/examples/visualizing-results.ipynb
@@ -185,7 +185,7 @@
     "bounds = [(-5.0, 10.0), (0.0, 15.0)]\n",
     "n_calls = 160\n",
     "\n",
-    "forest_res = forest_minimize(branin, bounds, n_calls=n_calls, base_estimator=\"et\",\n",
+    "forest_res = forest_minimize(branin, bounds, n_calls=n_calls, base_estimator=\"ET\",\n",
     "                             random_state=4)\n",
     "\n",
     "_ = plot_evaluations(forest_res, bins=10)"
@@ -319,7 +319,7 @@
     "bounds = [(0., 1.),] * 6\n",
     "\n",
     "forest_res = forest_minimize(hart6, bounds, n_calls=n_calls,\n",
-    "                             base_estimator=\"et\", random_state=4)"
+    "                             base_estimator=\"ET\", random_state=4)"
    ]
   },
   {
@@ -400,7 +400,7 @@
     "n_calls = 200\n",
     "\n",
     "forest_res = forest_minimize(hart6, bounds, n_calls=n_calls,\n",
-    "                             base_estimator=\"et\", random_state=4)\n",
+    "                             base_estimator=\"ET\", random_state=4)\n",
     "\n",
     "_ = plot_evaluations(forest_res)\n",
     "_ = plot_objective(forest_res)"

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -7,7 +7,7 @@ from ..learning import ExtraTreesRegressor
 from ..learning import RandomForestRegressor
 
 
-def forest_minimize(func, dimensions, base_estimator="et",
+def forest_minimize(func, dimensions, base_estimator="ET",
                     n_calls=100, n_random_starts=10,
                     acq_func="EI", acq_optimizer="auto",
                     x0=None, y0=None, random_state=None, verbose=False,
@@ -46,11 +46,11 @@ def forest_minimize(func, dimensions, base_estimator="et",
         - an instance of a `Dimension` object (`Real`, `Integer` or
           `Categorical`).
 
-    * `base_estimator` [string or `Regressor`, default=`"et"`]:
+    * `base_estimator` [string or `Regressor`, default=`"ET"`]:
         The regressor to use as surrogate model. Can be either
 
-        - `"rf"` for random forest regressor
-        - `"et"` for extra trees regressor
+        - `"RF"` for random forest regressor
+        - `"ET"` for extra trees regressor
         - instance of regressor with support for `return_std` in its predict
           method
 
@@ -141,18 +141,18 @@ def forest_minimize(func, dimensions, base_estimator="et",
 
     # Default estimator
     if isinstance(base_estimator, str):
-        if base_estimator not in ("rf", "et"):
+        if base_estimator not in ("RF", "ET"):
             raise ValueError(
                 "Valid strings for the base_estimator parameter"
-                " are: 'rf' or 'et', not '%s'" % base_estimator)
+                " are: 'RF' or 'ET', not '%s'" % base_estimator)
 
-        if base_estimator == "rf":
+        if base_estimator == "RF":
             base_estimator = RandomForestRegressor(n_estimators=100,
                                                    min_samples_leaf=3,
                                                    n_jobs=n_jobs,
                                                    random_state=rng)
 
-        elif base_estimator == "et":
+        elif base_estimator == "ET":
             base_estimator = ExtraTreesRegressor(n_estimators=100,
                                                  min_samples_leaf=3,
                                                  n_jobs=n_jobs,

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -26,7 +26,7 @@ MINIMIZERS = [gp_minimize]
 ACQUISITION = ["LCB", "PI", "EI"]
 
 
-for est, acq in product(["et", "rf"], ACQUISITION):
+for est, acq in product(["ET", "RF"], ACQUISITION):
     MINIMIZERS.append(
         partial(forest_minimize, base_estimator=est, acq_func=acq))
 for acq in ACQUISITION:

--- a/skopt/tests/test_forest_opt.py
+++ b/skopt/tests/test_forest_opt.py
@@ -16,8 +16,8 @@ from skopt.benchmarks import branin
 from skopt.benchmarks import hart6
 
 
-MINIMIZERS = [("et", partial(forest_minimize, base_estimator='et')),
-              ("rf", partial(forest_minimize, base_estimator='rf')),
+MINIMIZERS = [("ET", partial(forest_minimize, base_estimator='ET')),
+              ("RF", partial(forest_minimize, base_estimator='RF')),
               ("gbrt", gbrt_minimize)]
 
 
@@ -66,7 +66,7 @@ def test_tree_based_minimize():
         yield (check_minimize, minimizer, hart6, -3.32,
                np.tile((0.0, 1.0), (6, 1)), 1.0, 50)
 
-        if name == "et":
+        if name == "ET":
             yield (check_minimize, minimizer, branin, 0.39,
                    [(-5.0, 10.0), (0.0, 15.0)], 0.15, 125)
         else:


### PR DESCRIPTION
This is a fix for issue #153 to change the arguments to the base_estimator parameter of the forest_minimize function to uppercase.  I made edits in the forest.py and test_forest_opt.py files to reflect the changes.

This is my first contribution so I'm open to feedback on any mistakes I'm making.  (Blame @betatim and Linear Digressions for bringing me here :smile:)