### PR TITLE
Typo, "f of may be noisy"  → "of f may be noisy"

### DIFF
--- a/examples/bayesian-optimization.ipynb
+++ b/examples/bayesian-optimization.ipynb
@@ -34,7 +34,7 @@
     "\n",
     "- $f$ is a black box for which no closed form is known (nor its gradients);\n",
     "- $f$ is expensive to evaluate;\n",
-    "- evaluations $y = f(x)$ of may be noisy.\n",
+    "- and evaluations of $y = f(x)$ may be noisy.\n",
     "\n",
     "**Disclaimer.** If you do not have these constraints, then there is certainly a better optimization algorithm than Bayesian optimization."
    ]


### PR DESCRIPTION
Typo, "f of may be noisy"  → "of f may be noisy" in https://scikit-optimize.github.io/notebooks/bayesian-optimization.html