### PR TITLE
Switch from `ax` to `ax_`. Fix Numpy/matplotlib bug.

### DIFF
--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -142,7 +142,7 @@ def _format_scatter_plot_axes(ax, space, ylabel):
             ax_.xaxis.set_major_locator(MaxNLocator(6, prune='both'))
             ax_.yaxis.set_major_locator(MaxNLocator(6, prune='both'))
 
-    return ax
+    return ax_
 
 
 def partial_dependence(space, model, i, j=None, sample_points=None,


### PR DESCRIPTION
`ax` is `numpy.ndarray` while `ax_` is matplotlib 

**Got this error using the library:**
Traceback (most recent call last):
  File "bin/tune.py", line 209, in <module>
    main(base_config, tune_config)
  File "/root/pytorch-seq2seq/seq2seq/config/configurable.py", line 250, in configurable
    return func(*args, **merged)
  File "bin/tune.py", line 199, in main
    plot_result(optimizer, result)
  File "bin/tune.py", line 89, in plot_result
    ax.figure.savefig(path)
AttributeError: 'numpy.ndarray' object has no attribute 'figure'

Was running `plot_evaluations` and `plot_objective`.