### PR TITLE
[MRG] Remove tests on branin and hart6 

### DIFF
--- a/benchmarks/bench_branin.py
+++ b/benchmarks/bench_branin.py
@@ -1,4 +1,3 @@
-from functools import partial
 import numpy as np
 
 from skopt.benchmarks import branin
@@ -6,7 +5,8 @@ from skopt import gp_minimize, forest_minimize, gbrt_minimize
 
 bounds = [(-5.0, 10.0), (0.0, 15.0)]
 n_calls = 200
-optimizers = [("gp_minimize", gp_minimize), ("forest_minimize", forest_minimize),
+optimizers = [("gp_minimize", gp_minimize),
+              ("forest_minimize", forest_minimize),
               ("gbrt_minimize", gbrt_minimize)]
 
 for name, optimizer in optimizers:

--- a/benchmarks/bench_hart6.py
+++ b/benchmarks/bench_hart6.py
@@ -1,4 +1,3 @@
-from functools import partial
 import numpy as np
 
 from skopt.benchmarks import hart6
@@ -6,7 +5,8 @@ from skopt import gp_minimize, forest_minimize, gbrt_minimize
 
 bounds = np.tile((0., 1.), (6, 1))
 n_calls = 200
-optimizers = [("gp_minimize", gp_minimize), ("forest_minimize", forest_minimize),
+optimizers = [("gp_minimize", gp_minimize),
+              ("forest_minimize", forest_minimize),
               ("gbrt_minimize", gbrt_minimize)]
 
 for name, optimizer in optimizers:

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -6,7 +6,7 @@ from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_raises
 
-from skopt.acquisition import  gaussian_acquisition_1D
+from skopt.acquisition import gaussian_acquisition_1D
 from skopt.acquisition import gaussian_ei
 from skopt.acquisition import gaussian_lcb
 from skopt.acquisition import gaussian_pi
@@ -54,7 +54,7 @@ def test_acquisition_api():
 
 
 def check_gradient_correctness(X_new, model, acq_func, y_opt):
-    analytic_grad =  gaussian_acquisition_1D(
+    analytic_grad = gaussian_acquisition_1D(
         X_new, model, y_opt, acq_func)[1]
     num_grad_func = lambda x:  gaussian_acquisition_1D(
         x, model, y_opt, acq_func=acq_func)[0]

--- a/skopt/tests/test_dummy_opt.py
+++ b/skopt/tests/test_dummy_opt.py
@@ -1,13 +1,9 @@
-import numpy as np
-
 from sklearn.utils.testing import assert_less
 
 from skopt import dummy_minimize
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
-from skopt.benchmarks import branin
-from skopt.benchmarks import hart6
 
 
 def check_minimize(func, y_opt, dimensions, margin, n_calls):
@@ -19,5 +15,3 @@ def test_dummy_minimize():
     yield (check_minimize, bench1, 0., [(-2.0, 2.0)], 0.05, 10000)
     yield (check_minimize, bench2, -5, [(-6.0, 6.0)], 0.05, 10000)
     yield (check_minimize, bench3, -0.9, [(-2.0, 2.0)], 0.05, 10000)
-    yield (check_minimize, branin, 0.39, [(-5.0, 10.0), (0.0, 15.0)], 0.1, 10000)
-    yield (check_minimize, hart6, -3.32, np.tile((0.0, 1.0), (6, 1)), 0.5, 10000)

--- a/skopt/tests/test_forest_opt.py
+++ b/skopt/tests/test_forest_opt.py
@@ -1,7 +1,5 @@
 from functools import partial
 
-import numpy as np
-
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raise_message
@@ -12,8 +10,6 @@ from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
 from skopt.benchmarks import bench4
-from skopt.benchmarks import branin
-from skopt.benchmarks import hart6
 
 
 MINIMIZERS = [("ET", partial(forest_minimize, base_estimator='ET')),
@@ -37,12 +33,13 @@ def test_forest_minimize_api():
 
 
 def check_minimize(minimizer, func, y_opt, dimensions, margin,
-                        n_calls, n_random_starts=10, x0=None):
+                   n_calls, n_random_starts=10, x0=None):
     for n in range(3):
         r = minimizer(
             func, dimensions, n_calls=n_calls, random_state=n,
             n_random_starts=n_random_starts, x0=x0)
         assert_less(r.fun, y_opt + margin)
+
 
 def test_tree_based_minimize():
     for name, minimizer in MINIMIZERS:
@@ -58,17 +55,7 @@ def test_tree_based_minimize():
         X0 = [[-5.6], [-5.8], [5.8], [5.6]]
         yield (check_minimize, minimizer, bench2, -5,
                [(-6.0, 6.0)], 0.1, 100, 10, X0)
-
         yield (check_minimize, minimizer, bench3, -0.9,
                [(-2.0, 2.0)], 0.05, 25)
         yield (check_minimize, minimizer, bench4, 0.0,
-               [("-2", "-1", "0", "1", "2")], 0.05, 10)
-        yield (check_minimize, minimizer, hart6, -3.32,
-               np.tile((0.0, 1.0), (6, 1)), 1.0, 50)
-
-        if name == "ET":
-            yield (check_minimize, minimizer, branin, 0.39,
-                   [(-5.0, 10.0), (0.0, 15.0)], 0.15, 125)
-        else:
-            yield (check_minimize, minimizer, branin, 0.39,
-                   [(-5.0, 10.0), (0.0, 15.0)], 0.15, 200)
+               [("-2", "-1", "0", "1", "2")], 0.05, 10, 1)

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -1,4 +1,3 @@
-import numpy as np
 from itertools import product
 
 from sklearn.utils.testing import assert_array_equal
@@ -9,8 +8,6 @@ from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
 from skopt.benchmarks import bench4
-from skopt.benchmarks import branin
-from skopt.benchmarks import hart6
 
 
 def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
@@ -24,15 +21,14 @@ def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
 
 def test_gp_minimize():
     for search, acq in product(["sampling", "lbfgs"], ["LCB", "EI"]):
-        yield (check_minimize, bench1, 0., [(-2.0, 2.0)], search, acq, 0.05, 50)
-        yield (check_minimize, bench2, -5, [(-6.0, 6.0)], search, acq, 0.05, 75)
-        yield (check_minimize, bench3, -0.9, [(-2.0, 2.0)], search, acq, 0.05, 50)
+        yield (check_minimize, bench1, 0.,
+               [(-2.0, 2.0)], search, acq, 0.05, 50)
+        yield (check_minimize, bench2, -5,
+               [(-6.0, 6.0)], search, acq, 0.05, 75)
+        yield (check_minimize, bench3, -0.9,
+               [(-2.0, 2.0)], search, acq, 0.05, 50)
         yield (check_minimize, bench4, 0.0,
                [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
-        yield (check_minimize, branin, 0.39, [(-5.0, 10), (0.0, 15.)],
-               search, acq, 0.15, 100)
-        yield (check_minimize, hart6, -3.32, np.tile((0., 1.), (6, 1)),
-               search, acq, 1.0, 100)
 
 
 def test_n_jobs():

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -3,7 +3,6 @@ import numpy as np
 
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_less_equal
@@ -27,7 +26,7 @@ def check_dimension(Dimension, vals, random_val):
 def check_categorical(vals, random_val):
     x = Categorical(vals)
     assert_equal(x, Categorical(vals))
-    assert_not_equal(x, Categorical(vals[:-1] + ('zzz',)))
+    assert_not_equal(x, Categorical(vals[:-1] + ("zzz",)))
     assert_equal(x.rvs(random_state=1), random_val)
 
 
@@ -36,7 +35,7 @@ def test_dimensions():
     yield (check_dimension, Real, (1, 4), 2.251066014107722)
     yield (check_dimension, Integer, (1, 4), 2)
     yield (check_dimension, Integer, (1., 4.), 2)
-    yield (check_categorical, ('a', 'b', 'c', 'd'), 'b')
+    yield (check_categorical, ("a", "b", "c", "d"), "b")
     yield (check_categorical, (1., 2., 3., 4.), 2.)
 
 

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -1,4 +1,3 @@
-import numpy as np
 import tempfile
 
 from sklearn.utils.testing import assert_array_equal
@@ -35,19 +34,19 @@ def test_dump_and_load():
         dump(res, f)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
-    assert_true('func' in res_loaded.specs['args'])
+    assert_true("func" in res_loaded.specs["args"])
 
     # Test dumping without objective function
     with tempfile.TemporaryFile() as f:
         dump(res, f, store_objective=False)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
-    assert_true(not ('func' in res_loaded.specs['args']))
+    assert_true(not ("func" in res_loaded.specs["args"]))
 
     # Delete the objective function and dump the modified object
-    del res.specs['args']['func']
+    del res.specs["args"]["func"]
     with tempfile.TemporaryFile() as f:
         dump(res, f, store_objective=False)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
-    assert_true(not ('func' in res_loaded.specs['args']))
+    assert_true(not ("func" in res_loaded.specs["args"]))


### PR DESCRIPTION
This PR removes tests on `branin` and `hart6`, that should rather be considered as benchmarks.

Fix for #242.