### PR TITLE
[MRG] Reduce number of points sampled when using LBFGS

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -450,8 +450,12 @@ class Optimizer(object):
                 self.gains_ -= est.predict(np.vstack(self.next_xs_))
             self.models.append(est)
 
-            X = self.space.transform(self.space.rvs(
-                n_samples=self.n_points, random_state=self.rng))
+            if self.acq_optimizer == "sampling":
+                X = self.space.transform(self.space.rvs(
+                    n_samples=self.n_points, random_state=self.rng))
+            elif self.acq_optimizer == "lbfgs":
+                X = self.space.transform(self.space.rvs(
+                    n_samples=self.n_restarts_optimizer, random_state=self.rng))
             self.next_xs_ = []
             for cand_acq_func in self.cand_acq_funcs_:
                 values = _gaussian_acquisition(
@@ -467,7 +471,7 @@ class Optimizer(object):
                 # minimization starts from `n_restarts_optimizer` different
                 # points and the best minimum is used
                 elif self.acq_optimizer == "lbfgs":
-                    x0 = X[np.argsort(values)[:self.n_restarts_optimizer]]
+                    x0 = X[np.argsort(values)]
 
                     with warnings.catch_warnings():
                         warnings.simplefilter("ignore")

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -450,12 +450,11 @@ class Optimizer(object):
                 self.gains_ -= est.predict(np.vstack(self.next_xs_))
             self.models.append(est)
 
-            if self.acq_optimizer == "sampling":
-                X = self.space.transform(self.space.rvs(
-                    n_samples=self.n_points, random_state=self.rng))
-            elif self.acq_optimizer == "lbfgs":
-                X = self.space.transform(self.space.rvs(
-                    n_samples=self.n_restarts_optimizer, random_state=self.rng))
+            # even with BFGS as optimizer we want to sample a large number
+            # of points and then pick the best ones as starting points
+            X = self.space.transform(self.space.rvs(
+                n_samples=self.n_points, random_state=self.rng))
+
             self.next_xs_ = []
             for cand_acq_func in self.cand_acq_funcs_:
                 values = _gaussian_acquisition(
@@ -471,7 +470,7 @@ class Optimizer(object):
                 # minimization starts from `n_restarts_optimizer` different
                 # points and the best minimum is used
                 elif self.acq_optimizer == "lbfgs":
-                    x0 = X[np.argsort(values)]
+                    x0 = X[np.argsort(values)[:self.n_restarts_optimizer]]
 
                     with warnings.catch_warnings():
                         warnings.simplefilter("ignore")

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -422,7 +422,7 @@ def test_early_stopping_delta_x(minimizer):
     res = minimizer(bench1,
                     callback=DeltaXStopper(0.1),
                     dimensions=[(-1., 1.)],
-                    x0=[[0.1], [-0.1], [0.9]],
+                    x0=[[-0.1], [0.9], [0.1]],
                     n_calls=n_calls,
                     n_random_starts=0, random_state=1)
     assert len(res.x_iters) < n_calls


### PR DESCRIPTION
When using LBFGS as minimizer for the acquisition function we do not
need to sample as many points as when we optimise by random sampling.
This saves CPU time.

This illustrates https://github.com/scikit-optimize/scikit-optimize/issues/413#issuecomment-318578862