### PR TITLE
[MRG] Add support for random "base estimator" in Optimizer

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ Go forth!
 
 ### API changes
 
+* change interface of GradientBoostingQuantileRegressor's predict method to
+  match return type of other regressors
 * Dimensions of type Real are now inclusive of upper bound.
 
 

--- a/skopt/learning/gbrt.py
+++ b/skopt/learning/gbrt.py
@@ -88,7 +88,7 @@ class GradientBoostingQuantileRegressor(BaseEstimator, RegressorMixin):
 
         return self
 
-    def predict(self, X, return_std=False):
+    def predict(self, X, return_std=False, return_quantiles=False):
         """Predict.
 
         Predict `X` at every quantile if `return_std` is set to False.
@@ -104,9 +104,10 @@ class GradientBoostingQuantileRegressor(BaseEstimator, RegressorMixin):
         """
         predicted_quantiles = np.asarray(
             [rgr.predict(X) for rgr in self.regressors_])
-        if not return_std:
+        if return_quantiles:
             return predicted_quantiles.T
-        else:
+
+        elif return_std:
             std_quantiles = [0.16, 0.5, 0.84]
             is_present_mask = np.in1d(std_quantiles, self.quantiles)
             if not np.all(is_present_mask):
@@ -117,3 +118,6 @@ class GradientBoostingQuantileRegressor(BaseEstimator, RegressorMixin):
             high = self.regressors_[self.quantiles.index(0.84)].predict(X)
             mean = self.regressors_[self.quantiles.index(0.5)].predict(X)
             return mean, ((high - low) / 2.0)
+
+        # return the mean
+        return self.regressors_[self.quantiles.index(0.5)].predict(X)

--- a/skopt/learning/tests/test_gbrt.py
+++ b/skopt/learning/tests/test_gbrt.py
@@ -29,7 +29,7 @@ def test_gbrt_gaussian():
     rgr = GradientBoostingQuantileRegressor()
     rgr.fit(X, y)
 
-    estimates = rgr.predict(X)
+    estimates = rgr.predict(X, return_quantiles=True)
     assert_almost_equal(stats.norm.ppf(rgr.quantiles),
                         np.mean(estimates, axis=0),
                         decimal=2)
@@ -55,7 +55,7 @@ def test_gbrt_base_estimator():
     rgr = GradientBoostingQuantileRegressor(base_estimator=base)
     rgr.fit(X, y)
 
-    estimates = rgr.predict(X)
+    estimates = rgr.predict(X, return_quantiles=True)
     assert_almost_equal(stats.norm.ppf(rgr.quantiles),
                         np.mean(estimates, axis=0),
                         decimal=2)
@@ -74,9 +74,14 @@ def test_gbrt_with_std():
     model = GradientBoostingQuantileRegressor()
     model.fit(X, y)
 
-    assert_array_equal(model.predict(X_).shape, (len(X_), 3))
+    # three quantiles, so three numbers per sample
+    assert_array_equal(model.predict(X_, return_quantiles=True).shape,
+                       (len(X_), 3))
+    # "traditional" API which returns one number per sample, in this case
+    # just the median/mean
+    assert_array_equal(model.predict(X_).shape, (len(X_)))
 
-    l, c, h = model.predict(X_).T
+    l, c, h = model.predict(X_, return_quantiles=True).T
     assert_equal(l.shape, c.shape, h.shape)
     assert_equal(l.shape[0], X_.shape[0])
 

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -84,7 +84,7 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
     else:
         n_random_calls = n_calls
 
