### PR TITLE
[MRG] gp_minimize should not use default estimator when a custom one is provided

### DIFF
--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -207,9 +207,11 @@ def gp_minimize(func, dimensions, base_estimator=None,
     # Check params
     rng = check_random_state(random_state)
     space = normalize_dimensions(dimensions)
-    base_estimator = cook_estimator(
-        "GP", space=space, random_state=rng.randint(0, np.iinfo(np.int32).max),
-        noise=noise)
+
+    if base_estimator is None:
+        base_estimator = cook_estimator(
+            base, space=space, random_state=rng.randint(0, np.iinfo(np.int32).max),
+            noise=noise)
 
     return base_minimize(
         func, space, base_estimator=base_estimator,

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -210,7 +210,7 @@ def gp_minimize(func, dimensions, base_estimator=None,
 
     if base_estimator is None:
         base_estimator = cook_estimator(
-            base, space=space, random_state=rng.randint(0, np.iinfo(np.int32).max),
+            "GP", space=space, random_state=rng.randint(0, np.iinfo(np.int32).max),
             noise=noise)
 
     return base_minimize(

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -10,6 +10,8 @@ from skopt.benchmarks import bench2
 from skopt.benchmarks import bench3
 from skopt.benchmarks import bench4
 from skopt.benchmarks import branin
+from skopt.utils import cook_estimator
+from skopt.utils import normalize_dimensions
 
 
 def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
@@ -71,3 +73,17 @@ def test_gpr_default():
     """Smoke test that gp_minimize does not fail for default values."""
     gp_minimize(branin, ((-5.0, 10.0), (0.0, 15.0)), n_random_starts=1,
                 n_calls=2)
+
+
+@pytest.mark.fast_test
+def test_use_given_estimator():
+    """ Check that gp_minimize use the given estimator. """
+    domain = [(1.0, 2.0), (3.0, 4.0)]
+    space = normalize_dimensions(domain)
+    noise_correct = 1e+5
+    noise_fake = 1e-10
+    estimator = cook_estimator("GP", space=space, noise=noise_correct)
+    res = gp_minimize(branin, domain, n_calls=1, n_random_starts=1,
+                      base_estimator=estimator, noise=noise_fake)
+
+    assert res['models'][-1].noise == noise_correct

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -77,7 +77,9 @@ def test_gpr_default():
 
 @pytest.mark.fast_test
 def test_use_given_estimator():
-    """ Check that gp_minimize use the given estimator. """
+    """ Test that gp_minimize does not use default estimator if one is passed
+    in explicitly. """
+    # domain and space are created just to cook the estimator
     domain = [(1.0, 2.0), (3.0, 4.0)]
     space = normalize_dimensions(domain)
     noise_correct = 1e+5

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -11,7 +11,6 @@ from skopt.benchmarks import bench3
 from skopt.benchmarks import bench4
 from skopt.benchmarks import branin
 from skopt.utils import cook_estimator
-from skopt.utils import normalize_dimensions
 
 
 def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
@@ -79,12 +78,10 @@ def test_gpr_default():
 def test_use_given_estimator():
     """ Test that gp_minimize does not use default estimator if one is passed
     in explicitly. """
-    # domain and space are created just to cook the estimator
     domain = [(1.0, 2.0), (3.0, 4.0)]
-    space = normalize_dimensions(domain)
     noise_correct = 1e+5
     noise_fake = 1e-10
-    estimator = cook_estimator("GP", space=space, noise=noise_correct)
+    estimator = cook_estimator("GP", domain, noise=noise_correct)
     res = gp_minimize(branin, domain, n_calls=1, n_random_starts=1,
                       base_estimator=estimator, noise=noise_fake)
 


### PR DESCRIPTION
I think that gp_minimize should use the given optimizer, if it exists