### PR TITLE
[MRG+1] Optimizer() and gp_minimize should be equivalent

### DIFF
--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -205,8 +205,7 @@ def gp_minimize(func, dimensions, base_estimator=None,
     """
     # Check params
     rng = check_random_state(random_state)
-    transformed_dims = normalize_dimensions(dimensions)
-    space = Space(transformed_dims)
+    space = normalize_dimensions(dimensions)
     base_estimator = cook_estimator("GP", space=space, random_state=rng,
                                     noise=noise)
 

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -3,8 +3,6 @@
 from sklearn.utils import check_random_state
 
 from .base import base_minimize
-from ..space import check_dimension
-from ..space import Categorical
 from ..space import Space
 from ..utils import cook_estimator
 from ..utils import normalize_dimensions
@@ -213,7 +211,7 @@ def gp_minimize(func, dimensions, base_estimator=None,
                                     noise=noise)
 
     return base_minimize(
-        func, dimensions, base_estimator=base_estimator,
+        func, space, base_estimator=base_estimator,
         acq_func=acq_func,
         xi=xi, kappa=kappa, acq_optimizer=acq_optimizer, n_calls=n_calls,
         n_points=n_points, n_random_starts=n_random_starts,

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -14,6 +14,7 @@ from sklearn.utils import check_random_state
 
 from ..acquisition import _gaussian_acquisition
 from ..acquisition import gaussian_acquisition_1D
+from ..learning import GaussianProcessRegressor
 from ..space import Categorical
 from ..space import Space
 from ..utils import check_x_in_space
@@ -172,7 +173,10 @@ class Optimizer(object):
                           DeprecationWarning)
             n_initial_points = n_random_starts
 
-        if isinstance(base_estimator, str) and base_estimator.upper() == "GP":
+        self._check_arguments(base_estimator, n_initial_points, acq_optimizer,
+                              dimensions)
+
+        if isinstance(self.base_estimator_, GaussianProcessRegressor):
             dimensions = normalize_dimensions(dimensions)
 
         self.space = Space(dimensions)
@@ -188,7 +192,6 @@ class Optimizer(object):
             else:
                 self._non_cat_inds.append(ind)
 
-        self._check_arguments(base_estimator, n_initial_points, acq_optimizer)
         self.n_jobs = n_jobs
 
         # The cache of responses of `ask` method for n_points not None.
@@ -198,12 +201,12 @@ class Optimizer(object):
         self.cache_ = {}
 
     def _check_arguments(self, base_estimator, n_initial_points,
-                         acq_optimizer):
+                         acq_optimizer, dimensions):
         """Check arguments for sanity."""
 
         if isinstance(base_estimator, str):
             base_estimator = cook_estimator(
-                base_estimator, space=self.space, random_state=self.rng)
+                base_estimator, space=dimensions, random_state=self.rng)
 
         if not is_regressor(base_estimator) and base_estimator is not None:
             raise ValueError(

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -22,10 +22,13 @@ class _Ellipsis:
 
 
 def check_dimension(dimension, transform=None):
-    """
+    """Turn a provided dimension description into a dimension object.
+
     Checks that the provided dimension falls into one of the
     supported types. For a list of supported types, look at
-    the documentation of `dimension` below.
+    the documentation of ``dimension`` below.
+
+    If ``dimension`` is already a ``Dimension`` instance, return it.
 
     Parameters
     ----------
@@ -668,6 +671,7 @@ class Space(object):
 
     @property
     def is_categorical(self):
+        """Space contains exclusively categorical dimensions"""
         return all([isinstance(dim, Categorical) for dim in self.dimensions])
 
     def distance(self, point_a, point_b):

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -6,7 +6,9 @@ from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
 
+from skopt import gp_minimize
 from skopt.benchmarks import bench1
+from skopt.benchmarks import branin
 from skopt.learning import ExtraTreesRegressor, RandomForestRegressor
 from skopt.learning import GradientBoostingQuantileRegressor
 from skopt.optimizer import Optimizer
@@ -194,3 +196,21 @@ def test_optimizer_base_estimator_string_smoke(base_estimator):
     opt = Optimizer([(-2.0, 2.0)], base_estimator=base_estimator,
                     n_initial_points=1, acq_func="EI")
     opt.run(func=lambda x: x[0]**2, n_iter=3)
+
+
+def test_defaults_are_equivalent():
+    # check that the defaults of Optimizer reproduce the defaults of
+    # gp_minimize
+    space = [(-5., 10.), (0., 15.)]
+    opt = Optimizer(space, random_state=1)
+
+    for n in range(15):
+        x = opt.ask()
+        res_opt = opt.tell(x, branin(x))
+
+    res_min = gp_minimize(branin, space, n_calls=15, random_state=1)
+
+    assert res_min.space == res_opt.space
+    # tolerate small differences in the points sampled
+    assert np.allclose(res_min.x_iters, res_opt.x_iters, atol=1e-5)
+    assert np.allclose(res_min.x, res_opt.x, atol=1e-5)

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -19,6 +19,7 @@ from skopt.utils import point_aslist
 from skopt.utils import dimensions_aslist
 from skopt.utils import has_gradients
 from skopt.utils import cook_estimator
+from skopt.utils import normalize_dimensions
 
 
 def check_optimization_results_equality(res_1, res_2):
@@ -141,3 +142,25 @@ def test_categorical_gp_has_gradients():
     space = Space([('a', 'b')])
 
     assert not has_gradients(cook_estimator('GP', space=space))
+
+
+@pytest.mark.fast_test
+def test_normalize_dimensions_all_categorical():
+    dimensions = (['a', 'b', 'c'], ['1', '2', '3'])
+    space = normalize_dimensions(dimensions)
+    assert space.is_categorical
+
+
+@pytest.mark.fast_test
+@pytest.mark.parametrize("dimensions, normalizations",
+                         [(((1, 3), (1., 3.)),
+                           ('normalize', 'normalize')
+                           ),
+                          (((1, 3), ('a', 'b', 'c')),
+                           ('normalize', 'onehot')
+                           ),
+                          ])
+def test_normalize_dimensions(dimensions, normalizations):
+    space = normalize_dimensions(dimensions)
+    for dimension, normalization in zip(space, normalizations):
+        assert dimension.transform_ == normalization


### PR DESCRIPTION
Follow up for #402 

This PR adds a test that checks if indeed `Optimizer()` and `gp_minimize()` give the same results when used with default settings.

For that to be true I had to modify `gp_minimize` to use the normalised space. @MechCoder should take a look to double check.

Thoughts on the points only being within 1e-5 of each other instead of being identical? The random points are exactly identical but then it seems thigns diverge a bit once we start using the GP :-/