-    return base_minimize(func, dimensions, base_estimator=None,
+    return base_minimize(func, dimensions, base_estimator="dummy",
                          n_calls=n_calls, n_random_starts=n_random_calls,
                          x0=x0, y0=y0, random_state=random_state,
                          verbose=verbose,

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -79,8 +79,8 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
     """
     # all our calls want random suggestions, except if we need to evaluate
     # some initial points
-    if x0 is not None:
-        n_random_calls = n_calls - (len(x0) if not y0 else 0)
+    if x0 is not None and y0 is None:
+        n_random_calls = n_calls - len(x0)
     else:
         n_random_calls = n_calls
 

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -1,18 +1,6 @@
 """Random search."""
 
-import copy
-import inspect
-import numbers
-import numpy as np
-
-from collections import Iterable
-from sklearn.utils import check_random_state
-
-from ..callbacks import check_callback
-from ..callbacks import VerboseCallback
-from ..space import Space
-from ..utils import create_result
-from ..utils import eval_callbacks
+from .base import base_minimize
 
 
 def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
@@ -89,73 +77,15 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
         For more details related to the OptimizeResult object, refer
         http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.OptimizeResult.html
     """
-    # Save call args
-    specs = {"args": copy.copy(inspect.currentframe().f_locals),
-             "function": inspect.currentframe().f_code.co_name}
+    # all our calls want random suggestions, except if we need to evaluate
+    # some initial points
+    if x0 is not None:
+        n_random_calls = n_calls - (len(x0) if not y0 else 0)
+    else:
+        n_random_calls = n_calls
 
-    # Check params
-    rng = check_random_state(random_state)
-    space = Space(dimensions)
-
-    if x0 is None:
-        x0 = []
-    elif not isinstance(x0[0], list):
-        x0 = [x0]
-
-    if not isinstance(x0, list):
-        raise ValueError("`x0` should be a list, got %s" % type(x0))
-
-    n_init_func_calls = 0
-    if len(x0) > 0 and y0 is not None:
-        if isinstance(y0, Iterable):
-            y0 = list(y0)
-        elif isinstance(y0, numbers.Number):
-            y0 = [y0]
-        else:
-            raise ValueError("`y0` should be an iterable or a scalar, got %s"
-                             % type(y0))
-        if len(x0) != len(y0):
-            raise ValueError("`x0` and `y0` should have the same length")
-
-        if not all(map(np.isscalar, y0)):
-            raise ValueError("`y0` elements should be scalars")
-
-    elif len(x0) > 0 and y0 is None:
-        y0 = []
-        n_calls -= len(x0)
-        n_init_func_calls = len(x0)
-
-    elif len(x0) == 0 and y0 is not None:
-        raise ValueError("`x0`cannot be `None` when `y0` is provided")
-
-    else:  # len(x0) == 0 and y0 is None
-        y0 = []
-
-    callbacks = check_callback(callback)
-    if verbose:
-        callbacks.append(VerboseCallback(
-            n_init=n_init_func_calls, n_total=n_calls))
-
-    X = x0
-    y = y0
-
-    # Random search
-    X = X + space.rvs(n_samples=n_calls, random_state=rng)
-    first = True
-    result = None
-
-    for i in range(len(y0), len(X)):
-        y_i = func(X[i])
-
-        if first:
-            first = False
-            if not np.isscalar(y_i):
-                raise ValueError("`func` should return a scalar")
-
-        y.append(y_i)
-        result = create_result(X[:i + 1], y, space, rng, specs)
-        if eval_callbacks(callbacks, result):
-            break
-
-    y = np.array(y)
-    return create_result(X, y, space, rng, specs)
+    return base_minimize(func, dimensions, base_estimator=None,
+                         n_calls=n_calls, n_random_starts=n_random_calls,
+                         x0=x0, y0=y0, random_state=random_state,
+                         verbose=verbose,
+                         callback=callback)

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -207,12 +207,8 @@ class Optimizer(object):
 
         if has_gradients(self.base_estimator_) and acq_optimizer != "sampling":
             raise ValueError("The regressor {0} should run with "
-<<<<<<< 393d03b61d4e0981316699374b7c80565db166c9
                              "acq_optimizer"
-                             "='sampling'".format(type(base_estimator)))
-=======
-                             "acq_optimizer='sampling'.".format(type(base_estimator)))
->>>>>>> Add support for random "base estimator" in Optimizer
+                             "='sampling'.".format(type(base_estimator)))
 
         self.acq_optimizer = acq_optimizer
 

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -185,7 +185,7 @@ class Optimizer(object):
         if isinstance(base_estimator, str):
             base_estimator = cook_estimator(
                 base_estimator, space=self.space, random_state=self.rng)
-        if not is_regressor(base_estimator):
+        if not is_regressor(base_estimator) and base_estimator is not None:
             raise ValueError("%s has to be a regressor." % base_estimator)
         self.base_estimator_ = base_estimator
 
@@ -207,8 +207,12 @@ class Optimizer(object):
 
         if has_gradients(self.base_estimator_) and acq_optimizer != "sampling":
             raise ValueError("The regressor {0} should run with "
+<<<<<<< 393d03b61d4e0981316699374b7c80565db166c9
                              "acq_optimizer"
                              "='sampling'".format(type(base_estimator)))
+=======
+                             "acq_optimizer='sampling'.".format(type(base_estimator)))
+>>>>>>> Add support for random "base estimator" in Optimizer
 
         self.acq_optimizer = acq_optimizer
 
@@ -304,7 +308,7 @@ class Optimizer(object):
             if strategy == "cl_min":
                 y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie
             elif strategy == "cl_mean":
-                y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-max lie
+                y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-mean lie
             else:
                 y_lie = np.max(opt.yi) if opt.yi else 0.0  # CL-max lie
             opt.tell(x, y_lie)  # lie to the optimizer
