### PR TITLE
Remove tests from computation of coverage

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,6 @@
 # a pure python module
 [bdist_wheel]
 universal = 1
+
+[coverage:run]
+omit = */tests/*


### PR DESCRIPTION
Counting our tests when we compute the coverage feels like cheating 😀 