### PR TITLE
[WIP] Investigate CircleCI status

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -4,7 +4,7 @@ dependencies:
         timeout: 1024
 
 test:
-  # Run and convert examplesto markdown, then grep for errors
+  # Run and convert examples to markdown, then grep for errors
   override:
     - bash ./build_tools/circle/execute.sh:
         timeout: 3600


### PR DESCRIPTION
Fixed a typo in the circleci config to have a PR to play with to test out circleci integration.

Currently it only builds merges, but not on each PR. I  enabled "Build forked pull requests" (which was off). I expect we get builds for PRs now. Don't see a way to enable it via the config file though :-/