### PR TITLE
Fix test_utils.py with scikit-learn master

### DIFF
--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -44,6 +44,7 @@ def test_dump_and_load():
     # Test normal dumping and loading
     with tempfile.TemporaryFile() as f:
         dump(res, f)
+        f.seek(0)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
     assert_true("func" in res_loaded.specs["args"])
@@ -51,6 +52,7 @@ def test_dump_and_load():
     # Test dumping without objective function
     with tempfile.TemporaryFile() as f:
         dump(res, f, store_objective=False)
+        f.seek(0)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
     assert_true(not ("func" in res_loaded.specs["args"]))
@@ -59,6 +61,7 @@ def test_dump_and_load():
     del res.specs["args"]["func"]
     with tempfile.TemporaryFile() as f:
         dump(res, f, store_objective=False)
+        f.seek(0)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
     assert_true(not ("func" in res_loaded.specs["args"]))
@@ -74,6 +77,7 @@ def test_dump_and_load_optimizer():
 
     with tempfile.TemporaryFile() as f:
         dump(opt, f)
+        f.seek(0)
         load(f)
 
 


### PR DESCRIPTION
Need to seek at the beginning of the file before loading the pickle
from the file.

This is probably a change in the joblib we bundle with scikit-learn between scikit-learn 0.18 and scikit-learn master.

Note that I think this is fine and has the same behaviour as pickle:

```py
import tempfile
import pickle

with tempfile.TemporaryFile() as f:
    pickle.dump(object(), f)
    pickle.load(f)
```

```
---------------------------------------------------------------------------
EOFError                                  Traceback (most recent call last)
<ipython-input-3-5857a6e21a79> in <module>()
      4 with tempfile.TemporaryFile() as f:
      5     pickle.dump(object(), f)
----> 6     pickle.load(f)
      7 

EOFError: Ran out of input
```

Fixes part of #461.