### PR TITLE
[MRG+1] Fix handling of bool in Categorical space

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -67,7 +67,7 @@ def check_dimension(dimension, transform=None):
         raise ValueError("Dimension has to be a list or tuple.")
 
     if len(dimension) == 2:
-        if any([isinstance(d, str) for d in dimension]):
+        if any([isinstance(d, (str, bool)) for d in dimension]):
             return Categorical(dimension, transform=transform)
         elif all([isinstance(dim, numbers.Integral) for dim in dimension]):
             return Integer(*dimension, transform=transform)
@@ -364,7 +364,7 @@ class Categorical(Dimension):
             - "onehot", the transformed space is a one-hot encoded
               representation of the original space.
         """
-        self.categories = categories
+        self.categories = tuple(categories)
 
         if transform is None:
             transform = "onehot"

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -217,10 +217,18 @@ def test_space_consistency():
     # Categoricals
     s1 = Space([Categorical(["a", "b", "c"])])
     s2 = Space([Categorical(["a", "b", "c"])])
+    s3 = Space([["a", "b", "c"]])
     a1 = s1.rvs(n_samples=10, random_state=0)
     a2 = s2.rvs(n_samples=10, random_state=0)
+    a3 = s3.rvs(n_samples=10, random_state=0)
     assert_equal(s1, s2)
     assert_array_equal(a1, a2)
+    assert_equal(s1, s3)
+    assert_array_equal(a1, a3)
+
+    s1 = Space([(True, False)])
+    s2 = Space([Categorical([True, False])])
+    assert s1 == s2
 
 
 @pytest.mark.fast_test


### PR DESCRIPTION
Fixes #454 

Makes `Space(([False, True]))` produce a `Categorical` dimension instead of a `Integer`.