### PR TITLE
Proof of Concept: Keep transformation and dimensions independent

### DIFF
--- a/skopt/space.py
+++ b/skopt/space.py
@@ -76,19 +76,6 @@ class Log10(Transformer):
         return 10.0 ** np.asarray(Xt, dtype=np.float)
 
 
-class _Log10:
-    """Base 10 logarithm transform."""
-
-    def fit(self, X):
-        return self
-
-    def transform(self, X):
-        return np.log10(np.asarray(X, dtype=np.float))
-
-    def inverse_transform(self, Xt):
-        return 10.0 ** np.asarray(Xt, dtype=np.float)
-
-
 class CategoricalEncoder(Transformer):
     """OneHotEncoder that can handle categorical variables."""
 
@@ -141,75 +128,6 @@ class CategoricalEncoder(Transformer):
         return [
             self.inverse_mapping_[i] for i in self._lb.inverse_transform(Xt)
         ]
-
-class _CategoricalEncoder:
-    """OneHotEncoder that can handle categorical variables."""
-
-    def __init__(self):
-        """Convert labeled categories into one-hot encoded features."""
-        self._lb = LabelBinarizer()
-
-    def fit(self, X):
-        """Fit a list or array of categories.
-
-        Parameters
-        ----------
-        * `X` [array-like, shape=(n_categories,)]:
-            List of categories.
-        """
-        self.mapping_ = {v: i for i, v in enumerate(X)}
-        self.inverse_mapping_ = {i: v for v, i in self.mapping_.items()}
-        self._lb.fit([self.mapping_[v] for v in X])
-        self.n_classes = len(self._lb.classes_)
-
-        return self
-
-    def transform(self, X):
-        """Transform an array of categories to a one-hot encoded representation.
-
-        Parameters
-        ----------
-        * `X` [array-like, shape=(n_samples,)]:
-            List of categories.
-
-        Returns
-        -------
-        * `Xt` [array-like, shape=(n_samples, n_categories)]:
-            The one-hot encoded categories.
-        """
-        return self._lb.transform([self.mapping_[v] for v in X])
-
-    def inverse_transform(self, Xt):
-        """Inverse transform one-hot encoded categories back to their original
-           representation.
-
-        Parameters
-        ----------
-        * `Xt` [array-like, shape=(n_samples, n_categories)]:
-            One-hot encoded categories.
-
-        Returns
-        -------
-        * `X` [array-like, shape=(n_samples,)]:
-            The original categories.
-        """
-        Xt = np.asarray(Xt)
-        return [
-            self.inverse_mapping_[i] for i in self._lb.inverse_transform(Xt)
-        ]
-
-
-class _Identity:
-    """Identity transform."""
-
-    def fit(self, X):
-        return self
-
-    def transform(self, X):
-        return X
-
-    def inverse_transform(self, Xt):
-        return Xt
 
 
 class Dimension(object):

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -29,6 +29,51 @@ class _Identity:
         return Xt
 
 
+class Transformer(object):
+    def rvs(self, n_samples=1, random_state=None):
+        """Sample from the transformed dimension and convert it back
+        to the original dimension.
+
+        Parameters
+        ----------
+        * `n_samples` [int or None]:
+            The number of samples to be drawn.
+
+        * `random_state` [int, RandomState instance, or None (default)]:
+            Set random state to something other than None for reproducible
+            results.
+        """
+        rng = check_random_state(random_state)
+        samples = self.transformed_dim.rvs(
+            n_samples=n_samples, random_state=rng)
+        return self.inverse_transform(samples)
+
+    def fit(self, X):
+        return self
+
+    def transform(self, X):
+        raise NotImplementedError
+
+    def inverse_transform(self, X):
+        raise NotImplementedError
+
+
+class Log10(Transformer):
+    """Base 10 logarithm transform."""
+    def __init__(self, dim):
+        self.dim = dim
+        if not isinstance(dim, Real):
+            raise ValueError("Raise")
+        if isinstance(dim, Real):
+            self.transformed_dim = Real(np.log10(dim.low), np.log10(dim.high))
+
+    def transform(self, X):
+        return np.log10(np.asarray(X, dtype=np.float))
+
+    def inverse_transform(self, Xt):
+        return 10.0 ** np.asarray(Xt, dtype=np.float)
+
+
 class _Log10:
     """Base 10 logarithm transform."""
 

--- a/skopt/space.py
+++ b/skopt/space.py
@@ -79,12 +79,12 @@ class Log10(Transformer):
 class CategoricalEncoder(Transformer):
     """OneHotEncoder that can handle categorical variables."""
 
-    def __init__(self, dim):
+    def __init__(self, categories):
         """Convert labeled categories into one-hot encoded features."""
         self._lb = LabelBinarizer()
-        self.mapping_ = {v: i for i, v in enumerate(X)}
+        self.mapping_ = {v: i for i, v in enumerate(categories)}
         self.inverse_mapping_ = {i: v for v, i in self.mapping_.items()}
-        self._lb.fit([self.mapping_[v] for v in X])
+        self._lb.fit([self.mapping_[v] for v in self.categories])
         self.n_classes = len(self._lb.classes_)
 
     def rvs(self, n_samples=None, random_state=None):


### PR DESCRIPTION
With the current API, the way we handle dimensions and transformations is confusing. The places where the idea of a transformed dimensional space are used currently is while:
1. Supplying a log-uniform transform to `Real`
2. Supplying a one-hot encoding to `Categorical`

Also, the current methods on every `Dimension` instance are:
1. Rvs -- Sampling from the transformed dimensional space and then transforming back to the original space.
2. Transform -- Transforming to the transformed dimensional space.
3. Inverse Transform -- Transforming back from the transformed dimensional space.

I feel we should only keep `rvs` and have a `Transformer` object that takes the original dimension as a constructor argument and the transformed space should be defined by the Transformer itself. In this way we can do

``` python
t = Log10(Real(10**2, 10**4))
t.transform(10**3)
t.inverse_transform(3)
```

The reason it is better to use it a class rather than a function that returns the transformed dimension is that it becomes convenient to do the inverse mapping as well.

Open Questions:
- [ ] Is this the best way?
- [ ] What would be the best way to handle a pipeline of transformations?
- [ ] What would be the best way to handle this in terms of the Space API?
