### PR TITLE
[MRG+1] Converts tests to pytest

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ build/
 dist/
 *.egg-info/
 .idea/
+.cache/

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install: source build_tools/travis/install.sh
 
 script:
   - if [ ${COVERAGE} == "true" ];
-    then pytest --cov=skopt --durations=10; else
-    pytest --durations=10;
+    then travis_wait 25 pytest --cov=skopt --durations=10; else
+    travis_wait 25 pytest --durations=10;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install: source build_tools/travis/install.sh
 
 script:
   - if [ ${COVERAGE} == "true" ];
-    then travis_wait 25 pytest --cov=skopt --durations=10; else
-    travis_wait 25 pytest --durations=10;
+    then pytest --cov=skopt --durations=10; else
+    pytest --durations=10;
     fi
 
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ install: source build_tools/travis/install.sh
 
 script:
   - if [ ${COVERAGE} == "true" ];
-    then nosetests --with-coverage --cover-package=skopt --with-timer --timer-top-n 10; else
-    nosetests --with-timer --timer-top-n 10;
+    then pytest --cov=skopt --durations=10; else
+    pytest --durations=10;
     fi
 
 after_success:

--- a/README.md
+++ b/README.md
@@ -68,6 +68,6 @@ pip install -r requirements.txt
 python setup.py develop
 ```
 
-Run the tests by executing `nosetests` in the top level directory.
+Run the tests by executing `pytest` in the top level directory.
 
 All contributors are welcome!

--- a/build_tools/circle/install.sh
+++ b/build_tools/circle/install.sh
@@ -29,7 +29,7 @@ popd
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n testenv --yes python pip nose \
+conda create -n testenv --yes python pip pytest nose \
    numpy scipy scikit-learn matplotlib
 source activate testenv
 

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -25,16 +25,13 @@ popd
 
 # Configure the conda environment and put it in the path using the
 # provided versions
-conda create -n testenv --yes python=$PYTHON_VERSION pip nose \
-   numpy scipy scikit-learn matplotlib 
+conda create -n testenv --yes python=$PYTHON_VERSION pip nose pytest \
+   numpy scipy scikit-learn matplotlib
 source activate testenv
 
 if [[ "$COVERAGE" == "true" ]]; then
-    pip install coverage coveralls
+    pip install pytest-cov coverage coveralls
 fi
-
-# Enables nosetests --with-timer
-pip install nose-timer
 
 python --version
 python -c "import numpy; print('numpy %s' % numpy.__version__)"

--- a/skopt/__init__.py
+++ b/skopt/__init__.py
@@ -43,7 +43,7 @@ The development version can be installed through:
     pip install -r requirements.txt
     python setup.py develop
 
-Run the tests by executing `nosetests` in the top level directory.
+Run the tests by executing `pytest` in the top level directory.
 """
 
 from . import acquisition

--- a/skopt/learning/gaussian_process/tests/test_kernels.py
+++ b/skopt/learning/gaussian_process/tests/test_kernels.py
@@ -3,6 +3,7 @@ from scipy import optimize
 from scipy.spatial.distance import pdist, squareform
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
+import pytest
 
 from skopt.learning.gaussian_process import GaussianProcessRegressor
 from skopt.learning.gaussian_process.kernels import ConstantKernel
@@ -69,12 +70,12 @@ def check_gradient_correctness(kernel, X, Y, step_size=1e-4):
     assert_array_almost_equal(X_grad, num_grad, decimal=3)
 
 
-def test_gradient_correctness():
+@pytest.mark.parametrize("kernel", KERNELS)
+def test_gradient_correctness(kernel):
     rng = np.random.RandomState(0)
     X = rng.randn(5)
     Y = rng.randn(10, 5)
-    for kernel in KERNELS:
-        check_gradient_correctness(kernel, X, Y)
+    check_gradient_correctness(kernel, X, Y)
 
 
 def test_gradient_finiteness():

--- a/skopt/learning/gaussian_process/tests/test_kernels.py
+++ b/skopt/learning/gaussian_process/tests/test_kernels.py
@@ -74,7 +74,7 @@ def test_gradient_correctness():
     X = rng.randn(5)
     Y = rng.randn(10, 5)
     for kernel in KERNELS:
-        yield check_gradient_correctness, kernel, X, Y
+        check_gradient_correctness(kernel, X, Y)
 
 
 def test_gradient_finiteness():
@@ -88,7 +88,7 @@ def test_gradient_finiteness():
         X = rng.randn(5).tolist()
         Y = [X]
         for kernel in KERNELS:
-            yield check_gradient_correctness, kernel, X, Y, 1e-6
+            check_gradient_correctness(kernel, X, Y, 1e-6)
 
 
 def test_distance_string():

--- a/skopt/learning/tests/test_forest.py
+++ b/skopt/learning/tests/test_forest.py
@@ -26,7 +26,7 @@ def test_variance_toy_data():
     """Test that `return_std` behaves expected on toy data."""
     for Regressor in [partial(RandomForestRegressor, bootstrap=False),
                       ExtraTreesRegressor]:
-        yield check_variance_toy_data, Regressor
+        check_variance_toy_data(Regressor)
 
 
 def check_variance_no_split(Regressor):
@@ -52,7 +52,7 @@ def test_variance_no_split():
     """
     for Regressor in [partial(RandomForestRegressor, bootstrap=False),
                       ExtraTreesRegressor]:
-        yield check_variance_no_split, Regressor
+        check_variance_no_split(Regressor)
 
 
 def test_min_variance():

--- a/skopt/learning/tests/test_forest.py
+++ b/skopt/learning/tests/test_forest.py
@@ -2,6 +2,7 @@ import numpy as np
 from functools import partial
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_array_almost_equal
+import pytest
 
 from skopt.learning import RandomForestRegressor
 from skopt.learning import ExtraTreesRegressor
@@ -22,11 +23,12 @@ def check_variance_toy_data(Regressor):
         var, np.sqrt([0.666667, 0.666667, 0.666667, 6.0, 6.0, 6.0]))
 
 
-def test_variance_toy_data():
+@pytest.mark.parametrize("Regressor",
+                         [partial(RandomForestRegressor, bootstrap=False),
+                          ExtraTreesRegressor])
+def test_variance_toy_data(Regressor):
     """Test that `return_std` behaves expected on toy data."""
-    for Regressor in [partial(RandomForestRegressor, bootstrap=False),
-                      ExtraTreesRegressor]:
-        check_variance_toy_data(Regressor)
+    check_variance_toy_data(Regressor)
 
 
 def check_variance_no_split(Regressor):
@@ -42,7 +44,10 @@ def check_variance_no_split(Regressor):
     assert_array_almost_equal([np.mean(y)] * 1000, pred)
 
 
-def test_variance_no_split():
+@pytest.mark.parametrize("Regressor",
+                         [partial(RandomForestRegressor, bootstrap=False),
+                          ExtraTreesRegressor])
+def test_variance_no_split(Regressor):
     """
     Test that `return_std` behaves expected on a tree with one node.
 
@@ -50,9 +55,7 @@ def test_variance_no_split():
     no information gain which enables us to verify the mean and
     standard deviation.
     """
-    for Regressor in [partial(RandomForestRegressor, bootstrap=False),
-                      ExtraTreesRegressor]:
-        check_variance_no_split(Regressor)
+    check_variance_no_split(Regressor)
 
 
 def test_min_variance():

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -95,8 +95,8 @@ def test_minimizer_api():
                                 verbose=verbose, callback=call)
 
         assert(result.models is None)
-        yield (check_minimizer_api, result, n_calls)
-        yield (check_minimizer_bounds, result, n_calls)
+        check_minimizer_api(result, n_calls)
+        check_minimizer_bounds(result, n_calls)
         assert_raise_message(ValueError,
                              "return a scalar",
                              dummy_minimize, lambda x: x, [[-5, 10]])
@@ -112,8 +112,8 @@ def test_minimizer_api():
                                random_state=1,
                                verbose=verbose, callback=call)
 
-            yield (check_minimizer_api, result, n_calls, n_models)
-            yield (check_minimizer_bounds, result, n_calls)
+            check_minimizer_api(result, n_calls, n_models)
+            check_minimizer_bounds(result, n_calls)
             assert_raise_message(ValueError,
                                  "return a scalar",
                                  minimizer, lambda x: x, [[-5, 10]])
@@ -130,8 +130,8 @@ def test_minimizer_api_random_only():
                            n_calls=n_calls,
                            random_state=1)
 
-        yield (check_minimizer_api, result, n_calls)
-        yield (check_minimizer_bounds, result, n_calls)
+        check_minimizer_api(result, n_calls)
+        check_minimizer_bounds(result, n_calls)
 
 
 def test_init_vals_and_models():
@@ -187,7 +187,7 @@ def test_init_vals():
             partial(gbrt_minimize, n_random_starts=n_random_starts)
         ]
         for optimizer in optimizers:
-            yield (check_init_vals, optimizer, branin, space, x0, n_calls)
+            check_init_vals(optimizer, branin, space, x0, n_calls)
 
 
 def test_categorical_init_vals():
@@ -201,7 +201,7 @@ def test_categorical_init_vals():
     x0 = [["0"], ["1"], ["2"]]
     n_calls = 5
     for optimizer in optimizers:
-        yield (check_init_vals, optimizer, bench4, space, x0, n_calls)
+        check_init_vals(optimizer, bench4, space, x0, n_calls)
 
 
 def test_mixed_spaces():
@@ -215,7 +215,7 @@ def test_mixed_spaces():
     x0 = [["0", 2.0], ["1", 1.0], ["2", 1.0]]
     n_calls = 10
     for optimizer in optimizers:
-        yield (check_init_vals, optimizer, bench5, space, x0, n_calls)
+        check_init_vals(optimizer, bench5, space, x0, n_calls)
 
 
 def check_init_vals(optimizer, func, space, x0, n_calls):

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -4,6 +4,8 @@ from itertools import product
 import numpy as np
 from scipy.optimize import OptimizeResult
 
+import pytest
+
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_array_equal
@@ -82,59 +84,76 @@ def check_result_callable(res):
     assert_equal(np.min(res.func_vals), res.fun)
 
 
-def test_minimizer_api():
+def call_single(res):
+    pass
+
+
+@pytest.mark.parametrize("verbose, call",
+                         product(
+                            [True, False],
+                            [call_single, [call_single,
+                                           check_result_callable]]))
+def test_minimizer_api_dummy_minimize(verbose, call):
     # dummy_minimize is special as it does not support all parameters
     # and does not fit any models
-    call_single = lambda res: None
-    call_list = [call_single, check_result_callable]
     n_calls = 7
+    result = dummy_minimize(branin, [(-5.0, 10.0), (0.0, 15.0)],
+                            n_calls=n_calls, random_state=1,
+                            verbose=verbose, callback=call)
 
-    for verbose, call in product([True, False], [call_single, call_list]):
-        result = dummy_minimize(branin, [(-5.0, 10.0), (0.0, 15.0)],
-                                n_calls=n_calls, random_state=1,
-                                verbose=verbose, callback=call)
-
-        assert(result.models is None)
-        check_minimizer_api(result, n_calls)
-        check_minimizer_bounds(result, n_calls)
-        assert_raise_message(ValueError,
-                             "return a scalar",
-                             dummy_minimize, lambda x: x, [[-5, 10]])
-
-        n_calls = 7
-        n_random_starts = 3
-        n_models = n_calls - n_random_starts
-
-        for minimizer in MINIMIZERS:
-            result = minimizer(branin, [(-5.0, 10.0), (0.0, 15.0)],
-                               n_random_starts=n_random_starts,
-                               n_calls=n_calls,
-                               random_state=1,
-                               verbose=verbose, callback=call)
-
-            check_minimizer_api(result, n_calls, n_models)
-            check_minimizer_bounds(result, n_calls)
-            assert_raise_message(ValueError,
-                                 "return a scalar",
-                                 minimizer, lambda x: x, [[-5, 10]])
+    assert(result.models is None)
+    check_minimizer_api(result, n_calls)
+    check_minimizer_bounds(result, n_calls)
+    assert_raise_message(ValueError,
+                         "return a scalar",
+                         dummy_minimize, lambda x: x, [[-5, 10]])
 
 
-def test_minimizer_api_random_only():
+@pytest.mark.parametrize("verbose, call, minimizer",
+                         product(
+                            [True, False],
+                            [call_single, [call_single,
+                                           check_result_callable]],
+                            MINIMIZERS))
+def test_minimizer_api(verbose, call, minimizer):
+    n_calls = 7
+    n_random_starts = 3
+    n_models = n_calls - n_random_starts
+
+    result = minimizer(branin, [(-5.0, 10.0), (0.0, 15.0)],
+                       n_random_starts=n_random_starts,
+                       n_calls=n_calls,
+                       random_state=1,
+                       verbose=verbose, callback=call)
+
+    check_minimizer_api(result, n_calls, n_models)
+    check_minimizer_bounds(result, n_calls)
+    assert_raise_message(ValueError,
+                         "return a scalar",
+                         minimizer, lambda x: x, [[-5, 10]])
+
+
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_minimizer_api_random_only(minimizer):
     # no models should be fit as we only evaluate at random points
     n_calls = 5
     n_random_starts = 5
 
-    for minimizer in MINIMIZERS:
-        result = minimizer(branin, [(-5.0, 10.0), (0.0, 15.0)],
-                           n_random_starts=n_random_starts,
-                           n_calls=n_calls,
-                           random_state=1)
+    result = minimizer(branin, [(-5.0, 10.0), (0.0, 15.0)],
+                       n_random_starts=n_random_starts,
+                       n_calls=n_calls,
+                       random_state=1)
 
-        check_minimizer_api(result, n_calls)
-        check_minimizer_bounds(result, n_calls)
+    check_minimizer_api(result, n_calls)
+    check_minimizer_bounds(result, n_calls)
 
 
-def test_init_vals_and_models():
+@pytest.mark.parametrize("n_random_starts, optimizer_func",
+                         product([0, 5],
+                                 [gp_minimize,
+                                  forest_minimize,
+                                  gbrt_minimize]))
+def test_init_vals_and_models(n_random_starts, optimizer_func):
     # test how many models are fitted when using initial points, values
     # and random starts
     space = [(-5.0, 10.0), (0.0, 15.0)]
@@ -142,80 +161,74 @@ def test_init_vals_and_models():
     y0 = list(map(branin, x0))
     n_calls = 7
 
-    for n_random_starts in [0, 5]:
-        optimizers = [
-            partial(gp_minimize, n_random_starts=n_random_starts),
-            partial(forest_minimize, n_random_starts=n_random_starts),
-            partial(gbrt_minimize, n_random_starts=n_random_starts)
-        ]
-        for optimizer in optimizers:
-            res = optimizer(branin, space, x0=x0, y0=y0, random_state=0,
-                            n_calls=n_calls)
-            assert_equal(len(res.models), n_calls - n_random_starts)
+    optimizer = partial(optimizer_func, n_random_starts=n_random_starts)
+    res = optimizer(branin, space, x0=x0, y0=y0, random_state=0,
+                    n_calls=n_calls)
+    assert_equal(len(res.models), n_calls - n_random_starts)
 
 
-def test_init_points_and_models():
+@pytest.mark.parametrize("n_random_starts, optimizer_func",
+                         product([0, 5],
+                                 [gp_minimize,
+                                  forest_minimize,
+                                  gbrt_minimize]))
+def test_init_points_and_models(n_random_starts, optimizer_func):
     # test how many models are fitted when using initial points and random
     # starts 9no y0 in this case)
     space = [(-5.0, 10.0), (0.0, 15.0)]
     x0 = [[1, 2], [3, 4], [5, 6]]
     n_calls = 8
 
-    for n_random_starts in [0, 5]:
-        optimizers = [
-            partial(gp_minimize, n_random_starts=n_random_starts),
-            partial(forest_minimize, n_random_starts=n_random_starts),
-            partial(gbrt_minimize, n_random_starts=n_random_starts)
-        ]
-        for optimizer in optimizers:
-            res = optimizer(branin, space, x0=x0, random_state=0,
-                            n_calls=n_calls)
-            assert_equal(len(res.models),
-                         n_calls - n_random_starts - len(x0))
+    optimizer = partial(optimizer_func, n_random_starts=n_random_starts)
+    res = optimizer(branin, space, x0=x0, random_state=0,
+                    n_calls=n_calls)
+    assert_equal(len(res.models),
+                 n_calls - n_random_starts - len(x0))
 
 
-def test_init_vals():
+@pytest.mark.parametrize("n_random_starts, optimizer_func",
+                         product([0, 5],
+                                 [gp_minimize,
+                                  forest_minimize,
+                                  gbrt_minimize]))
+def test_init_vals(n_random_starts, optimizer_func):
     space = [(-5.0, 10.0), (0.0, 15.0)]
     x0 = [[1, 2], [3, 4], [5, 6]]
     n_calls = 10
 
-    for n_random_starts in [0, 5]:
-        optimizers = [
-            dummy_minimize,
-            partial(gp_minimize, n_random_starts=n_random_starts),
-            partial(forest_minimize, n_random_starts=n_random_starts),
-            partial(gbrt_minimize, n_random_starts=n_random_starts)
-        ]
-        for optimizer in optimizers:
-            check_init_vals(optimizer, branin, space, x0, n_calls)
+    optimizer = partial(optimizer_func, n_random_starts=n_random_starts)
+    check_init_vals(optimizer, branin, space, x0, n_calls)
 
 
-def test_categorical_init_vals():
-    optimizers = [
+def test_init_vals_dummy_minimize():
+    space = [(-5.0, 10.0), (0.0, 15.0)]
+    x0 = [[1, 2], [3, 4], [5, 6]]
+    n_calls = 10
+    check_init_vals(dummy_minimize, branin, space, x0, n_calls)
+
+
+@pytest.mark.parametrize("optimizer", [
         dummy_minimize,
         partial(gp_minimize, n_random_starts=0),
         partial(forest_minimize, n_random_starts=0),
-        partial(gbrt_minimize, n_random_starts=0)
-    ]
+        partial(gbrt_minimize, n_random_starts=0)])
+def test_categorical_init_vals(optimizer):
     space = [("-2", "-1", "0", "1", "2")]
     x0 = [["0"], ["1"], ["2"]]
     n_calls = 5
-    for optimizer in optimizers:
-        check_init_vals(optimizer, bench4, space, x0, n_calls)
+    check_init_vals(optimizer, bench4, space, x0, n_calls)
 
 
-def test_mixed_spaces():
-    optimizers = [
+@pytest.mark.parametrize("optimizer", [
         dummy_minimize,
         partial(gp_minimize, n_random_starts=0),
         partial(forest_minimize, n_random_starts=0),
-        partial(gbrt_minimize, n_random_starts=0)
-    ]
+        partial(gbrt_minimize, n_random_starts=0)])
+def test_mixed_spaces(optimizer):
     space = [("-2", "-1", "0", "1", "2"), (-2.0, 2.0)]
     x0 = [["0", 2.0], ["1", 1.0], ["2", 1.0]]
     n_calls = 10
-    for optimizer in optimizers:
-        check_init_vals(optimizer, bench5, space, x0, n_calls)
+    check_init_vals(optimizer, bench5, space, x0, n_calls)
 
 
 def check_init_vals(optimizer, func, space, x0, n_calls):
@@ -265,106 +278,106 @@ def check_init_vals(optimizer, func, space, x0, n_calls):
                   space, x0=x0, y0=[1])
 
 
-def test_invalid_n_calls_arguments():
-    for minimizer in MINIMIZERS:
-        assert_raise_message(ValueError,
-                             "Expected `n_calls` >= 10, got 0",
-                             minimizer,
-                             branin, [(-5.0, 10.0), (0.0, 15.0)],
-                             n_calls=0,
-                             random_state=1)
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_invalid_n_calls_arguments(minimizer):
+    assert_raise_message(ValueError,
+                         "Expected `n_calls` >= 10, got 0",
+                         minimizer,
+                         branin, [(-5.0, 10.0), (0.0, 15.0)],
+                         n_calls=0,
+                         random_state=1)
 
-        assert_raise_message(ValueError,
-                             "set `n_random_starts` > 0, or provide `x0`",
-                             minimizer,
-                             branin, [(-5.0, 10.0), (0.0, 15.0)],
-                             n_random_starts=0,
-                             random_state=1)
+    assert_raise_message(ValueError,
+                         "set `n_random_starts` > 0, or provide `x0`",
+                         minimizer,
+                         branin, [(-5.0, 10.0), (0.0, 15.0)],
+                         n_random_starts=0,
+                         random_state=1)
 
-        # n_calls >= n_random_starts
-        assert_raise_message(ValueError,
-                             "Expected `n_calls` >= 10",
-                             minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
-                             n_calls=1, n_random_starts=10, random_state=1)
+    # n_calls >= n_random_starts
+    assert_raise_message(ValueError,
+                         "Expected `n_calls` >= 10",
+                         minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
+                         n_calls=1, n_random_starts=10, random_state=1)
 
-        # n_calls >= n_random_starts + len(x0)
-        assert_raise_message(ValueError,
-                             "Expected `n_calls` >= 10",
-                             minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
-                             n_calls=1, x0=[[-1, 2], [-3, 3], [2, 5]],
-                             random_state=1, n_random_starts=7)
+    # n_calls >= n_random_starts + len(x0)
+    assert_raise_message(ValueError,
+                         "Expected `n_calls` >= 10",
+                         minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
+                         n_calls=1, x0=[[-1, 2], [-3, 3], [2, 5]],
+                         random_state=1, n_random_starts=7)
 
-        # n_calls >= n_random_starts when x0 and y0 are provided.
-        assert_raise_message(ValueError,
-                             "Expected `n_calls` >= 7",
-                             minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
-                             n_calls=1, x0=[[-1, 2], [-3, 3], [2, 5]],
-                             y0=[2.0, 3.0, 5.0],
-                             random_state=1, n_random_starts=7)
-
-
-def test_repeated_x():
-    for minimizer in MINIMIZERS:
-        assert_warns_message(
-            UserWarning, "has been evaluated at", minimizer, lambda x: x[0],
-            dimensions=[[0, 1]], x0=[[0], [1]], n_random_starts=0, n_calls=3)
-
-        assert_warns_message(
-            UserWarning, "has been evaluated at", minimizer, bench4,
-            dimensions=[("0", "1")], x0=[["0"], ["1"]], n_calls=3,
-            n_random_starts=0)
+    # n_calls >= n_random_starts when x0 and y0 are provided.
+    assert_raise_message(ValueError,
+                         "Expected `n_calls` >= 7",
+                         minimizer, branin, [(-5.0, 10.0), (0.0, 15.0)],
+                         n_calls=1, x0=[[-1, 2], [-3, 3], [2, 5]],
+                         y0=[2.0, 3.0, 5.0],
+                         random_state=1, n_random_starts=7)
 
 
-def test_consistent_x_iter_dimensions():
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_repeated_x(minimizer):
+    assert_warns_message(
+        UserWarning, "has been evaluated at", minimizer, lambda x: x[0],
+        dimensions=[[0, 1]], x0=[[0], [1]], n_random_starts=0, n_calls=3)
+
+    assert_warns_message(
+        UserWarning, "has been evaluated at", minimizer, bench4,
+        dimensions=[("0", "1")], x0=[["0"], ["1"]], n_calls=3,
+        n_random_starts=0)
+
+
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_consistent_x_iter_dimensions(minimizer):
     # check that all entries in x_iters have the same dimensions
-    for minimizer in MINIMIZERS:
-        # two dmensional problem, bench1 is a 1D function but in this
-        # instance we do not really care about the objective, could be
-        # a total dummy
-        res = minimizer(bench1,
-                        dimensions=[(0, 1), (2, 3)],
-                        x0=[[0, 2], [1, 2]], n_calls=3,
-                        n_random_starts=0)
-        assert len(set(len(x) for x in res.x_iters)) == 1
-        assert len(res.x_iters[0]) == 2
+    # two dmensional problem, bench1 is a 1D function but in this
+    # instance we do not really care about the objective, could be
+    # a total dummy
+    res = minimizer(bench1,
+                    dimensions=[(0, 1), (2, 3)],
+                    x0=[[0, 2], [1, 2]], n_calls=3,
+                    n_random_starts=0)
+    assert len(set(len(x) for x in res.x_iters)) == 1
+    assert len(res.x_iters[0]) == 2
 
-        # one dimensional problem
-        res = minimizer(bench1, dimensions=[(0, 1)], x0=[[0], [1]], n_calls=3,
-                        n_random_starts=0)
-        assert len(set(len(x) for x in res.x_iters)) == 1
-        assert len(res.x_iters[0]) == 1
+    # one dimensional problem
+    res = minimizer(bench1, dimensions=[(0, 1)], x0=[[0], [1]], n_calls=3,
+                    n_random_starts=0)
+    assert len(set(len(x) for x in res.x_iters)) == 1
+    assert len(res.x_iters[0]) == 1
 
-        assert_raise_message(RuntimeError,
-                             "use inconsistent dimensions",
-                             minimizer, bench1, dimensions=[(0, 1)],
-                             x0=[[0, 1]], n_calls=3, n_random_starts=0)
+    assert_raise_message(RuntimeError,
+                         "use inconsistent dimensions",
+                         minimizer, bench1, dimensions=[(0, 1)],
+                         x0=[[0, 1]], n_calls=3, n_random_starts=0)
 
-        assert_raise_message(RuntimeError,
-                             "use inconsistent dimensions",
-                             minimizer, bench1, dimensions=[(0, 1)],
-                             x0=[0, 1], n_calls=3, n_random_starts=0)
+    assert_raise_message(RuntimeError,
+                         "use inconsistent dimensions",
+                         minimizer, bench1, dimensions=[(0, 1)],
+                         x0=[0, 1], n_calls=3, n_random_starts=0)
 
 
-def test_early_stopping_delta_x():
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_early_stopping_delta_x(minimizer):
     n_calls = 15
-    for minimizer in MINIMIZERS:
-        res = minimizer(bench1,
-                        callback=DeltaXStopper(0.1),
-                        dimensions=[(-1., 1.)],
-                        x0=[[0.1], [-0.1], [0.9]],
-                        n_calls=n_calls,
-                        n_random_starts=0, random_state=1)
-        assert len(res.x_iters) < n_calls
+    res = minimizer(bench1,
+                    callback=DeltaXStopper(0.1),
+                    dimensions=[(-1., 1.)],
+                    x0=[[0.1], [-0.1], [0.9]],
+                    n_calls=n_calls,
+                    n_random_starts=0, random_state=1)
+    assert len(res.x_iters) < n_calls
 
 
-def test_early_stopping_delta_x_empty_result_object():
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_early_stopping_delta_x_empty_result_object(minimizer):
     # check that the callback handles the case of being passed an empty
     # results object, e.g. at the start of the optimization loop
     n_calls = 15
-    for minimizer in MINIMIZERS:
-        res = minimizer(bench1,
-                        callback=DeltaXStopper(0.1),
-                        dimensions=[(-1., 1.)],
-                        n_calls=n_calls,
-                        n_random_starts=1, random_state=1)
-        assert len(res.x_iters) < n_calls
+    res = minimizer(bench1,
+                    callback=DeltaXStopper(0.1),
+                    dimensions=[(-1., 1.)],
+                    n_calls=n_calls,
+                    n_random_starts=1, random_state=1)
+    assert len(res.x_iters) < n_calls

--- a/skopt/tests/test_dummy_opt.py
+++ b/skopt/tests/test_dummy_opt.py
@@ -12,6 +12,6 @@ def check_minimize(func, y_opt, dimensions, margin, n_calls):
 
 
 def test_dummy_minimize():
-    yield (check_minimize, bench1, 0., [(-2.0, 2.0)], 0.05, 10000)
-    yield (check_minimize, bench2, -5, [(-6.0, 6.0)], 0.05, 10000)
-    yield (check_minimize, bench3, -0.9, [(-2.0, 2.0)], 0.05, 10000)
+    check_minimize(bench1, 0., [(-2.0, 2.0)], 0.05, 10000)
+    check_minimize(bench2, -5, [(-6.0, 6.0)], 0.05, 10000)
+    check_minimize(bench3, -0.9, [(-2.0, 2.0)], 0.05, 10000)

--- a/skopt/tests/test_forest_opt.py
+++ b/skopt/tests/test_forest_opt.py
@@ -3,6 +3,7 @@ from functools import partial
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.utils.testing import assert_less
 from sklearn.utils.testing import assert_raise_message
+import pytest
 
 from skopt import gbrt_minimize
 from skopt import forest_minimize
@@ -17,19 +18,19 @@ MINIMIZERS = [("ET", partial(forest_minimize, base_estimator='ET')),
               ("gbrt", gbrt_minimize)]
 
 
-def test_forest_minimize_api():
+@pytest.mark.parametrize("base_estimator", [42, DecisionTreeClassifier()])
+def test_forest_minimize_api(base_estimator):
     # invalid string value
     assert_raise_message(ValueError,
                          "Valid strings for the base_estimator parameter",
                          forest_minimize, lambda x: 0., [],
                          base_estimator='abc')
 
-    for base_estimator in [42, DecisionTreeClassifier()]:
-        # not a string nor a regressor
-        assert_raise_message(ValueError,
-                             "has to be a regressor",
-                             forest_minimize, lambda x: 0., [],
-                             base_estimator=base_estimator)
+    # not a string nor a regressor
+    assert_raise_message(ValueError,
+                         "has to be a regressor",
+                         forest_minimize, lambda x: 0., [],
+                         base_estimator=base_estimator)
 
 
 def check_minimize(minimizer, func, y_opt, dimensions, margin,
@@ -41,21 +42,21 @@ def check_minimize(minimizer, func, y_opt, dimensions, margin,
         assert_less(r.fun, y_opt + margin)
 
 
-def test_tree_based_minimize():
-    for name, minimizer in MINIMIZERS:
-        check_minimize(minimizer, bench1, 0.,
-                       [(-2.0, 2.0)], 0.05, 25, 5)
+@pytest.mark.parametrize("name, minimizer", MINIMIZERS)
+def test_tree_based_minimize(name, minimizer):
+    check_minimize(minimizer, bench1, 0.,
+                   [(-2.0, 2.0)], 0.05, 25, 5)
 
-        # XXX: We supply points at the edge of the search
-        # space as an initial point to the minimizer.
-        # This makes sure that the RF model can find the minimum even
-        # if all the randomly sampled points are one side of the
-        # the minimum, since for a decision tree any point greater than
-        # max(sampled_points) would give a constant value.
-        X0 = [[-5.6], [-5.8], [5.8], [5.6]]
-        check_minimize(minimizer, bench2, -5,
-                       [(-6.0, 6.0)], 0.1, 100, 10, X0)
-        check_minimize(minimizer, bench3, -0.9,
-                       [(-2.0, 2.0)], 0.05, 25)
-        check_minimize(minimizer, bench4, 0.0,
-                       [("-2", "-1", "0", "1", "2")], 0.05, 10, 1)
+    # XXX: We supply points at the edge of the search
+    # space as an initial point to the minimizer.
+    # This makes sure that the RF model can find the minimum even
+    # if all the randomly sampled points are one side of the
+    # the minimum, since for a decision tree any point greater than
+    # max(sampled_points) would give a constant value.
+    X0 = [[-5.6], [-5.8], [5.8], [5.6]]
+    check_minimize(minimizer, bench2, -5,
+                   [(-6.0, 6.0)], 0.1, 100, 10, X0)
+    check_minimize(minimizer, bench3, -0.9,
+                   [(-2.0, 2.0)], 0.05, 25)
+    check_minimize(minimizer, bench4, 0.0,
+                   [("-2", "-1", "0", "1", "2")], 0.05, 10, 1)

--- a/skopt/tests/test_forest_opt.py
+++ b/skopt/tests/test_forest_opt.py
@@ -43,8 +43,8 @@ def check_minimize(minimizer, func, y_opt, dimensions, margin,
 
 def test_tree_based_minimize():
     for name, minimizer in MINIMIZERS:
-        yield (check_minimize, minimizer, bench1, 0.,
-               [(-2.0, 2.0)], 0.05, 25, 5)
+        check_minimize(minimizer, bench1, 0.,
+                       [(-2.0, 2.0)], 0.05, 25, 5)
 
         # XXX: We supply points at the edge of the search
         # space as an initial point to the minimizer.
@@ -53,9 +53,9 @@ def test_tree_based_minimize():
         # the minimum, since for a decision tree any point greater than
         # max(sampled_points) would give a constant value.
         X0 = [[-5.6], [-5.8], [5.8], [5.6]]
-        yield (check_minimize, minimizer, bench2, -5,
-               [(-6.0, 6.0)], 0.1, 100, 10, X0)
-        yield (check_minimize, minimizer, bench3, -0.9,
-               [(-2.0, 2.0)], 0.05, 25)
-        yield (check_minimize, minimizer, bench4, 0.0,
-               [("-2", "-1", "0", "1", "2")], 0.05, 10, 1)
+        check_minimize(minimizer, bench2, -5,
+                       [(-6.0, 6.0)], 0.1, 100, 10, X0)
+        check_minimize(minimizer, bench3, -0.9,
+                       [(-2.0, 2.0)], 0.05, 25)
+        check_minimize(minimizer, bench4, 0.0,
+                       [("-2", "-1", "0", "1", "2")], 0.05, 10, 1)

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -22,14 +22,29 @@ def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
     assert_less(r.fun, y_opt + margin)
 
 
-@pytest.mark.parametrize("search, acq", product(["sampling", "lbfgs"], ["LCB", "EI"]))
-def test_gp_minimize(search, acq):
+SEARCH_AND_ACQ = list(product(["sampling", "lbfgs"], ["LCB", "EI"]))
+
+
+@pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
+def test_gp_minimize_bench1(search, acq):
     check_minimize(bench1, 0.,
                    [(-2.0, 2.0)], search, acq, 0.05, 50)
+
+
+@pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
+def test_gp_minimize_bench2(search, acq):
     check_minimize(bench2, -5,
                    [(-6.0, 6.0)], search, acq, 0.05, 75)
+
+
+@pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
+def test_gp_minimize_bench3(search, acq):
     check_minimize(bench3, -0.9,
                    [(-2.0, 2.0)], search, acq, 0.05, 50)
+
+
+@pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
+def test_gp_minimize_bench4(search, acq):
     check_minimize(bench4, 0.0,
                    [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
 

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -23,14 +23,14 @@ def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
 
 def test_gp_minimize():
     for search, acq in product(["sampling", "lbfgs"], ["LCB", "EI"]):
-        yield (check_minimize, bench1, 0.,
-               [(-2.0, 2.0)], search, acq, 0.05, 50)
-        yield (check_minimize, bench2, -5,
-               [(-6.0, 6.0)], search, acq, 0.05, 75)
-        yield (check_minimize, bench3, -0.9,
-               [(-2.0, 2.0)], search, acq, 0.05, 50)
-        yield (check_minimize, bench4, 0.0,
-               [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
+        check_minimize(bench1, 0.,
+                       [(-2.0, 2.0)], search, acq, 0.05, 50)
+        check_minimize(bench2, -5,
+                       [(-6.0, 6.0)], search, acq, 0.05, 75)
+        check_minimize(bench3, -0.9,
+                       [(-2.0, 2.0)], search, acq, 0.05, 50)
+        check_minimize(bench4, 0.0,
+                       [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
 
 
 def test_n_jobs():

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -2,6 +2,7 @@ from itertools import product
 
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_less
+import pytest
 
 from skopt import gp_minimize
 from skopt.benchmarks import bench1
@@ -21,16 +22,16 @@ def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
     assert_less(r.fun, y_opt + margin)
 
 
-def test_gp_minimize():
-    for search, acq in product(["sampling", "lbfgs"], ["LCB", "EI"]):
-        check_minimize(bench1, 0.,
-                       [(-2.0, 2.0)], search, acq, 0.05, 50)
-        check_minimize(bench2, -5,
-                       [(-6.0, 6.0)], search, acq, 0.05, 75)
-        check_minimize(bench3, -0.9,
-                       [(-2.0, 2.0)], search, acq, 0.05, 50)
-        check_minimize(bench4, 0.0,
-                       [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
+@pytest.mark.parametrize("search, acq", product(["sampling", "lbfgs"], ["LCB", "EI"]))
+def test_gp_minimize(search, acq):
+    check_minimize(bench1, 0.,
+                   [(-2.0, 2.0)], search, acq, 0.05, 50)
+    check_minimize(bench2, -5,
+                   [(-6.0, 6.0)], search, acq, 0.05, 75)
+    check_minimize(bench3, -0.9,
+                   [(-2.0, 2.0)], search, acq, 0.05, 50)
+    check_minimize(bench4, 0.0,
+                   [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
 
 
 def test_n_jobs():

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -40,12 +40,12 @@ def check_limits(value, low, high):
 
 
 def test_dimensions():
-    yield (check_dimension, Real, (1., 4.), 2.251066014107722)
-    yield (check_dimension, Real, (1, 4), 2.251066014107722)
-    yield (check_dimension, Integer, (1, 4), 2)
-    yield (check_dimension, Integer, (1., 4.), 2)
-    yield (check_categorical, ("a", "b", "c", "d"), "b")
-    yield (check_categorical, (1., 2., 3., 4.), 2.)
+    check_dimension(Real, (1., 4.), 2.251066014107722)
+    check_dimension(Real, (1, 4), 2.251066014107722)
+    check_dimension(Integer, (1, 4), 2)
+    check_dimension(Integer, (1., 4.), 2)
+    check_categorical(("a", "b", "c", "d"), "b")
+    check_categorical((1., 2., 3., 4.), 2.)
 
 
 def test_real():
@@ -64,7 +64,7 @@ def test_real():
     assert_not_equal(log_uniform, Real(10**-5, 10**5))
     for i in range(50):
         random_val = log_uniform.rvs(random_state=i)
-        yield (check_limits, random_val, 10**-5, 10**5)
+        check_limits(random_val, 10**-5, 10**5)
     random_values = log_uniform.rvs(random_state=0, n_samples=10)
     assert_array_equal(random_values.shape, (10))
     transformed_vals = log_uniform.transform(random_values)
@@ -255,7 +255,7 @@ def test_space_api():
 def test_normalize():
     a = Real(2.0, 30.0, transform="normalize")
     for i in range(50):
-        yield (check_limits, a.rvs(random_state=i), 2, 30)
+        check_limits(a.rvs(random_state=i), 2, 30)
 
     rng = np.random.RandomState(0)
     X = rng.randn(100)
@@ -271,7 +271,7 @@ def test_normalize():
     # log-uniform prior
     a = Real(10**2.0, 10**4.0, prior="log-uniform", transform="normalize")
     for i in range(50):
-        yield (check_limits, a.rvs(random_state=i), 10**2, 10**4)
+        check_limits(a.rvs(random_state=i), 10**2, 10**4)
 
     rng = np.random.RandomState(0)
     X = np.clip(10**3 * rng.randn(100), 10**2.0, 10**4.0)
@@ -285,7 +285,7 @@ def test_normalize():
 
     a = Integer(2, 30, transform="normalize")
     for i in range(50):
-        yield (check_limits, a.rvs(random_state=i), 2, 30)
+        check_limits(a.rvs(random_state=i), 2, 30)
     assert_array_equal(a.transformed_bounds, (0, 1))
 
     X = rng.randint(2, 31)
@@ -307,8 +307,8 @@ def check_valid_transformation(klass):
 
 
 def test_valid_transformation():
-    yield (check_valid_transformation, Integer)
-    yield (check_valid_transformation, Real)
+    check_valid_transformation(Integer)
+    check_valid_transformation(Real)
 
 
 def test_invalid_dimension():


### PR DESCRIPTION
Converts tests from nosetests to pytest. The only real change needed was to convert the yield statements that nosetests uses to function calls. pytest shows the duration of test runs by default. nose is still a test requirement because of `assert_array_equal` from the sklearn library.

#220 