### PR TITLE
[MRG+1] Normalize integer dimensions

### DIFF
--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -52,6 +52,9 @@ def base_minimize(func, dimensions, base_estimator,
         - an instance of a `Dimension` object (`Real`, `Integer` or
           `Categorical`).
 
+         NOTE: The upper and lower bounds are inclusive for `Integer`
+         dimensions.
+
     * `base_estimator` [sklearn regressor]:
         Should inherit from `sklearn.base.RegressorMixin`.
         In addition, should have an optional `return_std` argument,
@@ -301,7 +304,7 @@ def base_minimize(func, dimensions, base_estimator,
             cand_acqs = np.array([r[1] for r in results])
             best_ind = np.argmin(cand_acqs)
             a = cand_acqs[best_ind]
-            
+
             if a < best:
                 next_x, best = cand_xs[best_ind], a
 

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -47,6 +47,9 @@ def forest_minimize(func, dimensions, base_estimator="ET",
         - an instance of a `Dimension` object (`Real`, `Integer` or
           `Categorical`).
 
+         NOTE: The upper and lower bounds are inclusive for `Integer`
+         dimensions.
+
     * `base_estimator` [string or `Regressor`, default=`"ET"`]:
         The regressor to use as surrogate model. Can be either
 

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -59,6 +59,9 @@ def gp_minimize(func, dimensions, base_estimator=None,
         - an instance of a `Dimension` object (`Real`, `Integer` or
           `Categorical`).
 
+         NOTE: The upper and lower bounds are inclusive for `Integer`
+         dimensions.
+
     * `base_estimator` [a Gaussian process estimator]:
         The Gaussian process estimator to use for optimization.
         By default, a Matern kernel is used with the following

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -62,7 +62,7 @@ def check_dimension(dimension, transform=None):
         return Categorical(dimension)
 
     if isinstance(dimension[0], numbers.Integral):
-        return Integer(*dimension)
+        return Integer(*dimension, transform=transform)
 
     if isinstance(dimension[0], numbers.Real):
         return Real(*dimension, transform=transform)
@@ -204,7 +204,7 @@ class Real(Dimension):
 
 
 class Integer(Dimension):
-    def __init__(self, low, high):
+    def __init__(self, low, high, transform=None):
         """Search space dimension that can take on integer values.
 
         Parameters
@@ -217,8 +217,17 @@ class Integer(Dimension):
         """
         self.low = low
         self.high = high
-        self._rvs = randint(self.low, self.high + 1)
-        self.transformer = Identity()
+        self.transform_ = transform
+
+        if transform and transform != "normalize":
+            raise ValueError("Expected transform to be 'normalize', got "
+                             "%s" % transform)
+        if transform == "normalize":
+            self._rvs = uniform(0, 1)
+            self.transformer = Normalize(low, high, is_int=True)
+        else:
+            self._rvs = randint(self.low, self.high + 1)
+            self.transformer = Identity()
 
     def __eq__(self, other):
         return (type(self) is type(other)
@@ -334,6 +343,9 @@ class Space:
             - as a list of categories (for `Categorical` dimensions), or
             - an instance of a `Dimension` object (`Real`, `Integer` or
               `Categorical`).
+
+            NOTE: The upper and lower bounds are inclusive for `Integer`
+            dimensions.
         """
         self.dimensions = [check_dimension(dim) for dim in dimensions]
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -251,7 +251,10 @@ class Integer(Dimension):
 
     @property
     def transformed_bounds(self):
-        return (self.low, self.high)
+        if self.transform_ == "normalize":
+            return 0, 1
+        else:
+            return (self.low, self.high)
 
 
 class Categorical(Dimension):

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -102,9 +102,10 @@ class Normalize(Transformer):
     * `high` [float]:
         Higher bound.
     """
-    def __init__(self, low, high):
+    def __init__(self, low, high, is_int=False):
         self.low = low
         self.high = high
+        self.is_int = is_int
 
     def transform(self, X):
         X = np.asarray(X)
@@ -120,7 +121,10 @@ class Normalize(Transformer):
             raise ValueError("All values should be less than 1.0")
         if np.any(X < 0.0):
             raise ValueError("All values should be greater than 0.0")
-        return X * (self.high - self.low) + self.low
+        X_norm = X * (self.high - self.low) + self.low
+        if self.is_int:
+            return np.round(X_norm)
+        return X_norm
 
 
 class Pipeline(Transformer):

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -121,10 +121,10 @@ class Normalize(Transformer):
             raise ValueError("All values should be less than 1.0")
         if np.any(X < 0.0):
             raise ValueError("All values should be greater than 0.0")
-        X_norm = X * (self.high - self.low) + self.low
+        X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_norm)
-        return X_norm
+            return np.round(X_orig).astype(np.int)
+        return X_orig
 
 
 class Pipeline(Transformer):

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -262,6 +262,7 @@ def test_normalize():
     a = Integer(2, 30, transform="normalize")
     for i in range(50):
         yield (check_limits, a.rvs(random_state=i), 2, 30)
+    assert_array_equal(a.transformed_bounds, (0, 1))
 
     X = rng.randint(2, 31)
     # Check transformed values are in [0, 1]

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -270,4 +270,6 @@ def test_normalize():
     assert_true(np.all(np.zeros_like(X) <= a.transform(X)))
 
     # Check inverse transform
-    assert_array_almost_equal(a.inverse_transform(a.transform(X)), X)
+    X_orig = a.inverse_transform(a.transform(X))
+    assert_equal(X_orig.dtype, "int64")
+    assert_array_equal(X_orig, X)

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -6,7 +6,7 @@ from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_not_equal
 from sklearn.utils.testing import assert_less_equal
-from sklearn.utils.testing import assert_greater
+from sklearn.utils.testing import assert_greater_equal
 from sklearn.utils.testing import assert_true
 
 from skopt.space import Space
@@ -41,7 +41,7 @@ def test_dimensions():
 
 def check_limits(value, lower_bound, upper_bound):
     assert_less_equal(lower_bound, value)
-    assert_greater(upper_bound, value)
+    assert_greater_equal(upper_bound, value)
 
 
 def test_real():
@@ -228,7 +228,7 @@ def test_space_api():
         assert_array_equal(b1, b2)
 
 
-def test_real_normalize():
+def test_normalize():
     a = Real(2.0, 30.0, transform="normalize")
     for i in range(50):
         yield (check_limits, a.rvs(random_state=i), 2, 30)
@@ -253,6 +253,18 @@ def test_real_normalize():
     X = np.clip(10**3 * rng.randn(100), 10**2.0, 10**4.0)
 
     # Check transform
+    assert_true(np.all(a.transform(X) <= np.ones_like(X)))
+    assert_true(np.all(np.zeros_like(X) <= a.transform(X)))
+
+    # Check inverse transform
+    assert_array_almost_equal(a.inverse_transform(a.transform(X)), X)
+
+    a = Integer(2, 30, transform="normalize")
+    for i in range(50):
+        yield (check_limits, a.rvs(random_state=i), 2, 30)
+
+    X = rng.randint(2, 31)
+    # Check transformed values are in [0, 1]
     assert_true(np.all(a.transform(X) <= np.ones_like(X)))
     assert_true(np.all(np.zeros_like(X) <= a.transform(X)))
 


### PR DESCRIPTION
We should normalize integer dimensions as well because the isotropic GP hyper-parameters might be highly dominated by these if they are on a completely different scale from the others such as from [1, 47]