### PR TITLE
check if transformer is instance of CategoricalEncoder in Pipeline.fit

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -152,7 +152,11 @@ class Pipeline(Transformer):
 
     def fit(self, X):
         for transformer in self.transformers:
-            transformer.fit(X)
+            if isinstance(transformer, CategoricalEncoder):
+                transformer.fit(X)
+            else:
+                raise TypeError("{} is not an instance of CategoricalEncoder"
+                                .format(transformer))
         return self
 
     def transform(self, X):


### PR DESCRIPTION
I propose we check that every ``transformer`` in the ``Pipeline`` class is an instance of ``CategoricalEncoder`` and raise a helpful error message if any of them are not.