### PR TITLE
Check point dimension on tell

### DIFF
--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -101,6 +101,47 @@ def test_bounds_checking_2D_multiple_points():
 
 
 @pytest.mark.fast_test
+def test_dimension_checking_1D():
+    low = -2
+    high = 2
+    opt = Optimizer([(low, high)])
+    with pytest.raises(ValueError) as e:
+        # within bounds but one dimension too high
+        opt.tell([low+1, low+1], 2.)
+    assert "Dimensions of point " in str(e.value)
+
+
+@pytest.mark.fast_test
+def test_dimension_checking_2D():
+    low = -2
+    high = 2
+    opt = Optimizer([(low, high), (low, high)])
+    # within bounds but one dimension too little
+    with pytest.raises(ValueError) as e:
+        opt.tell([low+1, ], 2.)
+    assert "Dimensions of point " in str(e.value)
+    # wthin bounds but one dimension to much
+    with pytest.raises(ValueError) as e:
+        opt.tell([low+1, low+1, low+1], 2.)
+    assert "Dimensions of point " in str(e.value)
+
+
+@pytest.mark.fast_test
+def test_dimension_checking_2D_multiple_points():
+    low = -2
+    high = 2
+    opt = Optimizer([(low, high), (low, high)])
+    # within bounds but one dimension too little
+    with pytest.raises(ValueError) as e:
+        opt.tell([[low+1, ], [low+1, low+2], [low+1, low+3]], 2.)
+    assert "dimensions as the space" in str(e.value)
+    # wthin bounds but one dimension to much
+    with pytest.raises(ValueError) as e:
+        opt.tell([[low + 1, low + 1, low + 1], [low + 1, low + 2], [low + 1, low + 3]], 2.)
+    assert "dimensions as the space" in str(e.value)
+
+
+@pytest.mark.fast_test
 def test_returns_result_object():
     base_estimator = ExtraTreesRegressor(random_state=2)
     opt = Optimizer([(-2.0, 2.0)], base_estimator, n_initial_points=1,

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -120,7 +120,7 @@ def test_dimension_checking_2D():
     with pytest.raises(ValueError) as e:
         opt.tell([low+1, ], 2.)
     assert "Dimensions of point " in str(e.value)
-    # wthin bounds but one dimension to much
+    # within bounds but one dimension too much
     with pytest.raises(ValueError) as e:
         opt.tell([low+1, low+1, low+1], 2.)
     assert "Dimensions of point " in str(e.value)
@@ -135,7 +135,7 @@ def test_dimension_checking_2D_multiple_points():
     with pytest.raises(ValueError) as e:
         opt.tell([[low+1, ], [low+1, low+2], [low+1, low+3]], 2.)
     assert "dimensions as the space" in str(e.value)
-    # wthin bounds but one dimension to much
+    # within bounds but one dimension too much
     with pytest.raises(ValueError) as e:
         opt.tell([[low + 1, low + 1, low + 1], [low + 1, low + 2], [low + 1, low + 3]], 2.)
     assert "dimensions as the space" in str(e.value)

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -187,10 +187,16 @@ def check_x_in_space(x, space):
         if not np.all([p in space for p in x]):
             raise ValueError("Not all points are within the bounds of"
                              " the space.")
+        if any([len(p) != len(space.dimensions) for p in x]):
+            raise ValueError("Not all points have the same dimensions as"
+                             " the space.")
     elif is_listlike(x):
         if x not in space:
             raise ValueError("Point (%s) is not within the bounds of"
                              " the space (%s)."
+                             % (x, space.bounds))
+        if len(x) != len(space.dimensions):
+            raise ValueError("Dimensions of point (%s) and space (%s) do not match"
                              % (x, space.bounds))
 
 


### PR DESCRIPTION
Fixes #487 
Added check for dimension of point and space.
Check is added in utils.check_x_in_space(), could also be added in __contains__ function of space, but then Exception message in check_x_in_space should be adapted.