### PR TITLE
[MRG+1]: Remove acq_optimizer from forest_minimize

### DIFF
--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -7,12 +7,10 @@ from ..learning import ExtraTreesRegressor
 from ..learning import RandomForestRegressor
 
 
-def forest_minimize(func, dimensions, base_estimator="ET",
-                    n_calls=100, n_random_starts=10,
-                    acq_func="EI", acq_optimizer="auto",
-                    x0=None, y0=None, random_state=None, verbose=False,
-                    callback=None, n_points=10000, xi=0.01, kappa=1.96,
-                    n_jobs=1):
+def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
+                    n_random_starts=10, acq_func="EI", x0=None, y0=None,
+                    random_state=None, verbose=False, callback=None,
+                    n_points=10000, xi=0.01, kappa=1.96, n_jobs=1):
     """Sequential optimisation using decision trees.
 
     A tree based regression model is used to model the expensive to evaluate


### PR DESCRIPTION
As described in #367, ``acq_optimizer`` is not documented in ``forest_minimize`` and its value does not have any effect on ``forest_minimize``.

In this PR, I propose removing ``acq_optimizer`` from  ``forest_minimize``. As mention by @betatim, one caveat arises when another option (besides ``'sampling'``) for ``acq_optimizer`` is implemented. That can be solved by adding ``acq_optimizer`` back to the list of arguments and proper docstrings.

Fixes #367.

 