### PR TITLE
[MRG] Add 'copy constructor' to Space

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -309,8 +309,8 @@ class Optimizer(object):
                 logits -= np.max(logits)
                 exp_logits = np.exp(self.eta * logits)
                 probs = exp_logits / np.sum(exp_logits)
-                next_x = self.next_xs_[np.argmax(np.random.multinomial(1,
-                                                                       probs))]
+                next_x = self.next_xs_[np.argmax(self.rng.multinomial(1,
+                                                                      probs))]
             else:
                 next_x = self.next_xs_[0]
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -489,6 +489,9 @@ class Space:
         return "Space([{}])".format(
             ',\n       '.join(map(str, dims)))
 
+    def __iter__(self):
+        return iter(self.dimensions)
+
     @property
     def is_real(self):
         """

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -148,6 +148,27 @@ def test_minimizer_api_random_only(minimizer):
     check_minimizer_bounds(result, n_calls)
 
 
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_minimizer_with_space(minimizer):
+    # check we can pass a Space instance as dimensions argument
+    n_calls = 7
+    n_random_starts = 4
+
+    space = Space([(-5.0, 10.0), (0.0, 15.0)])
+    space_result = minimizer(branin, space, n_calls=n_calls,
+                             n_random_starts=n_random_starts, random_state=1)
+
+    check_minimizer_api(space_result, n_calls)
+    check_minimizer_bounds(space_result, n_calls)
+
+    dimensions = [(-5.0, 10.0), (0.0, 15.0)]
+    result = minimizer(branin, dimensions, n_calls=n_calls,
+                       n_random_starts=n_random_starts, random_state=1)
+
+    assert np.allclose(space_result.x_iters, result.x_iters)
+    assert np.allclose(space_result.func_vals, result.func_vals)
+
+
 @pytest.mark.parametrize("n_random_starts, optimizer_func",
                          product([0, 5],
                                  [gp_minimize,

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -9,6 +9,7 @@ import pytest
 from sklearn.utils.testing import assert_almost_equal
 from sklearn.utils.testing import assert_array_less
 from sklearn.utils.testing import assert_array_equal
+from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raise_message
 from sklearn.utils.testing import assert_raises
@@ -163,8 +164,8 @@ def test_fixed_random_states(minimizer):
     result2 = minimizer(branin, dimensions, n_calls=n_calls,
                         n_random_starts=n_random_starts, random_state=1)
 
-    assert np.allclose(result1.x_iters, result2.x_iters)
-    assert np.allclose(result1.func_vals, result2.func_vals)
+    assert_array_almost_equal(result1.x_iters, result2.x_iters)
+    assert_array_almost_equal(result1.func_vals, result2.func_vals)
 
 
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
@@ -185,8 +186,8 @@ def test_minimizer_with_space(minimizer):
     result = minimizer(branin, dimensions, n_calls=n_calls,
                        n_random_starts=n_random_starts, random_state=1)
 
-    assert np.allclose(space_result.x_iters, result.x_iters)
-    assert np.allclose(space_result.func_vals, result.func_vals)
+    assert_array_almost_equal(space_result.x_iters, result.x_iters)
+    assert_array_almost_equal(space_result.func_vals, result.func_vals)
 
 
 @pytest.mark.parametrize("n_random_starts, optimizer_func",

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -149,8 +149,28 @@ def test_minimizer_api_random_only(minimizer):
 
 
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
+def test_fixed_random_states(minimizer):
+    # check that two runs produce exactly same results, if not there is a
+    # random state somewhere that is not reproducible
+    n_calls = 7
+    n_random_starts = 4
+
+    space = [(-5.0, 10.0), (0.0, 15.0)]
+    result1 = minimizer(branin, space, n_calls=n_calls,
+                        n_random_starts=n_random_starts, random_state=1)
+
+    dimensions = [(-5.0, 10.0), (0.0, 15.0)]
+    result2 = minimizer(branin, dimensions, n_calls=n_calls,
+                        n_random_starts=n_random_starts, random_state=1)
+
+    assert np.allclose(result1.x_iters, result2.x_iters)
+    assert np.allclose(result1.func_vals, result2.func_vals)
+
+
+@pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_minimizer_with_space(minimizer):
-    # check we can pass a Space instance as dimensions argument
+    # check we can pass a Space instance as dimensions argument and get same
+    # result
     n_calls = 7
     n_random_starts = 4
 

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -259,7 +259,7 @@ def test_space_from_space():
 
     space2 = Space(space)
 
-    assert space == space2
+    assert_equal(space, space2)
 
 
 def test_normalize():

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -252,6 +252,16 @@ def test_space_api():
         assert_array_equal(b1, b2)
 
 
+def test_space_from_space():
+    # can you pass a Space instance to the Space constructor?
+    space = Space([(0.0, 1.0), (-5, 5),
+                   ("a", "b", "c"), (1.0, 5.0, "log-uniform"), ("e", "f")])
+
+    space2 = Space(space)
+
+    assert space == space2
+
+
 def test_normalize():
     a = Real(2.0, 30.0, transform="normalize")
     for i in range(50):


### PR DESCRIPTION
Fixes #371 

Create a new Space instance from an existing one. The goal of this PR is to allow people to pass a `Space` instance everywhere we accept a list of dimensions as argument.

