### PR TITLE
[DOC]: fix actual acq_func default value

### DIFF
--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -76,7 +76,7 @@ def gp_minimize(func, dimensions, base_estimator=None,
         Number of evaluations of `func` with random points before
         approximating it with `base_estimator`.
 
-    * `acq_func` [string, default=`"EI"`]:
+    * `acq_func` [string, default=`"gp_hedge"`]:
         Function to minimize over the gaussian prior. Can be either
 
         - `"LCB"` for lower confidence bound.


### PR DESCRIPTION
It seems that the actual default of ``acq_func`` is ``gp_hedge``, not ``EI`` as stated in the docstring.