### PR TITLE
[MRG+1] Fail fast for examples

### DIFF
--- a/build_tools/circle/execute.sh
+++ b/build_tools/circle/execute.sh
@@ -3,13 +3,20 @@ source activate testenv
 export SKOPT_HOME=$(pwd)
 
 # Generating documentation
+mkdir -p ${HOME}/doc/skopt/notebooks
 for nb in examples/*ipynb; do
-    jupyter nbconvert --ExecutePreprocessor.timeout=1024 --execute "$nb" --to markdown |& tee -a nb_to_md.txt
+    jupyter nbconvert --ExecutePreprocessor.timeout=1024 --execute "$nb" --to markdown |& tee nb_to_md.txt
+    traceback=$(grep "Traceback (most recent call last):" nb_to_md.txt)
+    if [[ $traceback ]]; then
+        exit 1
+    fi
+    support_files=$(grep -oP "Support files will be in \K.+$" nb_to_md.txt)
+    if [[ $support_files ]]; then
+        cp -r ${SKOPT_HOME}/examples/$support_files ${HOME}/doc/skopt/notebooks
+    fi
 done
 
 cd ~
-mkdir -p ./doc/skopt/notebooks
 cp ${SKOPT_HOME}/examples/*md ${HOME}/doc/skopt/notebooks
-cp -r ${SKOPT_HOME}/examples/*_files ${HOME}/doc/skopt/notebooks
 python ${SKOPT_HOME}/build_tools/circle/make_doc.py --overwrite --html --html-dir ./doc --template-dir ${SKOPT_HOME}/build_tools/circle/templates --notebook-dir ./doc/skopt/notebooks skopt
 cp -r ./doc ${CIRCLE_ARTIFACTS}

--- a/build_tools/circle/execute.sh
+++ b/build_tools/circle/execute.sh
@@ -3,20 +3,17 @@ source activate testenv
 export SKOPT_HOME=$(pwd)
 
 # Generating documentation
-mkdir -p ${HOME}/doc/skopt/notebooks
 for nb in examples/*ipynb; do
     jupyter nbconvert --ExecutePreprocessor.timeout=1024 --execute "$nb" --to markdown |& tee nb_to_md.txt
     traceback=$(grep "Traceback (most recent call last):" nb_to_md.txt)
     if [[ $traceback ]]; then
         exit 1
     fi
-    support_files=$(grep -oP "Support files will be in \K.+$" nb_to_md.txt)
-    if [[ $support_files ]]; then
-        cp -r ${SKOPT_HOME}/examples/$support_files ${HOME}/doc/skopt/notebooks
-    fi
 done
 
 cd ~
+mkdir -p ${HOME}/doc/skopt/notebooks
 cp ${SKOPT_HOME}/examples/*md ${HOME}/doc/skopt/notebooks
+find ${SKOPT_HOME}/examples -name \*_files -exec cp -r {} ${HOME}/doc/skopt/notebooks \;
 python ${SKOPT_HOME}/build_tools/circle/make_doc.py --overwrite --html --html-dir ./doc --template-dir ${SKOPT_HOME}/build_tools/circle/templates --notebook-dir ./doc/skopt/notebooks skopt
 cp -r ./doc ${CIRCLE_ARTIFACTS}


### PR DESCRIPTION
Here is the circleci test with the updated fail fast execute.sh script:
https://circleci.com/gh/thomasjpfan/scikit-optimize/15

For testing purposes, I created a branch with the same script, but with a syntax error in bayesian-optimization.ipynb and ran it on circleci, https://circleci.com/gh/thomasjpfan/scikit-optimize/17, to show that the testing fails with the first error.

While updating the script, I noticed that if the notebook files don't have supporting files i.e. images, the `cp -r ${SKOPT_HOME}/examples/*_files ${HOME}/doc/skopt/notebooks` will fail. So I have updated that line with a find command. To make sure it works, I ran a circleci test where the example notebooks don't have supporting files:
https://circleci.com/gh/thomasjpfan/scikit-optimize/16