### PR TITLE
[MRG+1] Refactoring dimension transformations in `gp_minimize` to be used by `Optimizer`.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    repo: scikit-optimize/scikit-optimize
+    repo: scikit-optimize
     condition: "$PYTHON_VERSION = 3.5"
   password:
     secure: "NoybLUwpiDZAQAWkhd9IL0NnwbvW5Hy9cPumcVT3ZS7LJRGmb/zJfQajSIA7kf5RGGbydtCnKD82Mj5A9e1BRVgN6OEl7PJQD5EKCcFpaifnm5romTPN9i+BUeZz+mLpZUJbIANb6L3eBWqMthdsw1r6FR95YDL8mgVXvAqOA+7Inm4b+NssXK6XLyqwrN56UK1TT2oppCdKAVBk02oG/moF5czGbSHsNdcTpDHCPN7xJB/R4qxkvIa1z8WcsSjgpj2rhpCGmGM/XBpueROqvcycUOvG1nSNUn7q3/miOdZDCQvZkNSU10UlB+b3Yva3y1baGaNILYie0CC4dgVhWTSZI12fOfl9jCMzOLZAOPQghb+BjnVzxrHQHJeMFQR3VqXdSYY8basASfK/981siaVkXkEFnbKichEUtEHrDYgYCXCFGhA3GEDMQhvhqw2v3FTL3xN8VgVWjJUM4L/RRbJiXADXuxzb9/3v6PehF1NlSzEnwO5m7GuFbkPNBwZGuoMF0wQmLx5vb0E1T29R0oMHGe3k7BLhaFnMMii3bnPaSCWSsBE88Z1Bcwjs45JYgbWXZQG0ManeLEvM2digaQ0WDtkkjHqRjTeRR7f5+BvB0/meDZwW4XUccB8gCFDWC/jivLAwF8WRxpSLYBBUvfUax//OkKpzbHDsaZZh8i0="

--- a/.travis.yml
+++ b/.travis.yml
@@ -35,7 +35,7 @@ deploy:
   distributions: sdist bdist_wheel
   on:
     tags: true
-    repo: scikit-optimize
+    repo: scikit-optimize/scikit-optimize
     condition: "$PYTHON_VERSION = 3.5"
   password:
     secure: "NoybLUwpiDZAQAWkhd9IL0NnwbvW5Hy9cPumcVT3ZS7LJRGmb/zJfQajSIA7kf5RGGbydtCnKD82Mj5A9e1BRVgN6OEl7PJQD5EKCcFpaifnm5romTPN9i+BUeZz+mLpZUJbIANb6L3eBWqMthdsw1r6FR95YDL8mgVXvAqOA+7Inm4b+NssXK6XLyqwrN56UK1TT2oppCdKAVBk02oG/moF5czGbSHsNdcTpDHCPN7xJB/R4qxkvIa1z8WcsSjgpj2rhpCGmGM/XBpueROqvcycUOvG1nSNUn7q3/miOdZDCQvZkNSU10UlB+b3Yva3y1baGaNILYie0CC4dgVhWTSZI12fOfl9jCMzOLZAOPQghb+BjnVzxrHQHJeMFQR3VqXdSYY8basASfK/981siaVkXkEFnbKichEUtEHrDYgYCXCFGhA3GEDMQhvhqw2v3FTL3xN8VgVWjJUM4L/RRbJiXADXuxzb9/3v6PehF1NlSzEnwO5m7GuFbkPNBwZGuoMF0wQmLx5vb0E1T29R0oMHGe3k7BLhaFnMMii3bnPaSCWSsBE88Z1Bcwjs45JYgbWXZQG0ManeLEvM2digaQ0WDtkkjHqRjTeRR7f5+BvB0/meDZwW4XUccB8gCFDWC/jivLAwF8WRxpSLYBBUvfUax//OkKpzbHDsaZZh8i0="

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -9,7 +9,6 @@ from ..space import Space
 from ..utils import cook_estimator
 from ..utils import normalize_dimensions
 
