### PR TITLE
Enable python 3.6 on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,6 +11,7 @@ env:
   matrix:
     - DISTRIB="conda" PYTHON_VERSION="2.7" COVERAGE="false"
     - DISTRIB="conda" PYTHON_VERSION="3.5" COVERAGE="true"
+    - DISTRIB="conda" PYTHON_VERSION="3.6" COVERAGE="false"
 
 install: source build_tools/travis/install.sh
 


### PR DESCRIPTION
Let's see how we do on the next version of python