### PR TITLE
[MRG] Allow base_estimators to be strings

### DIFF
--- a/examples/ask-and-tell.ipynb
+++ b/examples/ask-and-tell.ipynb
@@ -139,7 +139,7 @@
    "outputs": [],
    "source": [
     "etr = ExtraTreesRegressor(random_state=2, n_estimators=200)\n",
-    "opt = Optimizer([(-2.0, 2.0)], etr, acq_optimizer=\"sampling\")"
+    "opt = Optimizer([(-2.0, 2.0)], \"ET\", acq_optimizer=\"sampling\")"
    ]
   },
   {

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -3,7 +3,7 @@
 from sklearn.utils import check_random_state
 
 from .base import base_minimize
-from ..utils import cook_skopt_estimator
+from ..utils import cook_estimator
 
 
 def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
@@ -142,8 +142,7 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
     rng = check_random_state(random_state)
 
     if isinstance(base_estimator, str):
-        base_estimator = cook_skopt_estimator(base_estimator, n_jobs=n_jobs,
-                                              random_state=rng)
+        base_estimator = cook_estimator(base_estimator, n_jobs=n_jobs, random_state=rng)
 
     return base_minimize(func, dimensions, base_estimator,
                          n_calls=n_calls, n_points=n_points,

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -3,8 +3,7 @@
 from sklearn.utils import check_random_state
 
 from .base import base_minimize
-from ..learning import ExtraTreesRegressor
-from ..learning import RandomForestRegressor
+from ..utils import cook_skopt_estimator
 
 
 def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
@@ -142,24 +141,9 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
     """
     rng = check_random_state(random_state)
 
-    # Default estimator
     if isinstance(base_estimator, str):
-        if base_estimator not in ("RF", "ET"):
-            raise ValueError(
-                "Valid strings for the base_estimator parameter"
-                " are: 'RF' or 'ET', not '%s'" % base_estimator)
-
-        if base_estimator == "RF":
-            base_estimator = RandomForestRegressor(n_estimators=100,
-                                                   min_samples_leaf=3,
-                                                   n_jobs=n_jobs,
-                                                   random_state=rng)
-
-        elif base_estimator == "ET":
-            base_estimator = ExtraTreesRegressor(n_estimators=100,
-                                                 min_samples_leaf=3,
-                                                 n_jobs=n_jobs,
-                                                 random_state=rng)
+        base_estimator = cook_skopt_estimator(base_estimator, n_jobs=n_jobs,
+                                              random_state=rng)
 
     return base_minimize(func, dimensions, base_estimator,
                          n_calls=n_calls, n_points=n_points,

--- a/skopt/optimizer/gbrt.py
+++ b/skopt/optimizer/gbrt.py
@@ -3,7 +3,7 @@ from sklearn.utils import check_random_state
 
 from .base import base_minimize
 from ..learning import GradientBoostingQuantileRegressor
-from ..utils import cook_skopt_estimator
+from ..utils import cook_estimator
 
 
 def gbrt_minimize(func, dimensions, base_estimator=None,
@@ -134,8 +134,7 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
     rng = check_random_state(random_state)
 
     if base_estimator is None:
-        base_estimator = cook_skopt_estimator("GBRT", random_state=rng,
-                                              n_jobs=n_jobs)
+        base_estimator = cook_estimator("GBRT", random_state=rng, n_jobs=n_jobs)
     return base_minimize(func, dimensions, base_estimator,
                          n_calls=n_calls, n_points=n_points,
                          n_random_starts=n_random_starts,

--- a/skopt/optimizer/gbrt.py
+++ b/skopt/optimizer/gbrt.py
@@ -1,9 +1,9 @@
 
-from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.utils import check_random_state
 
 from .base import base_minimize
 from ..learning import GradientBoostingQuantileRegressor
+from ..utils import cook_skopt_estimator
 
 
 def gbrt_minimize(func, dimensions, base_estimator=None,
@@ -133,13 +133,9 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
     # Check params
     rng = check_random_state(random_state)
 
-    # Default estimator
     if base_estimator is None:
-        gbrt = GradientBoostingRegressor(n_estimators=30, loss="quantile")
-        base_estimator = GradientBoostingQuantileRegressor(base_estimator=gbrt,
-                                                           n_jobs=n_jobs,
-                                                           random_state=rng)
-
+        base_estimator = cook_skopt_estimator("GBRT", random_state=rng,
+                                              n_jobs=n_jobs)
     return base_minimize(func, dimensions, base_estimator,
                          n_calls=n_calls, n_points=n_points,
                          n_random_starts=n_random_starts,

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -226,6 +226,8 @@ def gp_minimize(func, dimensions, base_estimator=None,
     base_estimator = cook_skopt_estimator(
         "GP", is_cat=is_cat, random_state=rng, noise=noise,
         n_dims=space.transformed_n_dims)
+    if is_cat:
+        acq_optimizer = "sampling"
 
     return base_minimize(
         func, dimensions, base_estimator=base_estimator,

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -15,6 +15,7 @@ from ..acquisition import _gaussian_acquisition
 from ..acquisition import gaussian_acquisition_1D
 from ..learning import ExtraTreesRegressor
 from ..learning import RandomForestRegressor
+from ..learning import GaussianProcessRegressor
 from ..learning import GradientBoostingQuantileRegressor
 from ..space import Categorical
 from ..space import Space
@@ -115,7 +116,7 @@ class Optimizer(object):
         to sample points, bounds, and type of parameters.
 
     """
-    def __init__(self, dimensions, base_estimator,
+    def __init__(self, dimensions, base_estimator="gp",
                  n_random_starts=None, n_initial_points=10,
                  acq_func="gp_hedge",
                  acq_optimizer="auto",
@@ -199,6 +200,9 @@ class Optimizer(object):
 
         if acq_optimizer == "auto":
             if is_tree_based:
+                acq_optimizer = "sampling"
+            elif (isinstance(self.base_estimator_, GaussianProcessRegressor)
+                  and self.space.is_categorical):
                 acq_optimizer = "sampling"
             else:
                 acq_optimizer = "lbfgs"

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -52,9 +52,9 @@ class Optimizer(object):
         Should inherit from `sklearn.base.RegressorMixin`.
         In addition the `predict` method, should have an optional `return_std`
         argument, which returns `std(Y | x)`` along with `E[Y | x]`.
-        If provided base_estimator is in ["GP", "RF", "ET", "GBRT"]
-        then the corresponding estimator in the minimize functions is used
-        as a surrogate model.
+        If base_estimator is one of ["GP", "RF", "ET", "GBRT"], a default
+        surrogate model of the corresponding type is used corresponding to what
+        is used in the minimize functions.
 
     * `n_random_starts` [int, default=10]:
         DEPRECATED, use `n_initial_points` instead.
@@ -200,7 +200,7 @@ class Optimizer(object):
         self.n_initial_points_ = n_initial_points
 
         if acq_optimizer == "auto":
-            if has_gradients(self.base_estimator_, self.space):
+            if has_gradients(self.base_estimator_):
                 acq_optimizer = "sampling"
             else:
                 acq_optimizer = "lbfgs"
@@ -209,7 +209,7 @@ class Optimizer(object):
             raise ValueError("Expected acq_optimizer to be 'lbfgs' or "
                              "'sampling', got {0}".format(acq_optimizer))
 
-        if has_gradients(self.base_estimator_, self.space) and acq_optimizer != "sampling":
+        if has_gradients(self.base_estimator_) and acq_optimizer != "sampling":
             raise ValueError("The regressor {0} should run with "
                              "acq_optimizer='sampling'".format(type(base_estimator)))
 

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -47,7 +47,7 @@ def test_gp_minimize_bench3(search, acq):
 
 
 @pytest.mark.fast_test
-@pytest.mark.parametrize("search, acq", list(product(["sampling", "lbfgs"], ["LCB", "EI"])))
+@pytest.mark.parametrize("search, acq", list(product(["sampling"], ["LCB", "EI"])))
 def test_gp_minimize_bench4(search, acq):
     check_minimize(bench4, 0.0,
                    [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -47,7 +47,7 @@ def test_gp_minimize_bench3(search, acq):
 
 
 @pytest.mark.fast_test
-@pytest.mark.parametrize("search, acq", SEARCH_AND_ACQ)
+@pytest.mark.parametrize("search, acq", list(product(["sampling", "lbfgs"], ["LCB", "EI"])))
 def test_gp_minimize_bench4(search, acq):
     check_minimize(bench4, 0.0,
                    [("-2", "-1", "0", "1", "2")], search, acq, 0.05, 10)

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -140,3 +140,19 @@ def test_exhaust_initial_calls():
     assert x3 == x4
     r3 = opt.tell(x3, 1.)
     assert len(r3.models) == 2
+
+
+@pytest.mark.fast_test
+def test_optimizer_base_estimator_string_invalid():
+    with pytest.raises(ValueError) as e:
+        opt = Optimizer([(-2.0, 2.0)], base_estimator="rtr",
+                        n_random_starts=1)
+    assert "'RF', 'ET' or 'GP'" in str(e.value)
+
+
+@pytest.mark.fast_test
+@pytest.mark.parametrize("base_estimator", ["GP", "RF", "ET"])
+def test_optimizer_base_estimator_string_smoke(base_estimator):
+    opt = Optimizer([(-2.0, 2.0)], base_estimator=base_estimator,
+                    n_random_starts=1)
+    opt.run(func=lambda x: x[0]**2, n_iter=3)

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -14,6 +14,7 @@ from scipy.optimize import OptimizeResult
 TREE_REGRESSORS = (ExtraTreesRegressor(random_state=2),
                    RandomForestRegressor(random_state=2),
                    GradientBoostingQuantileRegressor(random_state=2))
+ESTIMATOR_STRINGS = ["GP", "RF", "ET", "GBRT", "gp", "rf", "et", "gbrt"]
 
 
 @pytest.mark.fast_test
@@ -111,7 +112,7 @@ def test_acq_optimizer(base_estimator):
     with pytest.raises(ValueError) as e:
         opt = Optimizer([(-2.0, 2.0)], base_estimator=base_estimator,
                         n_random_starts=1, acq_optimizer='lbfgs')
-    assert 'The tree-based regressor' in str(e.value)
+    assert "should run with acq_optimizer='sampling'" in str(e.value)
 
 
 def test_exhaust_initial_calls():
@@ -151,8 +152,8 @@ def test_optimizer_base_estimator_string_invalid():
 
 
 @pytest.mark.fast_test
-@pytest.mark.parametrize("base_estimator", ["GP", "RF", "ET"])
+@pytest.mark.parametrize("base_estimator", ESTIMATOR_STRINGS)
 def test_optimizer_base_estimator_string_smoke(base_estimator):
     opt = Optimizer([(-2.0, 2.0)], base_estimator=base_estimator,
-                    n_random_starts=1)
+                    n_random_starts=1, acq_func="EI")
     opt.run(func=lambda x: x[0]**2, n_iter=3)

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -212,7 +212,30 @@ def expected_minimum(res, n_random_starts=20, random_state=None):
     return [v for v in best_x], best_fun
 
 
-def cook_skopt_estimator(base_estimator, n_dims=1, is_cat=False, **kwargs):
+def cook_estimator(base_estimator, space=None, **kwargs):
+    """
+    Cook a default estimator.
+
+    Parameters
+    ----------
+    * `base_estimator` ["GP", "RF", "ET", "GBRT" or sklearn regressor, default="gp"]:
+        Should inherit from `sklearn.base.RegressorMixin`.
+        In addition the `predict` method, should have an optional `return_std`
+        argument, which returns `std(Y | x)`` along with `E[Y | x]`.
+        If provided base_estimator is in ["GP", "RF", "ET", "GBRT"]
+        then the corresponding estimator used in the minimize functions
+        are used.
+
+    * `space` [Space instance]:
+        Has to be provided is the base_estimator is a gaussian process.
+        Ignored otherwise.
+
+    * `kwargs` [dict]:
+        Extra parameters provided to the base_estimator at init time.
+    """
+    if space is not None:
+        n_dims = space.transformed_n_dims
+        is_cat = space.is_categorical
     if isinstance(base_estimator, str):
         base_estimator = base_estimator.upper()
         if base_estimator not in ["GP", "ET", "RF", "GBRT"]:

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -212,22 +212,32 @@ def expected_minimum(res, n_random_starts=20, random_state=None):
     return [v for v in best_x], best_fun
 
 
+def has_gradients(estimator, space):
+    tree_estimators = (
+            ExtraTreesRegressor, RandomForestRegressor,
+            GradientBoostingQuantileRegressor)
+    return (
+        isinstance(estimator, tree_estimators) or
+        (isinstance(estimator, GaussianProcessRegressor) and space.is_categorical)
+    )
+
+
 def cook_estimator(base_estimator, space=None, **kwargs):
     """
     Cook a default estimator.
 
     Parameters
     ----------
-    * `base_estimator` ["GP", "RF", "ET", "GBRT" or sklearn regressor, default="gp"]:
+    * `base_estimator` ["GP", "RF", "ET", "GBRT" or sklearn regressor, default="GP"]:
         Should inherit from `sklearn.base.RegressorMixin`.
         In addition the `predict` method, should have an optional `return_std`
         argument, which returns `std(Y | x)`` along with `E[Y | x]`.
         If provided base_estimator is in ["GP", "RF", "ET", "GBRT"]
-        then the corresponding estimator used in the minimize functions
-        are used.
+        then the corresponding estimator in the minimize functions is used
+        as a surrogate model.
 
     * `space` [Space instance]:
-        Has to be provided is the base_estimator is a gaussian process.
+        Has to be provided if the base_estimator is a gaussian process.
         Ignored otherwise.
 
     * `kwargs` [dict]:


### PR DESCRIPTION
1. Allow base_estimator to be one of "gp", "et", "rf" or "gbrt", by default "gp"
2. Add a function `cook_skopt_estimator` in utils that allows to cook the default skopt estimators.