-
 def gp_minimize(func, dimensions, base_estimator=None,
                 n_calls=100, n_random_starts=10,
                 acq_func="gp_hedge", acq_optimizer="auto", x0=None, y0=None,

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -7,6 +7,7 @@ from ..space import check_dimension
 from ..space import Categorical
 from ..space import Space
 from ..utils import cook_estimator
+from ..utils import normalize_dimensions
 
 
 def gp_minimize(func, dimensions, base_estimator=None,
@@ -206,26 +207,7 @@ def gp_minimize(func, dimensions, base_estimator=None,
     """
     # Check params
     rng = check_random_state(random_state)
-
-    dim_types = [check_dimension(d) for d in dimensions]
-    is_cat = all([isinstance(check_dimension(d), Categorical)
-                  for d in dim_types])
-    if is_cat:
-        transformed_dims = [check_dimension(d, transform="identity")
-                            for d in dimensions]
-    else:
-        transformed_dims = []
-        for dim_type, dim in zip(dim_types, dimensions):
-            if isinstance(dim_type, Categorical):
-                transformed_dims.append(
-                    check_dimension(dim, transform="onehot")
-                    )
-            # To make sure that GP operates in the [0, 1] space
-            else:
-                transformed_dims.append(
-                    check_dimension(dim, transform="normalize")
-                    )
-
+    transformed_dims = normalize_dimensions(dimensions)
     space = Space(transformed_dims)
     base_estimator = cook_estimator("GP", space=space, random_state=rng,
                                     noise=noise)

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -9,6 +9,7 @@ from ..space import Space
 from ..utils import cook_estimator
 from ..utils import normalize_dimensions
 
+
 def gp_minimize(func, dimensions, base_estimator=None,
                 n_calls=100, n_random_starts=10,
                 acq_func="gp_hedge", acq_optimizer="auto", x0=None, y0=None,

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -131,7 +131,7 @@ class Optimizer(object):
         to sample points, bounds, and type of parameters.
 
     """
-    def __init__(self, dimensions, base_estimator="gp",
+    def __init__(self, dimensions, base_estimator="GP",
                  n_random_starts=None, n_initial_points=10,
                  acq_func="gp_hedge",
                  acq_optimizer="auto",
@@ -174,7 +174,7 @@ class Optimizer(object):
         self._check_arguments(base_estimator, n_initial_points, acq_optimizer)
         self.n_jobs = n_jobs
 
-        if base_estimator == "gp":
+        if base_estimator == "GP":
             dimensions = normalize_dimensions(dimensions)
         self.space = Space(dimensions)
         self.models = []

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -22,6 +22,7 @@ from ..utils import create_result
 from ..utils import has_gradients
 from ..utils import is_listlike
 from ..utils import is_2Dlistlike
+from ..utils import normalize_dimensions
 
 
 class Optimizer(object):
@@ -131,7 +132,7 @@ class Optimizer(object):
         to sample points, bounds, and type of parameters.
 
     """
-    def __init__(self, dimensions, base_estimator="gp",
+    def __init__(self, dimensions, base_estimator="GP",
                  n_random_starts=None, n_initial_points=10,
                  acq_func="gp_hedge",
                  acq_optimizer="auto",
@@ -165,6 +166,8 @@ class Optimizer(object):
         n_jobs = acq_optimizer_kwargs.get("n_jobs", 1)
         self.acq_optimizer_kwargs = acq_optimizer_kwargs
 
+        if base_estimator == "GP":
+            dimensions = normalize_dimensions(dimensions)
         self.space = Space(dimensions)
         self.models = []
         self.Xi = []

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -288,7 +288,7 @@ class Optimizer(object):
                https://hal.archives-ouvertes.fr/hal-00732512/document
 
                With this strategy a copy of optimizer is created, which is
-               then asked for a point, and the point is told to the copy of
+               then ed for a point, and the point is told to the copy of
                optimizer with some fake objective (lie), the next point is
                asked from copy, it is also told to the copy with fake
                objective and so on. The type of lie defines different

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -132,7 +132,7 @@ class Optimizer(object):
         to sample points, bounds, and type of parameters.
 
     """
-    def __init__(self, dimensions, base_estimator="GP",
+    def __init__(self, dimensions, base_estimator="gp",
                  n_random_starts=None, n_initial_points=10,
                  acq_func="gp_hedge",
                  acq_optimizer="auto",

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -24,7 +24,6 @@ from ..utils import is_listlike
 from ..utils import is_2Dlistlike
 from ..utils import normalize_dimensions
 
-
 class Optimizer(object):
     """Run bayesian optimisation loop.
 

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -24,6 +24,7 @@ from ..utils import is_listlike
 from ..utils import is_2Dlistlike
 from ..utils import normalize_dimensions
 
+
 class Optimizer(object):
     """Run bayesian optimisation loop.
 
@@ -173,7 +174,7 @@ class Optimizer(object):
 
         if base_estimator == "GP":
             dimensions = normalize_dimensions(dimensions)
-            
+
         self.space = Space(dimensions)
         self.models = []
         self.Xi = []

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -131,7 +131,7 @@ class Optimizer(object):
         to sample points, bounds, and type of parameters.
 
     """
-    def __init__(self, dimensions, base_estimator="GP",
+    def __init__(self, dimensions, base_estimator="gp",
                  n_random_starts=None, n_initial_points=10,
                  acq_func="gp_hedge",
                  acq_optimizer="auto",
@@ -197,7 +197,6 @@ class Optimizer(object):
 
         self._check_arguments(base_estimator, n_initial_points, acq_optimizer)
         self.n_jobs = n_jobs
-
 
         # The cache of responses of `ask` method for n_points not None.
         # This ensures that multiple calls to `ask` with n_points set

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -165,6 +165,15 @@ class Optimizer(object):
         n_jobs = acq_optimizer_kwargs.get("n_jobs", 1)
         self.acq_optimizer_kwargs = acq_optimizer_kwargs
 
+        if n_random_starts is not None:
+            warnings.warn(("n_random_starts will be removed in favour of "
+                           "n_initial_points."),
+                          DeprecationWarning)
+            n_initial_points = n_random_starts
+
+        self._check_arguments(base_estimator, n_initial_points, acq_optimizer)
+        self.n_jobs = n_jobs
+
         if base_estimator == "GP":
             dimensions = normalize_dimensions(dimensions)
         self.space = Space(dimensions)
@@ -179,15 +188,6 @@ class Optimizer(object):
                 self._cat_inds.append(ind)
             else:
                 self._non_cat_inds.append(ind)
-
-        if n_random_starts is not None:
-            warnings.warn(("n_random_starts will be removed in favour of "
-                           "n_initial_points."),
-                          DeprecationWarning)
-            n_initial_points = n_random_starts
-
-        self._check_arguments(base_estimator, n_initial_points, acq_optimizer)
-        self.n_jobs = n_jobs
 
         # The cache of responses of `ask` method for n_points not None.
         # This ensures that multiple calls to `ask` with n_points set

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -174,7 +174,7 @@ class Optimizer(object):
         self._check_arguments(base_estimator, n_initial_points, acq_optimizer)
         self.n_jobs = n_jobs
 
-        if base_estimator == "GP":
+        if base_estimator == "gp":
             dimensions = normalize_dimensions(dimensions)
         self.space = Space(dimensions)
         self.models = []

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -189,6 +189,16 @@ class Optimizer(object):
             else:
                 self._non_cat_inds.append(ind)
 
+        if n_random_starts is not None:
+            warnings.warn(("n_random_starts will be removed in favour of "
+                           "n_initial_points."),
+                          DeprecationWarning)
+            n_initial_points = n_random_starts
+
+        self._check_arguments(base_estimator, n_initial_points, acq_optimizer)
+        self.n_jobs = n_jobs
+
+
         # The cache of responses of `ask` method for n_points not None.
         # This ensures that multiple calls to `ask` with n_points set
         # return same sets of points.
@@ -287,7 +297,7 @@ class Optimizer(object):
                https://hal.archives-ouvertes.fr/hal-00732512/document
 
                With this strategy a copy of optimizer is created, which is
-               then ed for a point, and the point is told to the copy of
+               then asked for a point, and the point is told to the copy of
                optimizer with some fake objective (lie), the next point is
                asked from copy, it is also told to the copy with fake
                objective and so on. The type of lie defines different

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -456,7 +456,7 @@ def normalize_dimensions(dimensions):
     if isinstance(base_estimator, str):
         base_estimator = base_estimator.upper()
         if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for the base_estimator parameter "
+            raise ValueError("Valid strings for the base_estimator parameter " +
                              "are: 'RF', 'ET', 'GBRT', or 'GP'.")
     elif not is_regressor(base_estimator):
         raise ValueError("base_estimator has to be a regressor.")

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -17,6 +17,9 @@ from .learning.gaussian_process.kernels import ConstantKernel
 from .learning.gaussian_process.kernels import HammingKernel
 from .learning.gaussian_process.kernels import Matern
 
+from ..space import check_dimension
+from ..space import Categorical
+
 __all__ = (
     "load",
     "dump",
@@ -299,6 +302,8 @@ def cook_estimator(base_estimator, space=None, **kwargs):
         raise ValueError("base_estimator has to be a regressor.")
 
     if base_estimator == "GP":
+        if space is not None:
+
         cov_amplitude = ConstantKernel(1.0, (0.01, 1000.0))
         if is_cat:
             other_kernel = HammingKernel(length_scale=np.ones(n_dims))
@@ -327,6 +332,7 @@ def cook_estimator(base_estimator, space=None, **kwargs):
     base_estimator.set_params(**kwargs)
     return base_estimator
 
+<<<<<<< HEAD
 
 def dimensions_aslist(search_space):
     """Convert a dict representation of a search space into a list of
@@ -421,3 +427,45 @@ def point_aslist(search_space, point_as_dict):
         point_as_dict[k] for k in sorted(search_space.keys())
     ]
     return point_as_list
+=======
+def transform_gpdims(dimensions):
+    """
+    Transforms space for Gaussian processes.
+
+    Parameters
+    ----------
+    * `dimensions` [list, shape=(n_dims,)]:
+        List of search space dimensions.
+        Each search dimension can be defined either as
+
+        - a `(upper_bound, lower_bound)` tuple (for `Real` or `Integer`
+          dimensions),
+        - a `(upper_bound, lower_bound, "prior")` tuple (for `Real`
+          dimensions),
+        - as a list of categories (for `Categorical` dimensions), or
+        - an instance of a `Dimension` object (`Real`, `Integer` or
+          `Categorical`).
+
+         NOTE: The upper and lower bounds are inclusive for `Integer`
+         dimensions.
+    """
+    dim_types = [check_dimension(d) for d in dimensions]
+    is_cat = all([isinstance(check_dimension(d), Categorical)
+                  for d in dim_types])
+    if is_cat:
+        transformed_dims = [check_dimension(d, transform="identity")
+                            for d in dimensions]
+    else:
+        transformed_dims = []
+        for dim_type, dim in zip(dim_types, dimensions):
+            if isinstance(dim_type, Categorical):
+                transformed_dims.append(
+                    check_dimension(dim, transform="onehot")
+                    )
+            # To make sure that GP operates in the [0, 1] space
+            else:
+                transformed_dims.append(
+                    check_dimension(dim, transform="normalize")
+                    )
+    return transformed_dims
+>>>>>>> Refactoring transformation for gp dimensions for gp_minimize and Optimizer

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -419,9 +419,9 @@ def normalize_dimensions(dimensions):
     """
     if isinstance(estimator, str):
         estimator = estimator.upper()
-        if estimator not in ["GP", "ET", "RF"]:
+        if estimator not in ["GP", "ET", "RF", "GBRT"]:
             raise ValueError("Valid strings for estimator parameter "
-                             " are: 'RF', 'ET' or 'GP', not %s" % estimator)
+                             "are: 'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
     elif not is_regressor(estimator):
         raise ValueError("estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -419,9 +419,9 @@ def normalize_dimensions(dimensions):
     """
     if isinstance(estimator, str):
         estimator = estimator.upper()
-        if estimator not in ["GP", "ET", "RF", "GBRT"]:
+        if estimator not in ["GP", "ET", "RF"]:
             raise ValueError("Valid strings for estimator parameter "
-                             " are: 'RF, 'ET' or 'GP', not %s" % estimator)
+                             " are: 'RF', 'ET' or 'GP', not %s" % estimator)
     elif not is_regressor(estimator):
         raise ValueError("estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -17,8 +17,8 @@ from .learning.gaussian_process.kernels import ConstantKernel
 from .learning.gaussian_process.kernels import HammingKernel
 from .learning.gaussian_process.kernels import Matern
 
-from ..space import check_dimension
-from ..space import Categorical
+from .space import check_dimension
+from .space import Categorical
 
 __all__ = (
     "load",

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -360,6 +360,7 @@ def point_asdict(search_space, point_as_list):
     """Convert the list representation of a point from a search space
     to the dictionary representation, where keys are dimension names
     and values are corresponding to the values of dimensions in the list.
+
     Counterpart to parameters_aslist.
 
     Parameters

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -469,4 +469,6 @@ def normalize_dimensions(dimensions):
                     transformed_dims.append(
                         check_dimension(dim, transform="normalize")
                         )
+    else:
+        transformed_dims = dimensions
     return transformed_dims

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -453,15 +453,15 @@ def normalize_dimensions(dimensions):
         optimization estimator to be used.
         each estimator may use different transformations for dimensions.
     """
-    if isinstance(base_estimator, str):
-        base_estimator = base_estimator.upper()
-        if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
+    if isinstance(estimator, str):
+        estimator = base_estimator.upper()
+        if estimator not in ["GP", "ET", "RF", "GBRT"]:
             raise ValueError("Valid strings for base_estimator parameter "
                              " are: 'RF, 'ET' or 'GP', not %s" % base_estimator)
-    elif not is_regressor(base_estimator):
-        raise ValueError("base_estimator has to be a regressor.")
+    elif not is_regressor(estimator):
+        raise ValueError("estimator has to be a regressor.")
 
-    if estimator == "GP":
+    if estimator == "GP" or estimator == GaussianProcessRegressor: 
         dim_types = [check_dimension(d) for d in dimensions]
         is_cat = all([isinstance(check_dimension(d), Categorical)
                       for d in dim_types])

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -302,8 +302,6 @@ def cook_estimator(base_estimator, space=None, **kwargs):
         raise ValueError("base_estimator has to be a regressor.")
 
     if base_estimator == "GP":
-        if space is not None:
-
         cov_amplitude = ConstantKernel(1.0, (0.01, 1000.0))
         if is_cat:
             other_kernel = HammingKernel(length_scale=np.ones(n_dims))

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -457,7 +457,7 @@ def normalize_dimensions(dimensions):
         base_estimator = base_estimator.upper()
         if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
             raise ValueError("Valid strings for the base_estimator parameter "
-                   "are: 'RF', 'ET', 'GBRT', or 'GP'.")
+                             "are: 'RF', 'ET', 'GBRT', or 'GP'.")
     elif not is_regressor(base_estimator):
         raise ValueError("base_estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -456,8 +456,8 @@ def normalize_dimensions(dimensions):
     if isinstance(estimator, str):
         estimator = estimator.upper()
         if estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for base_estimator parameter "
-                             " are: 'RF, 'ET' or 'GP', not %s" % base_estimator)
+            raise ValueError("Valid strings for estimator parameter "
+                             " are: 'RF, 'ET' or 'GP', not %s" % estimator)
     elif not is_regressor(estimator):
         raise ValueError("estimator has to be a regressor.")
 
@@ -483,87 +483,3 @@ def normalize_dimensions(dimensions):
     else:
         transformed_dims = dimensions
     return transformed_dims
-
-def dimensions_aslist(search_space):
-    """Convert a dict representation of a search space into a list of
-    dimensions, ordered by sorted(search_space.keys()).
-    Parameters
-    ----------
-    search_space : dict
-        Represents search space. The keys are dimension names (strings)
-        and values are instances of classes that inherit from the class
-        skopt.space.Dimension (Real, Integer or Categorical)
-        Example:
-            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
-    Returns
-    -------
-    params_space_list: list of skopt.space.Dimension instances.
-        Example output with example inputs:
-            [Real(0,1), Integer(2,4), Real(-1,1)]
-    """
-    params_space_list = [
-        search_space[k] for k in sorted(search_space.keys())
-    ]
-    return params_space_list
-
-
-def point_asdict(search_space, point_as_list):
-    """Convert the list representation of a point from a search space
-    to the dictionary representation, where keys are dimension names
-    and values are corresponding to the values of dimensions in the list.
-    Counterpart to parameters_aslist.
-    Parameters
-    ----------
-    search_space : dict
-        Represents search space. The keys are dimension names (strings)
-        and values are instances of classes that inherit from the class
-        skopt.space.Dimension (Real, Integer or Categorical)
-        Example:
-            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
-    point_as_list : list
-        list with parameter values.The order of parameters in the list
-        is given by sorted(params_space.keys()).
-        Example:
-            [0.66, 3, -0.15]
-    Returns
-    -------
-    params_dict: dictionary with parameter names as keys to which
-        corresponding parameter values are assigned.
-        Example output with inputs:
-            {'name1': 0.66, 'name2': 3, 'name3': -0.15}
-    """
-    params_dict = {
-        k: v for k, v in zip(sorted(search_space.keys()), point_as_list)
-    }
-    return params_dict
-
-
-def point_aslist(search_space, point_as_dict):
-    """Convert a dictionary representation of a point from a search space to
-    the list representation. The list of values is created from the values of
-    the dictionary, sorted by the names of dimensions used as keys.
-    Counterpart to parameters_asdict.
-    Parameters
-    ----------
-    search_space : dict
-        Represents search space. The keys are dimension names (strings)
-        and values are instances of classes that inherit from the class
-        skopt.space.Dimension (Real, Integer or Categorical)
-        Example:
-            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
-    point_as_dict : dict
-        dict with parameter names as keys to which corresponding
-        parameter values are assigned.
-        Example:
-            {'name1': 0.66, 'name2': 3, 'name3': -0.15}
-    Returns
-    -------
-    point_as_list: list with point values.The order of
-        parameters in the list is given by sorted(params_space.keys()).
-        Example output with example inputs:
-            [0.66, 3, -0.15]
-    """
-    point_as_list = [
-        point_as_dict[k] for k in sorted(search_space.keys())
-    ]
-    return point_as_list

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -458,8 +458,8 @@ def normalize_dimensions(dimensions):
         if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
             raise ValueError("Valid strings for base_estimator parameter "
                              " are: 'RF, 'ET' or 'GP', not %s" % base_estimator)
-        elif not is_regressor(base_estimator):
-            raise ValueError("base_estimator has to be a regressor.")
+    elif not is_regressor(base_estimator):
+        raise ValueError("base_estimator has to be a regressor.")
 
     if estimator == "GP" or estimator == GaussianProcessRegressor:
         dim_types = [check_dimension(d) for d in dimensions]

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -332,7 +332,6 @@ def cook_estimator(base_estimator, space=None, **kwargs):
     base_estimator.set_params(**kwargs)
     return base_estimator
 
-<<<<<<< HEAD
 
 def dimensions_aslist(search_space):
     """Convert a dict representation of a search space into a list of
@@ -427,8 +426,9 @@ def point_aslist(search_space, point_as_dict):
         point_as_dict[k] for k in sorted(search_space.keys())
     ]
     return point_as_list
-=======
-def transform_gpdims(dimensions):
+
+
+def normalize_dimensions(dimensions):
     """
     Transforms space for Gaussian processes.
 
@@ -468,4 +468,3 @@ def transform_gpdims(dimensions):
                     check_dimension(dim, transform="normalize")
                     )
     return transformed_dims
->>>>>>> Refactoring transformation for gp dimensions for gp_minimize and Optimizer

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -420,9 +420,8 @@ def normalize_dimensions(dimensions):
     if isinstance(estimator, str):
         estimator = estimator.upper()
         if estimator not in ["GP", "ET", "RF", "GBRT"]:
-            assert "'RF', 'ET' or 'GP'" in str(estimator)
-            #raise ValueError("Valid strings for estimator parameter "
-            #                 "are: 'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
+            raise ValueError("Valid strings for estimator parameter "
+                             "are: 'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
     elif not is_regressor(estimator):
         raise ValueError("estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -25,7 +25,6 @@ __all__ = (
     "dump",
 )
 
-
 def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
     """
     Initialize an `OptimizeResult` object.
@@ -428,7 +427,10 @@ def point_aslist(search_space, point_as_dict):
 
 def normalize_dimensions(dimensions):
     """
-    Transforms space for Gaussian processes.
+    Normalize all dimensions.
+
+    This is particularly useful for Gaussian process based regressors and is used
+    internally by `gp_minimize.`
 
     Parameters
     ----------
@@ -446,11 +448,20 @@ def normalize_dimensions(dimensions):
 
          NOTE: The upper and lower bounds are inclusive for `Integer`
          dimensions.
-    * `estimator` [str, ]:
+
+    * `estimator` ["GP", "RF", "ET", "GBRT", or sklearn regressor, default="GP"]:
         optimization estimator to be used.
         each estimator may use different transformations for dimensions.
     """
-    if estimator == "GP":
+    if isinstance(base_estimator, str):
+        base_estimator = base_estimator.upper()
+        if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
+            raise ValueError("Valid strings for base_estimator parameter "
+                             " are: 'RF, 'ET' or 'GP', not %s" % base_estimator)
+        elif not is_regressor(base_estimator):
+            raise ValueError("base_estimator has to be a regressor.")
+
+    if estimator == "GP" or estimator == GaussianProcessRegressor:
         dim_types = [check_dimension(d) for d in dimensions]
         is_cat = all([isinstance(check_dimension(d), Categorical)
                       for d in dim_types])

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -420,8 +420,9 @@ def normalize_dimensions(dimensions):
     if isinstance(estimator, str):
         estimator = estimator.upper()
         if estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for estimator parameter "
-                             "are: 'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
+            assert "'RF', 'ET' or 'GP'" in str(estimator)
+            #raise ValueError("Valid strings for estimator parameter "
+            #                 "are: 'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
     elif not is_regressor(estimator):
         raise ValueError("estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -461,7 +461,7 @@ def normalize_dimensions(dimensions):
     elif not is_regressor(base_estimator):
         raise ValueError("base_estimator has to be a regressor.")
 
-    if estimator == "GP" or estimator == GaussianProcessRegressor:
+    if estimator == "GP":
         dim_types = [check_dimension(d) for d in dimensions]
         is_cat = all([isinstance(check_dimension(d), Categorical)
                       for d in dim_types])

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -454,14 +454,14 @@ def normalize_dimensions(dimensions):
         each estimator may use different transformations for dimensions.
     """
     if isinstance(estimator, str):
-        estimator = base_estimator.upper()
+        estimator = estimator.upper()
         if estimator not in ["GP", "ET", "RF", "GBRT"]:
             raise ValueError("Valid strings for base_estimator parameter "
                              " are: 'RF, 'ET' or 'GP', not %s" % base_estimator)
     elif not is_regressor(estimator):
         raise ValueError("estimator has to be a regressor.")
 
-    if estimator == "GP" or estimator == GaussianProcessRegressor: 
+    if estimator == "GP" or estimator == GaussianProcessRegressor:
         dim_types = [check_dimension(d) for d in dimensions]
         is_cat = all([isinstance(check_dimension(d), Categorical)
                       for d in dim_types])

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -456,8 +456,8 @@ def normalize_dimensions(dimensions):
     if isinstance(base_estimator, str):
         base_estimator = base_estimator.upper()
         if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for the base_estimator parameter \
-                              are: 'RF', 'ET','GBRT', or 'GP'.")
+            raise ValueError("Valid strings for the base_estimator parameter "
+                   "are: 'RF', 'ET', 'GBRT', or 'GP'.")
     elif not is_regressor(base_estimator):
         raise ValueError("base_estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -390,7 +390,46 @@ def point_asdict(search_space, point_as_list):
     return params_dict
 
 
+<<<<<<< HEAD
 def normalize_dimensions(dimensions):
+=======
+def point_aslist(search_space, point_as_dict):
+    """Convert a dictionary representation of a point from a search space to
+    the list representation. The list of values is created from the values of
+    the dictionary, sorted by the names of dimensions used as keys.
+
+    Counterpart to parameters_asdict.
+
+    Parameters
+    ----------
+    search_space : dict
+        Represents search space. The keys are dimension names (strings)
+        and values are instances of classes that inherit from the class
+        skopt.space.Dimension (Real, Integer or Categorical)
+        Example:
+            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
+
+    point_as_dict : dict
+        dict with parameter names as keys to which corresponding
+        parameter values are assigned.
+        Example:
+            {'name1': 0.66, 'name2': 3, 'name3': -0.15}
+
+    Returns
+    -------
+    point_as_list: list with point values.The order of
+        parameters in the list is given by sorted(params_space.keys()).
+        Example output with example inputs:
+            [0.66, 3, -0.15]
+    """
+    point_as_list = [
+        point_as_dict[k] for k in sorted(search_space.keys())
+    ]
+    return point_as_list
+
+
+def normalize_dimensions(dimensions, base_estimator="GP"):
+>>>>>>> swapping argument name for consistency and matching error statements.
     """
     Normalize all dimensions.
 
@@ -414,19 +453,19 @@ def normalize_dimensions(dimensions):
          NOTE: The upper and lower bounds are inclusive for `Integer`
          dimensions.
 
-    * `estimator` ["GP", "RF", "ET", "GBRT", or sklearn regressor, default="GP"]:
+    * `base_estimator` ["GP", "RF", "ET", "GBRT", or sklearn regressor, default="GP"]:
         optimization estimator to be used.
         each estimator may use different transformations for dimensions.
     """
-    if isinstance(estimator, str):
-        estimator = estimator.upper()
-        if estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for the estimator parameter are: \
-                              'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
-    elif not is_regressor(estimator):
-        raise ValueError("estimator has to be a regressor.")
+    if isinstance(base_estimator, str):
+        base_estimator = base_estimator.upper()
+        if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
+            raise ValueError("Valid strings for the base_estimator parameter are: \
+                              'RF', 'ET','GBRT', or 'GP', not %s." % base_estimator)
+    elif not is_regressor(base_estimator):
+        raise ValueError("base_estimator has to be a regressor.")
 
-    if estimator == "GP" or estimator == GaussianProcessRegressor:
+    if base_estimator == "GP" or base_estimator == GaussianProcessRegressor:
         dim_types = [check_dimension(d) for d in dimensions]
         is_cat = all([isinstance(check_dimension(d), Categorical)
                       for d in dim_types])

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -483,3 +483,87 @@ def normalize_dimensions(dimensions):
     else:
         transformed_dims = dimensions
     return transformed_dims
+
+def dimensions_aslist(search_space):
+    """Convert a dict representation of a search space into a list of
+    dimensions, ordered by sorted(search_space.keys()).
+    Parameters
+    ----------
+    search_space : dict
+        Represents search space. The keys are dimension names (strings)
+        and values are instances of classes that inherit from the class
+        skopt.space.Dimension (Real, Integer or Categorical)
+        Example:
+            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
+    Returns
+    -------
+    params_space_list: list of skopt.space.Dimension instances.
+        Example output with example inputs:
+            [Real(0,1), Integer(2,4), Real(-1,1)]
+    """
+    params_space_list = [
+        search_space[k] for k in sorted(search_space.keys())
+    ]
+    return params_space_list
+
+
+def point_asdict(search_space, point_as_list):
+    """Convert the list representation of a point from a search space
+    to the dictionary representation, where keys are dimension names
+    and values are corresponding to the values of dimensions in the list.
+    Counterpart to parameters_aslist.
+    Parameters
+    ----------
+    search_space : dict
+        Represents search space. The keys are dimension names (strings)
+        and values are instances of classes that inherit from the class
+        skopt.space.Dimension (Real, Integer or Categorical)
+        Example:
+            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
+    point_as_list : list
+        list with parameter values.The order of parameters in the list
+        is given by sorted(params_space.keys()).
+        Example:
+            [0.66, 3, -0.15]
+    Returns
+    -------
+    params_dict: dictionary with parameter names as keys to which
+        corresponding parameter values are assigned.
+        Example output with inputs:
+            {'name1': 0.66, 'name2': 3, 'name3': -0.15}
+    """
+    params_dict = {
+        k: v for k, v in zip(sorted(search_space.keys()), point_as_list)
+    }
+    return params_dict
+
+
+def point_aslist(search_space, point_as_dict):
+    """Convert a dictionary representation of a point from a search space to
+    the list representation. The list of values is created from the values of
+    the dictionary, sorted by the names of dimensions used as keys.
+    Counterpart to parameters_asdict.
+    Parameters
+    ----------
+    search_space : dict
+        Represents search space. The keys are dimension names (strings)
+        and values are instances of classes that inherit from the class
+        skopt.space.Dimension (Real, Integer or Categorical)
+        Example:
+            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
+    point_as_dict : dict
+        dict with parameter names as keys to which corresponding
+        parameter values are assigned.
+        Example:
+            {'name1': 0.66, 'name2': 3, 'name3': -0.15}
+    Returns
+    -------
+    point_as_list: list with point values.The order of
+        parameters in the list is given by sorted(params_space.keys()).
+        Example output with example inputs:
+            [0.66, 3, -0.15]
+    """
+    point_as_list = [
+        point_as_dict[k] for k in sorted(search_space.keys())
+    ]
+    return point_as_list

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -446,23 +446,27 @@ def normalize_dimensions(dimensions):
 
          NOTE: The upper and lower bounds are inclusive for `Integer`
          dimensions.
+    * `estimator` [str, ]:
+        optimization estimator to be used.
+        each estimator may use different transformations for dimensions.
     """
-    dim_types = [check_dimension(d) for d in dimensions]
-    is_cat = all([isinstance(check_dimension(d), Categorical)
-                  for d in dim_types])
-    if is_cat:
-        transformed_dims = [check_dimension(d, transform="identity")
-                            for d in dimensions]
-    else:
-        transformed_dims = []
-        for dim_type, dim in zip(dim_types, dimensions):
-            if isinstance(dim_type, Categorical):
-                transformed_dims.append(
-                    check_dimension(dim, transform="onehot")
-                    )
-            # To make sure that GP operates in the [0, 1] space
-            else:
-                transformed_dims.append(
-                    check_dimension(dim, transform="normalize")
-                    )
+    if estimator == "GP":
+        dim_types = [check_dimension(d) for d in dimensions]
+        is_cat = all([isinstance(check_dimension(d), Categorical)
+                      for d in dim_types])
+        if is_cat:
+            transformed_dims = [check_dimension(d, transform="identity")
+                                for d in dimensions]
+        else:
+            transformed_dims = []
+            for dim_type, dim in zip(dim_types, dimensions):
+                if isinstance(dim_type, Categorical):
+                    transformed_dims.append(
+                        check_dimension(dim, transform="onehot")
+                        )
+                # To make sure that GP operates in the [0, 1] space
+                else:
+                    transformed_dims.append(
+                        check_dimension(dim, transform="normalize")
+                        )
     return transformed_dims

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -448,38 +448,23 @@ def normalize_dimensions(dimensions):
 
          NOTE: The upper and lower bounds are inclusive for `Integer`
          dimensions.
-
-    * `base_estimator` ["GP", "RF", "ET", "GBRT", or sklearn regressor, default="GP"]:
-        optimization estimator to be used.
-        each estimator may use different transformations for dimensions.
     """
-    if isinstance(base_estimator, str):
-        base_estimator = base_estimator.upper()
-        if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for the base_estimator parameter " +
-                             "are: 'RF', 'ET', 'GBRT', or 'GP'.")
-    elif not is_regressor(base_estimator):
-        raise ValueError("base_estimator has to be a regressor.")
-
-    if base_estimator == "GP" or base_estimator == GaussianProcessRegressor:
-        dim_types = [check_dimension(d) for d in dimensions]
-        is_cat = all([isinstance(check_dimension(d), Categorical)
-                      for d in dim_types])
-        if is_cat:
-            transformed_dims = [check_dimension(d, transform="identity")
-                                for d in dimensions]
-        else:
-            transformed_dims = []
-            for dim_type, dim in zip(dim_types, dimensions):
-                if isinstance(dim_type, Categorical):
-                    transformed_dims.append(
-                        check_dimension(dim, transform="onehot")
-                        )
-                # To make sure that GP operates in the [0, 1] space
-                else:
-                    transformed_dims.append(
-                        check_dimension(dim, transform="normalize")
-                        )
+    dim_types = [check_dimension(d) for d in dimensions]
+    is_cat = all([isinstance(check_dimension(d), Categorical)
+                  for d in dim_types])
+    if is_cat:
+        transformed_dims = [check_dimension(d, transform="identity")
+                            for d in dimensions]
     else:
-        transformed_dims = dimensions
+        transformed_dims = []
+        for dim_type, dim in zip(dim_types, dimensions):
+            if isinstance(dim_type, Categorical):
+                transformed_dims.append(
+                    check_dimension(dim, transform="onehot")
+                    )
+            # To make sure that GP operates in the [0, 1] space
+            else:
+                transformed_dims.append(
+                    check_dimension(dim, transform="normalize")
+                    )
     return transformed_dims

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -329,7 +329,7 @@ def cook_estimator(base_estimator, space=None, **kwargs):
 
     base_estimator.set_params(**kwargs)
     return base_estimator
-    
+
 
 def dimensions_aslist(search_space):
     """Convert a dict representation of a search space into a list of

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -25,6 +25,7 @@ __all__ = (
     "dump",
 )
 
+
 def create_result(Xi, yi, space=None, rng=None, specs=None, models=None):
     """
     Initialize an `OptimizeResult` object.
@@ -420,8 +421,8 @@ def normalize_dimensions(dimensions):
     if isinstance(estimator, str):
         estimator = estimator.upper()
         if estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for estimator parameter "
-                             "are: 'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
+            raise ValueError("Valid strings for the estimator parameter are: \
+                              'RF', 'ET', 'GBRT', or 'GP', not %s" % estimator)
     elif not is_regressor(estimator):
         raise ValueError("estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -390,9 +390,6 @@ def point_asdict(search_space, point_as_list):
     return params_dict
 
 
-<<<<<<< HEAD
-def normalize_dimensions(dimensions):
-=======
 def point_aslist(search_space, point_as_dict):
     """Convert a dictionary representation of a point from a search space to
     the list representation. The list of values is created from the values of
@@ -428,8 +425,7 @@ def point_aslist(search_space, point_as_dict):
     return point_as_list
 
 
-def normalize_dimensions(dimensions, base_estimator="GP"):
->>>>>>> swapping argument name for consistency and matching error statements.
+def normalize_dimensions(dimensions):
     """
     Normalize all dimensions.
 
@@ -460,8 +456,8 @@ def normalize_dimensions(dimensions, base_estimator="GP"):
     if isinstance(base_estimator, str):
         base_estimator = base_estimator.upper()
         if base_estimator not in ["GP", "ET", "RF", "GBRT"]:
-            raise ValueError("Valid strings for the base_estimator parameter are: \
-                              'RF', 'ET','GBRT', or 'GP', not %s." % base_estimator)
+            raise ValueError("Valid strings for the base_estimator parameter \
+                              are: 'RF', 'ET','GBRT', or 'GP'.")
     elif not is_regressor(base_estimator):
         raise ValueError("base_estimator has to be a regressor.")
 

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -359,7 +359,6 @@ def point_asdict(search_space, point_as_list):
     """Convert the list representation of a point from a search space
     to the dictionary representation, where keys are dimension names
     and values are corresponding to the values of dimensions in the list.
-
     Counterpart to parameters_aslist.
 
     Parameters
@@ -388,41 +387,6 @@ def point_asdict(search_space, point_as_list):
         k: v for k, v in zip(sorted(search_space.keys()), point_as_list)
     }
     return params_dict
-
-
-def point_aslist(search_space, point_as_dict):
-    """Convert a dictionary representation of a point from a search space to
-    the list representation. The list of values is created from the values of
-    the dictionary, sorted by the names of dimensions used as keys.
-
-    Counterpart to parameters_asdict.
-
-    Parameters
-    ----------
-    search_space : dict
-        Represents search space. The keys are dimension names (strings)
-        and values are instances of classes that inherit from the class
-        skopt.space.Dimension (Real, Integer or Categorical)
-        Example:
-            {'name1': Real(0,1), 'name2': Integer(2,4), 'name3': Real(-1,1)}
-
-    point_as_dict : dict
-        dict with parameter names as keys to which corresponding
-        parameter values are assigned.
-        Example:
-            {'name1': 0.66, 'name2': 3, 'name3': -0.15}
-
-    Returns
-    -------
-    point_as_list: list with point values.The order of
-        parameters in the list is given by sorted(params_space.keys()).
-        Example output with example inputs:
-            [0.66, 3, -0.15]
-    """
-    point_as_list = [
-        point_as_dict[k] for k in sorted(search_space.keys())
-    ]
-    return point_as_list
 
 
 def normalize_dimensions(dimensions):


### PR DESCRIPTION
This is a small step towards obtaining the same results with `gp_minimize` and the `Optimizer` class noted in https://github.com/scikit-optimize/scikit-optimize/issues/402. 

The code extracts the code responsible for transforming the `dimensions` in `gp_minimize`, creating a new function, ~~`transform_gpdims`~~  ~~`transform_dims`~~ `normalize_dimensions`, which can then be used by both `gp_minimize` and `Optimizer`. 