### PR TITLE
Ignore build_tools for the language bar

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+build_tools/*  linguist-documentation=true


### PR DESCRIPTION
I'm sorry, this PR is _really_ nitpicking.

Currently, the language bar shows that `skopt` has 15.8% Mako and 2% Shell, although these are only for the build tools.

Wouldn't it be better to exclude them and indicate that `skopt` is 100% Python?

We could also include the Jupyter notebooks in the `examples` folder. 