### PR TITLE
Persistence with skopt.dump() and skopt.load()

### DIFF
--- a/examples/store-and-load-results.ipynb
+++ b/examples/store-and-load-results.ipynb
@@ -1,0 +1,269 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Store and load `skopt` optimization results\n",
+    "\n",
+    "Mikhail Pak, October 2016."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": true
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "np.random.seed(777)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Problem statement\n",
+    "\n",
+    "We often want to store optimization results in a file. This can be useful, for example,\n",
+    "\n",
+    "* if you want to share your results with colleagues;\n",
+    "* if you want to archive and/or document your work;\n",
+    "* or if you want to postprocess your results in a different Python instance or on an another computer.\n",
+    "\n",
+    "The process of converting an object into a byte stream that can be stored in a file is called _serialization_.\n",
+    "Conversely, _deserialization_ means loading an object from a byte stream.\n",
+    "\n",
+    "**Warning:** Deserialization is not secure against malicious or erroneous code. Never load serialized data from untrusted or unauthenticated sources!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simple example\n",
+    "\n",
+    "We will use the same optimization problem as in the [`bayesian-optimization.ipynb`](https://github.com/scikit-optimize/scikit-optimize/blob/master/examples/bayesian-optimization.ipynb) notebook:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from skopt import gp_minimize\n",
+    "\n",
+    "noise_level = 0.1\n",
+    "\n",
+    "def obj_fun(x, noise_level=noise_level):\n",
+    "    return np.sin(5 * x[0]) * (1 - np.tanh(x[0] ** 2)) + np.random.randn() * noise_level\n",
+    "\n",
+    "res = gp_minimize(obj_fun,            # the function to minimize\n",
+    "                  [(-2.0, 2.0)],      # the bounds on each dimension of x\n",
+    "                  x0=[0.],            # the starting point\n",
+    "                  acq_func=\"LCB\",     # the acquisition function (optional)\n",
+    "                  n_calls=15,         # the number of evaluations of f including at x0\n",
+    "                  n_random_starts=0,  # the number of random initialization points\n",
+    "                  random_state=777)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "As long as your Python session is active, you can access all the optimization results via the `res` object.\n",
+    "\n",
+    "So how can you store this data in a file? `skopt` conveniently provides functions `skopt.dump()` and `skopt.load()` that handle this for you. These functions are essentially thin wrappers around the [`joblib`](http://pythonhosted.org/joblib) module's `dump()` and `load()`.\n",
+    "\n",
+    "We will now show how to use `skopt.dump()` and `skopt.load()` for storing and loading results."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Using `skopt.dump()` and `skopt.load()`\n",
+    "\n",
+    "For storing optimization results into a file, call the `skopt.dump()` function:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "from skopt import dump, load\n",
+    "\n",
+    "dump(res, 'result.pkl')"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "And load from file using `skopt.load()`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 4,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "-0.17493386623950199"
+      ]
+     },
+     "execution_count": 4,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "res_loaded = load('result.pkl')\n",
+    "\n",
+    "res_loaded.fun"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can fine-tune the serialization and deserialization process by calling `skopt.dump()` and `skopt.load()` with additional keyword arguments. See the `joblib` documentation ([dump](https://pythonhosted.org/joblib/generated/joblib.dump.html) and [load](https://pythonhosted.org/joblib/generated/joblib.load.html)) for the additional parameters.\n",
+    "\n",
+    "For instance, you can specify the compression algorithm and compression level (highest in this case):"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 5,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Without compression: 66278 bytes\n",
+      "Compressed with gz:  17623 bytes\n"
+     ]
+    }
+   ],
+   "source": [
+    "dump(res, 'result.gz', compress=9)\n",
+    "\n",
+    "from os.path import getsize\n",
+    "print('Without compression: {} bytes'.format(getsize('result.pkl')))\n",
+    "print('Compressed with gz:  {} bytes'.format(getsize('result.gz')))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Unserializable objective functions\n",
+    "\n",
+    "Notice that if your objective function is non-trivial (e.g. it calls MATLAB engine from Python), it might be not serializable and `skopt.dump()` will raise an exception when you try to store the optimization results.\n",
+    "In this case you should disable storing the objective function by calling `skopt.dump()` with the keyword argument `store_objective=False`:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 6,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "dump(res, 'result_without_objective.pkl', store_objective=False)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Notice that the entry `'func'` is absent in the loaded object but is still present in the local variable:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 7,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Loaded object:  dict_keys(['verbose', 'base_estimator', 'dimensions', 'n_random_starts', 'n_calls', 'x0', 'n_points', 'callback', 'acq_optimizer', 'n_restarts_optimizer', 'kappa', 'acq_func', 'xi', 'random_state', 'y0'])\n",
+      "Local variable: dict_keys(['dimensions', 'n_random_starts', 'n_calls', 'n_restarts_optimizer', 'kappa', 'func', 'random_state', 'callback', 'verbose', 'x0', 'n_points', 'acq_optimizer', 'base_estimator', 'acq_func', 'xi', 'y0'])\n"
+     ]
+    }
+   ],
+   "source": [
+    "res_loaded_without_objective = load('result_without_objective.pkl')\n",
+    "\n",
+    "print('Loaded object: ', res_loaded_without_objective.specs['args'].keys())\n",
+    "print('Local variable:', res.specs['args'].keys())"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Possible problems\n",
+    "\n",
+    "* __Python versions incompatibility:__ In general, objects serialized in Python 2 cannot be deserialized in Python 3 and vice versa.\n",
+    "* __Security issues:__ Once again, do not load any files from untrusted sources.\n",
+    "* __Extremely large results objects:__ If your optimization results object is extremely large, calling `skopt.dump()` with `store_objective=False` might cause performance issues. This is due to creation of a deep copy without the objective function. If the objective function it is not critical to you, you can simply delete it before calling `skopt.dump()`. In this case, no deep copy is created:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 8,
+   "metadata": {
+    "collapsed": false
+   },
+   "outputs": [],
+   "source": [
+    "del res.specs['args']['func']\n",
+    "\n",
+    "dump(res, 'result_without_objective_2.pkl')"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/skopt/__init__.py
+++ b/skopt/__init__.py
@@ -57,6 +57,7 @@ from .optimizer import dummy_minimize
 from .optimizer import forest_minimize
 from .optimizer import gbrt_minimize
 from .optimizer import gp_minimize
+from .utils import load, dump
 
 
 __version__ = "0.1"
@@ -72,4 +73,7 @@ __all__ = ("acquisition",
            "gp_minimize",
            "dummy_minimize",
            "forest_minimize",
-           "gbrt_minimize")
+           "gbrt_minimize",
+           "dump",
+           "load",
+           )

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -1,0 +1,53 @@
+import numpy as np
+import tempfile
+
+from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_equal
+from sklearn.utils.testing import assert_true
+
+from skopt import gp_minimize
+from skopt import load
+from skopt import dump
+from skopt.benchmarks import bench3
+
+
+def check_optimization_results_equality(res_1, res_2):
+    # Check if the results objects have the same keys
+    assert_equal(sorted(res_1.keys()), sorted(res_2.keys()))
+    # Shallow check of the main optimization results
+    assert_array_equal(res_1.x, res_2.x)
+    assert_array_equal(res_1.x_iters, res_2.x_iters)
+    assert_array_equal(res_1.fun, res_2.fun)
+    assert_array_equal(res_1.func_vals, res_2.func_vals)
+
+
+def test_dump_and_load():
+    res = gp_minimize(bench3,
+                      [(-2.0, 2.0)],
+                      x0=[0.],
+                      acq_func="LCB",
+                      n_calls=2,
+                      n_random_starts=0,
+                      random_state=1)
+
+    # Test normal dumping and loading
+    with tempfile.TemporaryFile() as f:
+        dump(res, f)
+        res_loaded = load(f)
+    check_optimization_results_equality(res, res_loaded)
+    assert_true('func' in res_loaded.specs['args'])
+
+    # Test dumping without objective function
+    with tempfile.TemporaryFile() as f:
+        dump(res, f, store_objective=False)
+        res_loaded = load(f)
+    check_optimization_results_equality(res, res_loaded)
+    assert_true(not ('func' in res_loaded.specs['args']))
+
+    # Delete the objective function and dump the modified object
+    del res.specs['args']['func']
+    with tempfile.TemporaryFile() as f:
+        dump(res, f, store_objective=False)
+        res_loaded = load(f)
+    check_optimization_results_equality(res, res_loaded)
+    assert_true(not ('func' in res_loaded.specs['args']))

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -71,9 +71,13 @@ def dump(res, filename, store_objective=True, **kwargs):
         Whether the objective function should be stored. Set `store_objective`
         to `False` if your objective function (`.specs['args']['func']`) is
         unserializable (i.e. if an exception is raised when trying to serialize
-        the optimization result). Notice that in this case a deep copy of the
-        optimization result is created. This can potentially lead to performance
-        problems.
+        the optimization result).
+
+        Notice that if `store_objective` is set to `False`, a deep copy of the
+        optimization result is created, potentially leading to performance
+        problems if `res` is very large. If the objective function is not
+        critical, one can delete it before calling `skopt.dump()` and thus avoid
+        deep copying of `res`.
 
     * `**kwargs` [other keyword arguments]:
         All other keyword arguments will be passed to `joblib.dump`.


### PR DESCRIPTION
See #190 

To do:
- [x] Write unit tests

~~Be more specific when catching the pickling exception, search for `func` in the error message~~