### PR TITLE
[MRG+1] DeadlineCallback, early stopping for a fixed budget

### DIFF
--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -142,7 +142,6 @@ class TimerCallback(object):
         elapsed_time = time() - self._time
         self.iter_time.append(elapsed_time)
         self._time = time()
-        print("I am from TimerCallback!")
 
 
 class EarlyStopper(object):
@@ -157,7 +156,6 @@ class EarlyStopper(object):
         * `result` [`OptimizeResult`, scipy object]:
             The optimization as a OptimizeResult object.
         """
-        print("You will have a criterion!")
         return self._criterion(result)
 
     def _criterion(self, result):

--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -249,8 +249,8 @@ class DeadlineStopper(EarlyStopper):
         return self._criterion(result)
 
     def _criterion(self, result):
-        if len(result.x_iters) >= 1:
+        if result.x_iters:
             time_remaining = self.total_time - np.sum(self.iter_time)
             return time_remaining <= np.max(self.iter_time)
         else:
-            None
+            return None

--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -242,13 +242,11 @@ class DeadlineStopper(EarlyStopper):
         self.iter_time = []
         self.total_time = total_time
 
-    def __call__(self, result):
+    def _criterion(self, result):
         elapsed_time = time() - self._time
         self.iter_time.append(elapsed_time)
         self._time = time()
-        return self._criterion(result)
 
-    def _criterion(self, result):
         if result.x_iters:
             time_remaining = self.total_time - np.sum(self.iter_time)
             return time_remaining <= np.max(self.iter_time)

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -1,14 +1,18 @@
 import pytest
 
+import numpy as np
 from collections import namedtuple
 
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_less
 
 from skopt import dummy_minimize
+from skopt import gp_minimize
 from skopt.benchmarks import bench1
+from skopt.benchmarks import bench3
 from skopt.callbacks import TimerCallback
 from skopt.callbacks import DeltaYStopper
+from skopt.callbacks import DeadlineStopper
 
 
 @pytest.mark.fast_test
@@ -28,3 +32,16 @@ def test_deltay_stopper():
     assert deltay(Result([0, 1, 2, 3, 4, 0.1, 0.19]))
     assert not deltay(Result([0, 1, 2, 3, 4, 0.1]))
     assert deltay(Result([0, 1])) is None
+
+
+@pytest.mark.fast_test
+def test_deadline_stopper():
+    deadline = DeadlineStopper(0.0001)
+    gp_minimize(bench3, [(-1.0, 1.0)], callback=deadline, n_calls=10, random_state=1)
+    assert len(deadline.iter_time) == 1
+    assert np.sum(deadline.iter_time) > deadline.total_time
+
+    deadline = DeadlineStopper(60)
+    gp_minimize(bench3, [(-1.0, 1.0)], callback=deadline, n_calls=10, random_state=1)
+    assert len(deadline.iter_time) == 10
+    assert np.sum(deadline.iter_time) < deadline.total_time


### PR DESCRIPTION
Creates a new `DeadlineCallback` class, an early stopping callback for fixed time budgets. When running optimizations on our clusters, we have fixed wall times for the jobs to be completed within. After pushing the clock a couple of times, I decided to write this class. 

After specifying the total amount of time you would like the optimization to run, the callback keeps track of the time taken for each iteration (exactly as in `TimerCallback`). It then decrements the iteration time from the total time, saving this as `time_remaining`. The early stopping occurs when the `time_remaining` is less than or equal to longest single iteration time. 

> Note: This code has some repetition from the `TimerCallback`. I originally tried to use multiple inheritance with both the `TimerCallback` and the `EarlyStopper` class, but ran into issues working around both parent classes' `__call__` methods. I also tried using composition as well a combination of inheritance and composition without much luck. If you guys have any thoughts on using multiple inheritance here, I am all ears!