@@ -320,7 +324,7 @@ class Optimizer(object):
         observations have been `tell`ed, after that `base_estimator` is used
         to determine the next point.
         """
-        if self._n_initial_points > 0:
+        if self._n_initial_points > 0 or self.base_estimator_ is None:
             # this will not make a copy of `self.rng` and hence keep advancing
             # our random state.
             return self.space.rvs(random_state=self.rng)[0]
@@ -395,7 +399,8 @@ class Optimizer(object):
 
         # after being "told" n_initial_points we switch from sampling
         # random points to using a surrogate model
-        if fit and self._n_initial_points <= 0:
+        if (fit and self._n_initial_points <= 0 and
+           self.base_estimator_ is not None):
             transformed_bounds = np.array(self.space.transformed_bounds)
             est = clone(self.base_estimator_)
 

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -103,7 +103,7 @@ def test_minimizer_api_dummy_minimize(verbose, call):
                             n_calls=n_calls, random_state=1,
                             verbose=verbose, callback=call)
 
-    assert(result.models is None)
+    assert result.models == []
     check_minimizer_api(result, n_calls)
     check_minimizer_bounds(result, n_calls)
     assert_raise_message(ValueError,

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -133,15 +133,24 @@ def test_exhaust_initial_calls(base_estimator):
     assert x1 != x2
     # second call to tell()
     r2 = opt.tell(x2, 4.)
-    assert len(r2.models) == 1
+    if base_estimator.lower() == 'dummy':
+        assert len(r2.models) == 0
+    else:
+        assert len(r2.models) == 1
     # this is the first non-random point
     x3 = opt.ask()
     assert x2 != x3
     x4 = opt.ask()
-    # no new information was added so should be the same
-    assert x3 == x4
     r3 = opt.tell(x3, 1.)
-    assert len(r3.models) == 2
+    # no new information was added so should be the same, unless we are using
+    # the dummy estimator which will forever return random points and never
+    # fits any models
+    if base_estimator.lower() == 'dummy':
+        assert x3 != x4
+        assert len(r3.models) == 0
+    else:
+        assert x3 == x4
+        assert len(r3.models) == 2
 
 
 @pytest.mark.fast_test

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -148,7 +148,7 @@ def test_optimizer_base_estimator_string_invalid():
     with pytest.raises(ValueError) as e:
         Optimizer([(-2.0, 2.0)], base_estimator="rtr",
                   n_initial_points=1)
-    assert "'RF', 'ET' or 'GP'" in str(e.value)
+    assert "'RF', 'ET', 'GP', 'GBRT' or 'DUMMY'" in str(e.value)
 
 
 @pytest.mark.fast_test

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -14,7 +14,8 @@ from scipy.optimize import OptimizeResult
 TREE_REGRESSORS = (ExtraTreesRegressor(random_state=2),
                    RandomForestRegressor(random_state=2),
                    GradientBoostingQuantileRegressor(random_state=2))
-ESTIMATOR_STRINGS = ["GP", "RF", "ET", "GBRT", "gp", "rf", "et", "gbrt"]
+ESTIMATOR_STRINGS = ["GP", "RF", "ET", "GBRT", "DUMMY",
+                     "gp", "rf", "et", "gbrt", "dummy"]
 
 
 @pytest.mark.fast_test

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -115,10 +115,10 @@ def test_acq_optimizer(base_estimator):
     assert "should run with acq_optimizer='sampling'" in str(e.value)
 
 
-def test_exhaust_initial_calls():
+@pytest.mark.parametrize("base_estimator", ESTIMATOR_STRINGS)
+def test_exhaust_initial_calls(base_estimator):
     # check a model is fitted and used to make suggestions after we added
     # at least n_initial_points via tell()
-    base_estimator = ExtraTreesRegressor(random_state=2)
     opt = Optimizer([(-2.0, 2.0)], base_estimator, n_initial_points=2,
                     acq_optimizer="sampling", random_state=1)
 

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -77,14 +77,14 @@ def test_expected_minimum():
     res = gp_minimize(bench3,
                       [(-2.0, 2.0)],
                       x0=[0.],
-                      noise=0.0,
+                      noise=1e-8,
                       n_calls=20,
                       random_state=1)
 
     x_min, f_min = expected_minimum(res, random_state=1)
     x_min2, f_min2 = expected_minimum(res, random_state=1)
 
-    assert f_min <= res.fun  # true since noise=0.0
+    assert f_min <= res.fun  # true since noise ~= 0.0
     assert x_min == x_min2
     assert f_min == f_min2
 


### PR DESCRIPTION
Fixes #406 

This removes the need to special case dummy_minimize by adding
the ability to switch to supplying only random suggestions in
the Optimizer class.

Still uses `None`, needs changing to "dummy".