### PR TITLE
Implements pytest attributes to select fast and slow running tests

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -79,7 +79,11 @@ The development version can be installed through:
     cd scikit-optimize
     pip install -e.
 
-Run the tests by executing ``pytest`` in the top level directory.
+Run all tests by executing `pytest` in the top level directory.
+
+To only run the subset of tests with low run time, you can use `pytest -m 'fast_test'`. On the other hand `pytest -m 'slow_test'` is also possible. To exclude all slow running tests try `pytest -m 'not slow_test'`.
+
+This is implemented using pytest [attributes](https://docs.pytest.org/en/latest/mark.html). If a tests runs longer than 1 second, it is marked as slow, else as fast.
 
 All contributors are welcome!
 

--- a/skopt/learning/gaussian_process/tests/test_gpr.py
+++ b/skopt/learning/gaussian_process/tests/test_gpr.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from scipy import optimize
 
 from sklearn.utils.testing import assert_almost_equal
@@ -7,7 +9,6 @@ from sklearn.utils.testing import assert_false
 from sklearn.utils.testing import assert_true
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_array_equal
-import pytest
 
 from skopt.learning import GaussianProcessRegressor
 from skopt.learning.gaussian_process.kernels import RBF
@@ -35,6 +36,7 @@ def predict_wrapper(X, gpr):
     return gpr.predict(X, return_std=True)
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("kernel", [kernel1, kernel2, kernel3, kernel4])
 def test_param_for_white_kernel_in_Sum(kernel):
     kernel_with_noise = kernel + wk
@@ -47,6 +49,7 @@ def test_param_for_white_kernel_in_Sum(kernel):
     assert_false(_param_for_white_kernel_in_Sum(kernel5)[0])
 
 
+@pytest.mark.fast_test
 def test_noise_equals_gaussian():
     gpr1 = GaussianProcessRegressor(rbf + wk).fit(X, y)
 
@@ -61,6 +64,7 @@ def test_noise_equals_gaussian():
     assert_false(np.any(std1 == std2))
 
 
+@pytest.mark.fast_test
 def test_mean_gradient():
     length_scale = np.arange(1, 6)
     X = rng.randn(10, 5)
@@ -78,6 +82,7 @@ def test_mean_gradient():
     assert_array_almost_equal(mean_grad, num_grad, decimal=3)
 
 
+@pytest.mark.fast_test
 def test_std_gradient():
     length_scale = np.arange(1, 6)
     X = rng.randn(10, 5)

--- a/skopt/learning/gaussian_process/tests/test_kernels.py
+++ b/skopt/learning/gaussian_process/tests/test_kernels.py
@@ -72,6 +72,7 @@ def check_gradient_correctness(kernel, X, Y, step_size=1e-4):
     assert_array_almost_equal(X_grad, num_grad, decimal=3)
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("kernel", KERNELS)
 def test_gradient_correctness(kernel):
     rng = np.random.RandomState(0)
@@ -80,6 +81,7 @@ def test_gradient_correctness(kernel):
     check_gradient_correctness(kernel, X, Y)
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("random_state, kernel", product([0, 1], KERNELS))
 def test_gradient_finiteness(random_state, kernel):
     """
@@ -93,6 +95,7 @@ def test_gradient_finiteness(random_state, kernel):
     check_gradient_correctness(kernel, X, Y, 1e-6)
 
 
+@pytest.mark.fast_test
 def test_distance_string():
     # Inspired by test_hamming_string_array in scipy.tests.test_distance
     a = np.array(['eggs', 'spam', 'spam', 'eggs', 'spam', 'spam', 'spam',
@@ -109,6 +112,7 @@ def test_distance_string():
     assert_array_almost_equal(-np.log(hm(X)) / 20.0, true_values)
 
 
+@pytest.mark.fast_test
 def test_isotropic_kernel():
     rng = np.random.RandomState(0)
     X = rng.randint(0, 4, (5, 3))
@@ -120,6 +124,7 @@ def test_isotropic_kernel():
     assert_array_almost_equal(scipy_dist, hm(X))
 
 
+@pytest.mark.fast_test
 def test_anisotropic_kernel():
     rng = np.random.RandomState(0)
     X = rng.randint(0, 4, (5, 3))
@@ -136,6 +141,7 @@ def test_anisotropic_kernel():
     assert_array_almost_equal(X_kernel, X_kernel_aniso)
 
 
+@pytest.mark.fast_test
 def test_kernel_gradient():
     rng = np.random.RandomState(0)
     hm = HammingKernel(length_scale=2.0)
@@ -168,6 +174,7 @@ def test_kernel_gradient():
     assert_array_almost_equal(K_gradient_approx, K_gradient, 4)
 
 
+@pytest.mark.fast_test
 def test_Y_is_not_None():
     rng = np.random.RandomState(0)
     hm = HammingKernel()
@@ -177,6 +184,7 @@ def test_Y_is_not_None():
     assert_array_equal(hm(X), hm(X, X))
 
 
+@pytest.mark.fast_test
 def test_gp_regressor():
     rng = np.random.RandomState(0)
     X = np.asarray([

--- a/skopt/learning/tests/test_gbrt.py
+++ b/skopt/learning/tests/test_gbrt.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from scipy import stats
 
 from sklearn.ensemble import GradientBoostingRegressor
@@ -17,6 +19,7 @@ def truth(X):
     return 0.5 * np.sin(1.75*X[:, 0])
 
 
+@pytest.mark.fast_test
 def test_gbrt_gaussian():
     # estimate quantiles of the normal distribution
     rng = np.random.RandomState(1)
@@ -33,6 +36,7 @@ def test_gbrt_gaussian():
                         decimal=2)
 
 
+@pytest.mark.fast_test
 def test_gbrt_base_estimator():
     rng = np.random.RandomState(1)
     N = 10000
@@ -58,6 +62,7 @@ def test_gbrt_base_estimator():
                         decimal=2)
 
 
+@pytest.mark.fast_test
 def test_gbrt_with_std():
     # simple test of the interface
     rng = np.random.RandomState(1)
@@ -81,6 +86,7 @@ def test_gbrt_with_std():
     assert_array_equal(std, (h - l) / 2.0)
 
 
+@pytest.mark.fast_test
 def test_gbrt_in_parallel():
     # check estimate quantiles with parallel
     rng = np.random.RandomState(1)

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 from scipy import optimize
 
@@ -20,6 +21,8 @@ class ConstSurrogate:
         return np.zeros(X.shape[0]), np.ones(X.shape[0])
 
 
+
+@pytest.mark.fast_test
 def test_acquisition_ei_correctness():
     # check that it works with a vector as well
     X = 10 * np.ones((4, 2))
@@ -27,6 +30,7 @@ def test_acquisition_ei_correctness():
     assert_array_almost_equal(ei, [0.1977966] * 4)
 
 
+@pytest.mark.fast_test
 def test_acquisition_pi_correctness():
     # check that it works with a vector as well
     X = 10 * np.ones((4, 2))
@@ -34,6 +38,7 @@ def test_acquisition_pi_correctness():
     assert_array_almost_equal(pi, [0.308538] * 4)
 
 
+@pytest.mark.fast_test
 def test_acquisition_lcb_correctness():
     # check that it works with a vector as well
     X = 10 * np.ones((4, 2))
@@ -41,6 +46,7 @@ def test_acquisition_lcb_correctness():
     assert_array_almost_equal(lcb, [-0.3] * 4)
 
 
+@pytest.mark.fast_test
 def test_acquisition_api():
     rng = np.random.RandomState(0)
     X = rng.randn(10, 2)
@@ -62,6 +68,7 @@ def check_gradient_correctness(X_new, model, acq_func, y_opt):
     assert_array_almost_equal(analytic_grad, num_grad, 4)
 
 
+@pytest.mark.fast_test
 def test_acquisition_gradient():
     rng = np.random.RandomState(0)
     X = rng.randn(20, 5)

--- a/skopt/tests/test_benchmarks.py
+++ b/skopt/tests/test_benchmarks.py
@@ -1,4 +1,6 @@
 import numpy as np
+import pytest
+
 from sklearn.utils.testing import assert_array_almost_equal
 from sklearn.utils.testing import assert_almost_equal
 
@@ -6,6 +8,7 @@ from skopt.benchmarks import branin
 from skopt.benchmarks import hart6
 
 
+@pytest.mark.fast_test
 def test_branin():
     xstars = np.asarray([(-np.pi, 12.275), (+np.pi, 2.275), (9.42478, 2.475)])
     f_at_xstars = np.asarray([branin(xstar) for xstar in xstars])
@@ -13,6 +16,7 @@ def test_branin():
     assert_array_almost_equal(f_at_xstars, branin_min)
 
 
+@pytest.mark.fast_test
 def test_hartmann6():
     assert_almost_equal(hart6((0.20169, 0.15001, 0.476874,
                                0.275332, 0.311652, 0.6573)),

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -1,3 +1,5 @@
+import pytest
+
 from collections import namedtuple
 
 from sklearn.utils.testing import assert_equal
@@ -9,6 +11,7 @@ from skopt.callbacks import TimerCallback
 from skopt.callbacks import DeltaYStopper
 
 
+@pytest.mark.fast_test
 def test_timer_callback():
     callback = TimerCallback()
     dummy_minimize(bench1, [(-1.0, 1.0)], callback=callback, n_calls=10)
@@ -16,6 +19,7 @@ def test_timer_callback():
     assert_less(0.0, sum(callback.iter_time))
 
 
+@pytest.mark.fast_test
 def test_deltay_stopper():
     deltay = DeltaYStopper(0.2, 3)
 

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -89,6 +89,7 @@ def call_single(res):
     pass
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("verbose, call",
                          product(
                             [True, False],
@@ -110,6 +111,7 @@ def test_minimizer_api_dummy_minimize(verbose, call):
                          dummy_minimize, lambda x: x, [[-5, 10]])
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("verbose, call, minimizer",
                          product(
                             [True, False],
@@ -134,6 +136,7 @@ def test_minimizer_api(verbose, call, minimizer):
                          minimizer, lambda x: x, [[-5, 10]])
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_minimizer_api_random_only(minimizer):
     # no models should be fit as we only evaluate at random points
@@ -149,6 +152,7 @@ def test_minimizer_api_random_only(minimizer):
     check_minimizer_bounds(result, n_calls)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_fixed_random_states(minimizer):
     # check that two runs produce exactly same results, if not there is a
@@ -168,6 +172,7 @@ def test_fixed_random_states(minimizer):
     assert_array_almost_equal(result1.func_vals, result2.func_vals)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_minimizer_with_space(minimizer):
     # check we can pass a Space instance as dimensions argument and get same
@@ -190,6 +195,7 @@ def test_minimizer_with_space(minimizer):
     assert_array_almost_equal(space_result.func_vals, result.func_vals)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("n_random_starts, optimizer_func",
                          product([0, 5],
                                  [gp_minimize,
@@ -209,6 +215,7 @@ def test_init_vals_and_models(n_random_starts, optimizer_func):
     assert_equal(len(res.models), n_calls - n_random_starts)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("n_random_starts, optimizer_func",
                          product([0, 5],
                                  [gp_minimize,
@@ -228,6 +235,7 @@ def test_init_points_and_models(n_random_starts, optimizer_func):
                  n_calls - n_random_starts - len(x0))
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("n_random_starts, optimizer_func",
                          product([0, 5],
                                  [gp_minimize,
@@ -242,6 +250,7 @@ def test_init_vals(n_random_starts, optimizer_func):
     check_init_vals(optimizer, branin, space, x0, n_calls)
 
 
+@pytest.mark.fast_test
 def test_init_vals_dummy_minimize():
     space = [(-5.0, 10.0), (0.0, 15.0)]
     x0 = [[1, 2], [3, 4], [5, 6]]
@@ -249,6 +258,7 @@ def test_init_vals_dummy_minimize():
     check_init_vals(dummy_minimize, branin, space, x0, n_calls)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("optimizer", [
         dummy_minimize,
         partial(gp_minimize, n_random_starts=0),
@@ -261,6 +271,7 @@ def test_categorical_init_vals(optimizer):
     check_init_vals(optimizer, bench4, space, x0, n_calls)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("optimizer", [
         dummy_minimize,
         partial(gp_minimize, n_random_starts=0),
@@ -320,6 +331,7 @@ def check_init_vals(optimizer, func, space, x0, n_calls):
                   space, x0=x0, y0=[1])
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_invalid_n_calls_arguments(minimizer):
     assert_raise_message(ValueError,
@@ -358,6 +370,7 @@ def test_invalid_n_calls_arguments(minimizer):
                          random_state=1, n_random_starts=7)
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_repeated_x(minimizer):
     assert_warns_message(
@@ -370,6 +383,7 @@ def test_repeated_x(minimizer):
         n_random_starts=0)
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_consistent_x_iter_dimensions(minimizer):
     # check that all entries in x_iters have the same dimensions
@@ -400,6 +414,7 @@ def test_consistent_x_iter_dimensions(minimizer):
                          x0=[0, 1], n_calls=3, n_random_starts=0)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_early_stopping_delta_x(minimizer):
     n_calls = 15
@@ -412,6 +427,7 @@ def test_early_stopping_delta_x(minimizer):
     assert len(res.x_iters) < n_calls
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("minimizer", MINIMIZERS)
 def test_early_stopping_delta_x_empty_result_object(minimizer):
     # check that the callback handles the case of being passed an empty

--- a/skopt/tests/test_dummy_opt.py
+++ b/skopt/tests/test_dummy_opt.py
@@ -1,3 +1,5 @@
+import pytest
+
 from sklearn.utils.testing import assert_less
 
 from skopt import dummy_minimize
@@ -11,6 +13,7 @@ def check_minimize(func, y_opt, dimensions, margin, n_calls):
     assert_less(r.fun, y_opt + margin)
 
 
+@pytest.mark.slow_test
 def test_dummy_minimize():
     check_minimize(bench1, 0., [(-2.0, 2.0)], 0.05, 10000)
     check_minimize(bench2, -5, [(-6.0, 6.0)], 0.05, 10000)

--- a/skopt/tests/test_forest_opt.py
+++ b/skopt/tests/test_forest_opt.py
@@ -18,6 +18,7 @@ MINIMIZERS = [("ET", partial(forest_minimize, base_estimator='ET')),
               ("gbrt", gbrt_minimize)]
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("base_estimator", [42, DecisionTreeClassifier()])
 def test_forest_minimize_api(base_estimator):
     # invalid string value
@@ -42,6 +43,7 @@ def check_minimize(minimizer, func, y_opt, dimensions, margin,
         assert_less(r.fun, y_opt + margin)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("name, minimizer", MINIMIZERS)
 def test_tree_based_minimize(name, minimizer):
     check_minimize(minimizer, bench1, 0.,

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -25,30 +25,35 @@ def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
 SEARCH_AND_ACQ = list(product(["sampling", "lbfgs"], ["LCB", "EI"]))
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
 def test_gp_minimize_bench1(search, acq):
     check_minimize(bench1, 0.,
                    [(-2.0, 2.0)], search, acq, 0.05, 50)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
 def test_gp_minimize_bench2(search, acq):
     check_minimize(bench2, -5,
                    [(-6.0, 6.0)], search, acq, 0.05, 75)
 
 
+@pytest.mark.slow_test
 @pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
 def test_gp_minimize_bench3(search, acq):
     check_minimize(bench3, -0.9,
                    [(-2.0, 2.0)], search, acq, 0.05, 50)
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
 def test_gp_minimize_bench4(search, acq):
     check_minimize(bench4, 0.0,
                    [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)
 
 
+@pytest.mark.fast_test
 def test_n_jobs():
     r_single = gp_minimize(bench3, [(-2.0, 2.0)], acq_optimizer="lbfgs",
                            acq_func="EI", n_calls=2, n_random_starts=1,
@@ -59,6 +64,7 @@ def test_n_jobs():
     assert_array_equal(r_single.x_iters, r_double.x_iters)
 
 
+@pytest.mark.fast_test
 def test_gpr_default():
     """Smoke test that gp_minimize does not fail for default values."""
     gpr = GaussianProcessRegressor()

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -16,6 +16,7 @@ TREE_REGRESSORS = (ExtraTreesRegressor(random_state=2),
                    GradientBoostingQuantileRegressor(random_state=2))
 
 
+@pytest.mark.fast_test
 def test_multiple_asks():
     # calling ask() multiple times without a tell() inbetween should
     # be a "no op"
@@ -34,6 +35,7 @@ def test_multiple_asks():
     assert_equal(opt.ask(), opt.ask())
 
 
+@pytest.mark.fast_test
 def test_invalid_tell_arguments():
     base_estimator = ExtraTreesRegressor(random_state=2)
     opt = Optimizer([(-2.0, 2.0)], base_estimator, n_random_starts=1,
@@ -43,6 +45,7 @@ def test_invalid_tell_arguments():
     assert_raises(ValueError, opt.tell, [1.], [1., 1.])
 
 
+@pytest.mark.fast_test
 def test_bounds_checking_1D():
     low = -2.
     high = 2.
@@ -57,6 +60,7 @@ def test_bounds_checking_1D():
     assert_raises(ValueError, opt.tell, [low - 0.5, high], (2., 3.))
 
 
+@pytest.mark.fast_test
 def test_bounds_checking_2D():
     low = -2.
     high = 2.
@@ -72,6 +76,7 @@ def test_bounds_checking_2D():
     assert_raises(ValueError, opt.tell, [low - 0.5, high + 0.5], 2.)
 
 
+@pytest.mark.fast_test
 def test_bounds_checking_2D_multiple_points():
     low = -2.
     high = 2.
@@ -88,6 +93,7 @@ def test_bounds_checking_2D_multiple_points():
                   [2., 3.])
 
 
+@pytest.mark.fast_test
 def test_returns_result_object():
     base_estimator = ExtraTreesRegressor(random_state=2)
     opt = Optimizer([(-2.0, 2.0)], base_estimator, n_random_starts=1,
@@ -99,6 +105,7 @@ def test_returns_result_object():
     assert_equal(np.min(result.func_vals), result.fun)
 
 
+@pytest.mark.fast_test
 @pytest.mark.parametrize("base_estimator", TREE_REGRESSORS)
 def test_acq_optimizer(base_estimator):
     with pytest.raises(ValueError) as e:

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -1,3 +1,4 @@
+import pytest
 import numbers
 import numpy as np
 
@@ -39,6 +40,7 @@ def check_limits(value, low, high):
     assert_greater_equal(high, value)
 
 
+@pytest.mark.fast_test
 def test_dimensions():
     check_dimension(Real, (1., 4.), 2.251066014107722)
     check_dimension(Real, (1, 4), 2.251066014107722)
@@ -48,6 +50,7 @@ def test_dimensions():
     check_categorical((1., 2., 3., 4.), 2.)
 
 
+@pytest.mark.fast_test
 def test_real():
     a = Real(1, 25)
     for i in range(50):
@@ -73,6 +76,7 @@ def test_real():
         log_uniform.inverse_transform(transformed_vals), random_values)
 
 
+@pytest.mark.fast_test
 def test_real_bounds():
     # should give same answer as using check_limits() but this is easier
     # to read
@@ -84,6 +88,7 @@ def test_real_bounds():
     assert_false(np.nextafter(2.1, 3.) in a)
 
 
+@pytest.mark.fast_test
 def test_integer():
     a = Integer(1, 10)
     for i in range(50):
@@ -98,6 +103,7 @@ def test_integer():
     assert_array_equal(a.inverse_transform(random_values), random_values)
 
 
+@pytest.mark.fast_test
 def test_categorical_transform():
     categories = ["apple", "orange", "banana", None, True, False, 3]
     cat = Categorical(categories)
@@ -127,6 +133,7 @@ def test_categorical_transform():
     assert_array_equal(ent_inverse, categories)
 
 
+@pytest.mark.fast_test
 def test_categorical_transform_binary():
     categories = ["apple", "orange"]
     cat = Categorical(categories)
@@ -144,6 +151,7 @@ def test_categorical_transform_binary():
     assert_array_equal(ent_inverse, categories)
 
 
+@pytest.mark.fast_test
 def test_space_consistency():
     # Reals (uniform)
 
@@ -203,6 +211,7 @@ def test_space_consistency():
     assert_array_equal(a1, a2)
 
 
+@pytest.mark.fast_test
 def test_space_api():
     space = Space([(0.0, 1.0), (-5, 5),
                    ("a", "b", "c"), (1.0, 5.0, "log-uniform"), ("e", "f")])
@@ -252,6 +261,7 @@ def test_space_api():
         assert_array_equal(b1, b2)
 
 
+@pytest.mark.fast_test
 def test_space_from_space():
     # can you pass a Space instance to the Space constructor?
     space = Space([(0.0, 1.0), (-5, 5),
@@ -262,6 +272,7 @@ def test_space_from_space():
     assert_equal(space, space2)
 
 
+@pytest.mark.fast_test
 def test_normalize():
     a = Real(2.0, 30.0, transform="normalize")
     for i in range(50):
@@ -316,11 +327,13 @@ def check_valid_transformation(klass):
                         klass, 2, 30, transform='not a valid transform name')
 
 
+@pytest.mark.fast_test
 def test_valid_transformation():
     check_valid_transformation(Integer)
     check_valid_transformation(Real)
 
 
+@pytest.mark.fast_test
 def test_invalid_dimension():
     assert_raises_regex(ValueError, "has to be a list or tuple",
                         space_check_dimension, "23")
@@ -328,6 +341,7 @@ def test_invalid_dimension():
                         space_check_dimension, (23,))
 
 
+@pytest.mark.fast_test
 def test_categorical_identity():
     categories = ["cat", "dog", "rat"]
     cat = Categorical(categories, transform="identity")
@@ -338,6 +352,7 @@ def test_categorical_identity():
     assert_array_equal(samples, cat.inverse_transform(transformed))
 
 
+@pytest.mark.fast_test
 def test_categorical_distance():
     categories = ['car', 'dog', 'orange']
     cat = Categorical(categories)
@@ -350,24 +365,28 @@ def test_categorical_distance():
                 assert delta == 1
 
 
+@pytest.mark.fast_test
 def test_integer_distance():
     ints = Integer(1, 10)
     for i in range(1, 10+1):
         assert_equal(ints.distance(4, i), abs(4 - i))
 
 
+@pytest.mark.fast_test
 def test_integer_distance_out_of_range():
     ints = Integer(1, 10)
     assert_raises_regex(RuntimeError, "compute distance for values within",
                         ints.distance, 11, 10)
 
 
+@pytest.mark.fast_test
 def test_real_distance_out_of_range():
     ints = Real(1, 10)
     assert_raises_regex(RuntimeError, "compute distance for values within",
                         ints.distance, 11, 10)
 
 
+@pytest.mark.fast_test
 def test_real_distance():
     reals = Real(1, 10)
     for i in range(1, 10+1):

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -1,3 +1,4 @@
+import pytest
 import tempfile
 
 from sklearn.utils.testing import assert_array_equal
@@ -23,6 +24,7 @@ def check_optimization_results_equality(res_1, res_2):
     assert_array_equal(res_1.func_vals, res_2.func_vals)
 
 
+@pytest.mark.fast_test
 def test_dump_and_load():
     res = gp_minimize(bench3,
                       [(-2.0, 2.0)],
@@ -55,6 +57,7 @@ def test_dump_and_load():
     assert_true(not ("func" in res_loaded.specs["args"]))
 
 
+@pytest.mark.fast_test
 def test_dump_and_load_optimizer():
     base_estimator = ExtraTreesRegressor(random_state=2)
     opt = Optimizer([(-2.0, 2.0)], base_estimator, n_random_starts=1,


### PR DESCRIPTION
This PR implements changes proposed in #293 by adding pytest attributes to all tests depending on their run time.

I picked the threshold between slow and fasts tests to be at 1 second. This yields all fast tests to run in approx 10s while the slow tests take another 10min. If one test is performed multiple times with different input parameters, only the slowest run is taken into account.

* To only run the fast tests: `pytest -m 'fast_test'`
* To only run the slow tests: `pytest -m 'slow_test'`
* To only run tests w/o any attribute: `pytest -m 'not slow_test and not fast_test'`

