### PR TITLE
[WIP] MC Batch (q-EI) Design

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -328,16 +328,20 @@ class Optimizer(object):
         opt = self.copy()
 
         X = []
+
         for i in range(n_points):
-            x = opt.ask()
-            X.append(x)
             if strategy == "cl_min":
-                y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie
-            elif strategy == "cl_mean":
-                y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-mean lie
-            else:
-                y_lie = np.max(opt.yi) if opt.yi else 0.0  # CL-max lie
-            opt.tell(x, y_lie)  # lie to the optimizer
+                x = opt.ask()
+                X.append(x)
+                if strategy == "cl_min":
+                    y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie
+                elif strategy == "cl_mean":
+                    y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-mean lie
+                else:
+                    y_lie = np.max(opt.yi) if opt.yi else 0.0  # CL-max lie
+                opt.tell(x, y_lie)  # lie to the optimizer
+            elif strategy == "mc":
+                pass
 
         self.cache_ = {(n_points, strategy): X}  # cache_ the result
 

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -304,7 +304,7 @@ class Optimizer(object):
         if n_points is None:
             return self._ask()
 
-        supported_strategies = ["cl_min", "cl_mean", "cl_max"]
+        supported_strategies = ["cl_min", "cl_mean", "cl_max", "mc"]
 
         if not (isinstance(n_points, int) and n_points > 0):
             raise ValueError(


### PR DESCRIPTION
I'm working on this one lately. Although there are still some API details that I hesitate, it's now comparatively clearer and I could summarize the previous discussions here.

Related: #343 #403 #352 #445 

#### Batch design and parallelization
Batch design helps implement parallelization.

```text
Parallel Optimization
Input: Function f, Current dataset (X,y)
Output: Global minimum x_min = argmin f
1  while (pending iterations):
2  |  Create a new copy of optimizer 'opt'
3  |  ......
4  |  Through different batch design strategies, 
5  |  accumulate p points X_new=(x_1..x_p).
6  |  ......
7  |  Discard 'opt'
8  |  Evaluate f(X_new) in parallel get y_new
9  |  Append (X_new,y_new) to (X,y)
10 |  Fit updated model, discard opt
11 end while (**having k batches/k*p points evaluated now**)
12 return global minimum x_min = argmin y
```

#### Algorithms
To accumulate `p` points as a batch:

- *Constant Liar* method acquires points sequentially by telling a lie for last sampled point until having a batch of points.

- *Monte Carlo* method takes a comparatively computational expensive approach: acquire `q` points first, calculate acquisition values through Monte Carlo sampling from posterior predictions and sequentially choose points that minimize the acquisition values.

```text
Constant liar Batch Design (Current Algorithm)
Input: Copied optimizer 'opt'
Output: A batch of p points X_new=(x_1..x_p)
1  while (pending points to sample):
2  |  Choose next point x_i=argmin EI(X)
3  |  Find current best y_opt
4  |  Lie with constant y_i=y_opt
5  |  Append (x_i,y_i) to (X,y) within 'opt'
6  |  Fit the copied model with (X,y) in 'opt'
7  end while
```

```text
Monte Carlo Batch Design
Input: Copied optimizer 'opt'
Output: A batch of p points X_new=(x_1..x_p)
1  while (pending points to sample):
2  |  Choose next group of pending points X_pend
3  |  (qIs) Calculate batch improvements using MC
3.1|  |--while (pending simulations):
3.2|     |  Sample from posterior prediction y_pend for X_pend in 'opt'
3.3|     |  Find current best y_opt from both opt.y and y_pend
3.4|     |  (qI) Calculate batch improvement at X_pend
3.5|     end while
4  |  (qEI) Average improvements over simulations
5  |  Select x_i = argmin qEI from X_pend
6  |  Append (x_i,y_i) to (X,y) within 'opt'
6  |  Fit the copied model with (X,y) in 'opt'
6  end while
```

#### API
I would like to propose the following change to the current optimizer API.

Current API inside `ask`:

```py
opt = self.copy()
X = []
for i in range(n_points):
   x = opt.ask()
   X.append(x)
   if strategy == "cl_min":
      y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie
   elif strategy == "cl_mean":
      y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-mean lie
   else:
      y_lie = np.max(opt.yi) if opt.yi else 0.0  # CL-max lie
   opt.tell(x, y_lie)  # lie to the optimizer
```

If directly edit current `ask` API: (**Need Discussions!**)

```py
opt = self.copy()
X = []
for i in range(n_points):
   if "cl" in strategy:
      x = opt._ask(1)
      X.append(x)
      if strategy == "cl_min":
         y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie
      elif strategy == "cl_mean":
         y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-mean lie
      else:
         y_lie = np.max(opt.yi) if opt.yi else 0.0  # CL-max lie
      opt.tell(x, y_lie)  # lie to the optimizer
   elif strategy == "mc": # only for GP regressor
      # ... raise error if not GP
      x = opt._ask(q) # ask for q points
      y_lies = opt.base_estimator_.sample_y(x, n_samples=n_sims,
                 random_state=opt.rng) # simulate from posterior
      opt.tell(x, y_lies) # y_lies.shape=(q, n_sims)
```

First of all, `_ask` needs to switch from suggesting one point to q points (q is taken as 1 in the heuristic method).

The real complicated part IMO is within each simulation, same batch of `x` values is provided with different `y` values. They are used to calculate the improvements but are not supposed to be recorded or used for predictions. So the original constant liar approach needs to change a lot.

Two ways I can think of:

- Separate `tell` into different functions, for example:
  - `record`: which append/extend points to existing `Xi` and `yi`
  - `suggest`: which suggest next point to add in the batch
  - Then for CL: record and suggest, MC: do not record but suggest
  - ...
- Keep current `tell` function and do record every time. But substitute the last `q` fantasies (`y`s) from last simulation with new simulation, because in the end this copied optimizer is going to be discarded.

But since the function is already >100 lines, is it better if we split `tell`?

#### Additions:
- MCMC for the original Spearmint algorithm, as the next step, can then be added where we sample posterior `y`s. And hyperparameters of kernel is considered. Therefore `sample_y` in the original `sklearn` GPR is no longer useful.
- `n_points` as a variable is used for both batch size and BFGS/sampling. I confused its usage before Manoj pointed out to me. Therefore, when we want to name `q`, what name are we going to give it? Shall we change the batch size one in ask just to `batch_size` and use `n_points` for `q`?
- `acq_func`: if just to accommodate simulations, then no need to write a separate function. (Put a loop sending each simulation `y_opt` in and get `values` and average them afterwards.)
- Some comments on disadvantages of this approach from last discussions:
  - Within each simulation: sample from the posterior, fit a new GP, compute the acquisition function values. This is expensive.
  - Optimization: Manoj considers to use a fine-grid to optimize the expected acquisition function and not use any numerical-gradient based techniques since this function itself is not too cheap. `Spearmint` uses the other. This needs to be further discussed and tested as well.