### PR TITLE
Add a RepeatedMinStopper callback and tests.

### DIFF
--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -238,8 +238,6 @@ class RepeatedMinStopper(EarlyStopper):
         if result.fun < self.minimum:
             self.minimum = result.fun
             self.count = 0
-        elif result.fun > self.minimum:
-            self.count = 0
         else:
             self.count += 1
 

--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -222,6 +222,30 @@ class DeltaYStopper(EarlyStopper):
             return None
 
 
+class RepeatedMinStopper(EarlyStopper):
+    """Stop the optimization when there is no improvement in the minimum.
+
+    Stop the optimization when there is no improvement in the minimum
+    achieved function evaluation after `n_best` iterations.
+    """
+    def __init__(self, n_best=50):
+        super(EarlyStopper, self).__init__()
+        self.n_best = n_best
+        self.count = 0
+        self.minimum = np.finfo(np.float).max
+
+    def _criterion(self, result):
+        if result.fun < self.minimum:
+            self.minimum = result.fun
+            self.count = 0
+        elif result.fun > self.minimum:
+            self.count = 0
+        else:
+            self.count += 1
+
+        return self.count >= self.n_best
+
+
 class DeadlineStopper(EarlyStopper):
     """
     Stop the optimization before running out of a fixed budget of time.

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -12,6 +12,7 @@ from skopt.benchmarks import bench1
 from skopt.benchmarks import bench3
 from skopt.callbacks import TimerCallback
 from skopt.callbacks import DeltaYStopper
+from skopt.callbacks import RepeatedMinStopper
 from skopt.callbacks import DeadlineStopper
 
 
@@ -32,6 +33,23 @@ def test_deltay_stopper():
     assert deltay(Result([0, 1, 2, 3, 4, 0.1, 0.19]))
     assert not deltay(Result([0, 1, 2, 3, 4, 0.1]))
     assert deltay(Result([0, 1])) is None
+
+
+@pytest.mark.fast_test
+def test_repeatedmin_stopper():
+    repeatedmin = RepeatedMinStopper(3)
+
+    Result = namedtuple('Result', ['fun'])
+
+    func_vals = [1, 2, 3, 4]
+    for vals in (func_vals[:ii + 1] for ii in range(len(func_vals))):
+        stop = repeatedmin._criterion(Result(min(vals)))
+    assert stop
+
+    func_vals = [1, 2, 0, 4]
+    for vals in (func_vals[:ii + 1] for ii in range(len(func_vals))):
+        stop = repeatedmin._criterion(Result(min(vals)))
+    assert not stop
 
 
 @pytest.mark.fast_test


### PR DESCRIPTION
This callback stops the optimisation when there has been no improvement
in the achieved minimum after `n_best` steps.