### PR TITLE
Fixing TyperError with Categorical of len gt 7

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -429,7 +429,7 @@ class Categorical(Dimension):
 
     def __repr__(self):
         if len(self.categories) > 7:
-            cats = self.categories[:3] + [_Ellipsis()] + self.categories[-3:]
+            cats = list(self.categories[:3]) + [_Ellipsis()] + list(self.categories[-3:])
         else:
             cats = self.categories
 


### PR DESCRIPTION
Small bug fix to be able to print Categorical space with a length greather than 7.