### PR TITLE
include models in result passed to callback(s)

### DIFF
--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -314,7 +314,7 @@ def base_minimize(func, dimensions, base_estimator,
         next_x = space.inverse_transform(next_x.reshape((1, -1)))[0]
         yi.append(func(next_x))
         Xi.append(next_x)
-        curr_res = create_result(Xi, yi, space, rng, specs)
+        curr_res = create_result(Xi, yi, space, rng, specs, models)
         for c in callbacks:
             if callbacks:
                 c(curr_res)


### PR DESCRIPTION
I am continuously saving the current_result in gp_minimize() using a wrapper around dump() as a callback after every iteration like this:

```
def dump_cb(res):
    res2 = copy.deepcopy(res)
    del res2.specs['args']['func']
    del res2.specs['args']['callback']
    dump(res2, 'result.pkl', store_objective=True)
```

(I copied the deepcopy from https://github.com/scikit-optimize/scikit-optimize/blob/master/skopt/utils.py#L88 and added deletion of the callback as it was not serializable - it might make a useful additon to the callbacks.py module, let me know if you want me to implement it)

I then want to be able to inspect the ongoing training progress using the visualization plots. this worked fine except for plot_objective() which crashed because the result was missing the models in the following line: https://github.com/scikit-optimize/scikit-optimize/blob/master/skopt/plots.py#L307

this pull request includes the models in the result passed to the callback making them available to plot_objective() through the dump.
