### PR TITLE
[MRG] Update AUTHORS, link roadmap and split circleci build

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -2,6 +2,7 @@
 
 Scikit-Optimize is a community effort. Contributors include, in alphabetical order:
 
+* [andreh7][andreh7]
 * [Nuno Campos][nfcampos]
 * [Mehdi Cherti][mehdidc]
 * [Alexander Fabisch][AlexanderFabisch]
@@ -10,6 +11,7 @@ Scikit-Optimize is a community effort. Contributors include, in alphabetical ord
 * [Gilles Louppe][glouppe]
 * [cmmalone][cmmalone]
 * [nel215][nel215]
+* [Taylor Smith][jtsmith2]
 
 The scikit-optimize logo was a contribution by
 [Jeremy Anderson][objectadjective] and **Rose Peng**.
@@ -23,3 +25,5 @@ The scikit-optimize logo was a contribution by
 [cmmalone]: https://github.com/cmmalone
 [nel215]: https://github.com/nel215
 [objectadjective]: https://github.com/objectadjective
+[jtsmith2]: https://github.com/jtsmith2
+[andreh7]: https://github.com/andreh7

--- a/README.md
+++ b/README.md
@@ -62,7 +62,10 @@ and the other [examples](https://github.com/scikit-optimize/scikit-optimize/tree
 
 ## Development
 
-The library is still experimental and under heavy development.
+The library is still experimental and under heavy development. Checkout the
+[ROADMAP](https://github.com/scikit-optimize/scikit-optimize/issues/202) for
+the next release or look at some [easy issues](https://github.com/scikit-optimize/scikit-optimize/issues?q=is%3Aissue+is%3Aopen+label%3AEasy)
+to get started contributing.
 
 The development version can be installed through:
 ```

--- a/build_tools/circle/execute.sh
+++ b/build_tools/circle/execute.sh
@@ -1,0 +1,15 @@
+export PATH="$HOME/miniconda3/bin:$PATH"
+source activate testenv
+export SKOPT_HOME=$(pwd)
+
+# Generating documentation
+for nb in examples/*ipynb; do
+    jupyter nbconvert --ExecutePreprocessor.timeout=1024 --execute "$nb" --to markdown |& tee -a nb_to_md.txt
+done
+
+cd ~
+mkdir -p ./doc/skopt/notebooks
+cp ${SKOPT_HOME}/examples/*md ${HOME}/doc/skopt/notebooks
+cp -r ${SKOPT_HOME}/examples/*_files ${HOME}/doc/skopt/notebooks
+python ${SKOPT_HOME}/build_tools/circle/make_doc.py --overwrite --html --html-dir ./doc --template-dir ${SKOPT_HOME}/build_tools/circle/templates --notebook-dir ./doc/skopt/notebooks skopt
+cp -r ./doc ${CIRCLE_ARTIFACTS}

--- a/build_tools/circle/install.sh
+++ b/build_tools/circle/install.sh
@@ -46,15 +46,3 @@ pip install pdoc==0.3.2 pygments
 # importing matplotlib once builds the font caches. This avoids
 # having warnings in our example notebooks
 python -c "import matplotlib.pyplot as plt"
-
-# Generating documentation
-for nb in examples/*ipynb; do
-    jupyter nbconvert --ExecutePreprocessor.timeout=1024 --execute "$nb" --to markdown |& tee -a nb_to_md.txt
-done
-
-cd ~
-mkdir -p ./doc/skopt/notebooks
-cp ${SKOPT_HOME}/examples/*md ${HOME}/doc/skopt/notebooks
-cp -r ${SKOPT_HOME}/examples/*_files ${HOME}/doc/skopt/notebooks
-python ${SKOPT_HOME}/build_tools/circle/make_doc.py --overwrite --html --html-dir ./doc --template-dir ${SKOPT_HOME}/build_tools/circle/templates --notebook-dir ./doc/skopt/notebooks skopt
-cp -r ./doc ${CIRCLE_ARTIFACTS}

--- a/circle.yml
+++ b/circle.yml
@@ -4,8 +4,10 @@ dependencies:
         timeout: 1024
 
 test:
-  # Grep error on the documentation
+  # Run and convert examplesto markdown, then grep for errors
   override:
+    - bash ./build_tools/circle/execute.sh:
+        timeout: 1024
     - if grep -q "Traceback (most recent call last):" nb_to_md.txt; then false; else true; fi
 
 deployment:


### PR DESCRIPTION
Mainly administrative stuff.

I split the CircleCI stuff because the length of the log file that you can see online is limited and mainly full of download bars for setting up the env which makes it hard to see what is actually failing. Hopefully this way we get better online logs.