### PR TITLE
[MRG+1] ENH: improve performance of distance methods in Dimension subclasses

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -250,7 +250,7 @@ class Real(Dimension):
         if not (a in self and b in self):
             raise RuntimeError("Can only compute distance for values within "
                                "the space, not %s and %s." % (a, b))
-        return np.abs(a - b)
+        return abs(a - b)
 
 
 class Integer(Dimension):
@@ -336,7 +336,7 @@ class Integer(Dimension):
         if not (a in self and b in self):
             raise RuntimeError("Can only compute distance for values within "
                                "the space, not %s and %s." % (a, b))
-        return np.abs(a - b)
+        return abs(a - b)
 
 
 class Categorical(Dimension):


### PR DESCRIPTION
This change is based on the fact that:
```
In [2]: %timeit np.abs(1 - 2)
The slowest run took 166.84 times longer than the fastest. This could mean that an intermediate result is being cached.
1000000 loops, best of 3: 953 ns per loop

In [3]: %timeit abs(1 - 2)
The slowest run took 23.36 times longer than the fastest. This could mean that an intermediate result is being cached.
10000000 loops, best of 3: 80.9 ns per loop
```