### PR TITLE
[MRG] Fix install instructions to explicitly install numpy

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -37,6 +37,7 @@ Install
 
 ::
 
+    pip install numpy # install numpy explicitly first
     pip install scikit-optimize
 
 Getting started

--- a/build_tools/circle/execute.sh
+++ b/build_tools/circle/execute.sh
@@ -2,6 +2,10 @@ export PATH="$HOME/miniconda3/bin:$PATH"
 source activate testenv
 export SKOPT_HOME=$(pwd)
 
+python --version
+python -c "import numpy; print('numpy %s' % numpy.__version__)"
+python -c "import scipy; print('scipy %s' % scipy.__version__)"
+
 # Generating documentation
 for nb in examples/*ipynb; do
     jupyter nbconvert --ExecutePreprocessor.timeout=3600 --execute "$nb" --to markdown |& tee nb_to_md.txt

--- a/build_tools/circle/install.sh
+++ b/build_tools/circle/install.sh
@@ -33,9 +33,6 @@ conda create -n testenv --yes python pip pytest nose \
    numpy
 source activate testenv
 
-python --version
-python -c "import numpy; print('numpy %s' % numpy.__version__)"
-python -c "import scipy; print('scipy %s' % scipy.__version__)"
 pip install -e.
 export SKOPT_HOME=$(pwd)
 

--- a/build_tools/circle/install.sh
+++ b/build_tools/circle/install.sh
@@ -30,7 +30,7 @@ popd
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n testenv --yes python pip pytest nose \
-   numpy scipy scikit-learn matplotlib cython
+   numpy
 source activate testenv
 
 python --version

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -26,7 +26,7 @@ popd
 # Configure the conda environment and put it in the path using the
 # provided versions
 conda create -n testenv --yes python=$PYTHON_VERSION pip nose pytest \
-   numpy scipy scikit-learn matplotlib cython
+   numpy
 source activate testenv
 
 if [[ "$COVERAGE" == "true" ]]; then

--- a/build_tools/travis/install.sh
+++ b/build_tools/travis/install.sh
@@ -33,7 +33,7 @@ if [[ "$COVERAGE" == "true" ]]; then
     pip install pytest-cov coverage coveralls
 fi
 
+pip install -e.
 python --version
 python -c "import numpy; print('numpy %s' % numpy.__version__)"
 python -c "import scipy; print('scipy %s' % scipy.__version__)"
-pip install -e.


### PR DESCRIPTION
Closes #404 and adds a (temporary?) workaround to the install instructions.

We need to install numpy before trying to install scikit-optimize
as numpy is needed to run the `setup.py` of scikit-garden which
we depend on. While scikit-garden declares numpy as a dependency the seutp.py can't be executed without it being installed, which creates some kind of infinite loop.

The discussion of having numpy in `setup.py` is in scikit-garden/scikit-garden#23