### PR TITLE
[MRG+1] Implement greedy A-optimal acquisition function for pure exploration

### DIFF
--- a/skopt/acquisition.py
+++ b/skopt/acquisition.py
@@ -105,11 +105,11 @@ def gaussian_lcb(X, model, kappa=1.96, return_grad=False):
         It should have a ``return_std`` parameter that returns the standard
         deviation.
 
-    * `kappa`: [float, default 1.96 or 'Aopt']:
+    * `kappa`: [float, default 1.96 or 'inf']:
         Controls how much of the variance in the predicted values should be
         taken into account. If set to be very high, then we are favouring
         exploration over exploitation and vice versa.
-        If set to 'Aopt', the acquisition function will only use the variance
+        If set to 'inf', the acquisition function will only use the variance
         which is useful in a pure exploration setting.
         Useless if ``method`` is set to "LCB".
 
@@ -134,13 +134,13 @@ def gaussian_lcb(X, model, kappa=1.96, return_grad=False):
                 X, return_std=True, return_mean_grad=True,
                 return_std_grad=True)
 
-            if kappa == "Aopt":
+            if kappa == "inf":
                 return -std, -std_grad
             return mu - kappa * std, mu_grad - kappa * std_grad
 
         else:
             mu, std = model.predict(X, return_std=True)
-            if kappa == "Aopt":
+            if kappa == "inf":
                 return -std
             return mu - kappa * std
 

--- a/skopt/acquisition.py
+++ b/skopt/acquisition.py
@@ -105,10 +105,12 @@ def gaussian_lcb(X, model, kappa=1.96, return_grad=False):
         It should have a ``return_std`` parameter that returns the standard
         deviation.
 
-    * `kappa`: [float, default 1.96]:
+    * `kappa`: [float, default 1.96 or 'Aopt']:
         Controls how much of the variance in the predicted values should be
         taken into account. If set to be very high, then we are favouring
         exploration over exploitation and vice versa.
+        If set to 'Aopt', the acquisition function will only use the variance
+        which is useful in a pure exploration setting.
         Useless if ``method`` is set to "LCB".
 
     * `return_grad`: [boolean, optional]:
@@ -132,10 +134,14 @@ def gaussian_lcb(X, model, kappa=1.96, return_grad=False):
                 X, return_std=True, return_mean_grad=True,
                 return_std_grad=True)
 
+            if kappa == "Aopt":
+                return -std, -std_grad
             return mu - kappa * std, mu_grad - kappa * std_grad
 
         else:
             mu, std = model.predict(X, return_std=True)
+            if kappa == "Aopt":
+                return -std
             return mu - kappa * std
 
 

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -71,6 +71,14 @@ def test_acquisition_pi_correctness():
 
 
 @pytest.mark.fast_test
+def test_acquisition_a_opt_correctness():
+    # check that it works with a vector as well
+    X = 10 * np.ones((4, 2))
+    aopt = gaussian_lcb(X, ConstSurrogate(), kappa='Aopt')
+    assert_array_almost_equal(aopt, [-1.0] * 4)
+
+
+@pytest.mark.fast_test
 def test_acquisition_lcb_correctness():
     # check that it works with a vector as well
     X = 10 * np.ones((4, 2))

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -71,11 +71,11 @@ def test_acquisition_pi_correctness():
 
 
 @pytest.mark.fast_test
-def test_acquisition_a_opt_correctness():
+def test_acquisition_variance_correctness():
     # check that it works with a vector as well
     X = 10 * np.ones((4, 2))
-    aopt = gaussian_lcb(X, ConstSurrogate(), kappa='Aopt')
-    assert_array_almost_equal(aopt, [-1.0] * 4)
+    var = gaussian_lcb(X, ConstSurrogate(), kappa='inf')
+    assert_array_almost_equal(var, [-1.0] * 4)
 
 
 @pytest.mark.fast_test


### PR DESCRIPTION
This acquisition function aims at reducing the overall uncertainty of our objective function approximation.
This is useful if you want to accurately gauge the effect of every hyperparameter on the objective function, typically to set proper ranges for the subsequent optimization or to remove a parameter completely.

The `gaussian_a_opt` function uses the standard deviation provided by the base estimator and samples those points first where it is maximal.

Suggestions for improvement are welcome.