### PR TITLE
[MRG] Fix bug in has_gradients

### DIFF
--- a/skopt/__init__.py
+++ b/skopt/__init__.py
@@ -59,6 +59,7 @@ from .optimizer import gbrt_minimize
 from .optimizer import gp_minimize
 from .optimizer import Optimizer
 from .searchcv import BayesSearchCV
+from .space import Space
 from .utils import dump
 from .utils import expected_minimum
 from .utils import load
@@ -82,5 +83,6 @@ __all__ = (
     "dump",
     "load",
     "expected_minimum",
-    "BayesSearchCV"
+    "BayesSearchCV",
+    "Space"
 )

--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -76,8 +76,9 @@ def base_minimize(func, dimensions, base_estimator,
         is updated with the optimal value obtained by optimizing `acq_func`
         with `acq_optimizer`.
 
-        - If set to `"sampling"`, then the point among these `n_points`
-          where the `acq_func` is minimum is the next candidate minimum.
+        - If set to `"sampling"`, then `acq_func` is optimized by computing
+          `acq_func` at `n_points` randomly sampled points and the smallest
+          value found is used.
         - If set to `"lbfgs"`, then
               - The `n_restarts_optimizer` no. of points which the acquisition
                 function is least are taken as start points.

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -85,6 +85,9 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
         n_random_calls = n_calls
 
     return base_minimize(func, dimensions, base_estimator="dummy",
+                         # explicitly set optimizer to sampling as "dummy"
+                         # minimizer does not provide gradients.
+                         acq_optimizer="sampling",
                          n_calls=n_calls, n_random_starts=n_random_calls,
                          x0=x0, y0=y0, random_state=random_state,
                          verbose=verbose,

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -222,15 +222,16 @@ class Optimizer(object):
 
         if acq_optimizer == "auto":
             if has_gradients(self.base_estimator_):
-                acq_optimizer = "sampling"
-            else:
                 acq_optimizer = "lbfgs"
+            else:
+                acq_optimizer = "sampling"
 
         if acq_optimizer not in ["lbfgs", "sampling"]:
             raise ValueError("Expected acq_optimizer to be 'lbfgs' or "
                              "'sampling', got {0}".format(acq_optimizer))
 
-        if has_gradients(self.base_estimator_) and acq_optimizer != "sampling":
+        if (not has_gradients(self.base_estimator_) and
+            acq_optimizer != "sampling"):
             raise ValueError("The regressor {0} should run with "
                              "acq_optimizer"
                              "='sampling'.".format(type(base_estimator)))

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -12,8 +12,14 @@ from skopt import expected_minimum
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench3
 from skopt.learning import ExtraTreesRegressor
-from skopt.optimizer import Optimizer
-from skopt.utils import point_asdict, point_aslist, dimensions_aslist
+from skopt import Optimizer
+from skopt import Space
+from skopt.utils import point_asdict
+from skopt.utils import point_aslist
+from skopt.utils import dimensions_aslist
+from skopt.utils import has_gradients
+from skopt.utils import cook_estimator
+
 
 
 def check_optimization_results_equality(res_1, res_2):
@@ -115,3 +121,20 @@ def test_dict_list_space_representation():
         point,
         point_aslist(chef_space, point_asdict(chef_space, point))
     )
+
+
+@pytest.mark.fast_test
+@pytest.mark.parametrize("estimator, gradients",
+                         zip(["GP", "RF", "ET", "GBRT", "DUMMY"],
+                             [True, False, False, False, False]))
+def test_has_gradients(estimator, gradients):
+    space = Space([(-2.0, 2.0)])
+
+    assert has_gradients(cook_estimator(estimator, space=space)) == gradients
+
+
+@pytest.mark.fast_test
+def test_categorical_gp_has_gradients():
+    space = Space([('a', 'b')])
+
+    assert not has_gradients(cook_estimator('GP', space=space))


### PR DESCRIPTION
Fix bug in `has_gradients` and add tests for it at the same time.

`has_gradients` was returning `not has_gradients` as far as I could tell.

One thing I'd like to double check, the special case for `space.is_categorical` when constructing the GP kernel: Hamming kernels are only for spaces which have exclusively categorical dimensions. Is that correct?