### PR TITLE
[WIP] test and fix for printing Categorical variables

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -384,7 +384,7 @@ class Categorical(Dimension):
         * `categories` [list, shape=(n_categories,)]:
             Sequence of possible categories.
 
-        * `prior` [list, shape=(categories,), default=None]:
+        * `prior` [list, shape=(n_categories,), default=None]:
             Prior probabilities for each category. By default all categories
             are equally likely.
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -431,7 +431,7 @@ class Categorical(Dimension):
 
     def __repr__(self):
         if len(self.categories) > 7:
-            cats = self.categories[:3] + [_Ellipsis()] + self.categories[-3:]
+            cats = self.categories[:3] + (_Ellipsis(),) + self.categories[-3:]
         else:
             cats = self.categories
 

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -381,7 +381,7 @@ def test_categorical_identity():
 def test_categorical_repr(capsys):
 
     # ensure printing of Categorical objects does not
-    # raise an exception. Hhowever we do not insist
+    # raise an exception. However we do not insist
     # on the exact output format.
 
     for categories in (

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -1,3 +1,5 @@
+from __future__ import print_function
+
 import pytest
 import numbers
 import numpy as np
@@ -374,6 +376,27 @@ def test_categorical_identity():
     transformed = cat.transform(samples)
     assert_array_equal(transformed, samples)
     assert_array_equal(samples, cat.inverse_transform(transformed))
+
+@pytest.mark.fast_test
+def test_categorical_repr():
+
+    # ensure printing of Categorical objects does not
+    # raise an exception. Hhowever we do not insist
+    # on the exact output format.
+
+    import cStringIO as StringIO
+
+    for categories in (
+        range(3), # short ( < 7 items) list of categories
+        range(8), # long ( >= 7 items) list of categories with ellipsis
+        ):
+
+        categories = list(categories)
+        cat = Categorical(categories, transform="identity")
+
+        out = StringIO.StringIO()
+
+        print(cat, file = out)
 
 
 @pytest.mark.fast_test

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -378,21 +378,19 @@ def test_categorical_identity():
     assert_array_equal(samples, cat.inverse_transform(transformed))
 
 @pytest.mark.fast_test
-def test_categorical_repr(capsys):
+@pytest.mark.parametrize("categories",
+                         [range(3), # short ( < 7 items) list of categories
+                          range(8), # long ( >= 7 items) list of categories with ellipsis
+                          ])
+def test_categorical_repr(capsys, categories):
 
     # ensure printing of Categorical objects does not
     # raise an exception. However we do not insist
     # on the exact output format.
 
-    for categories in (
-        range(3), # short ( < 7 items) list of categories
-        range(8), # long ( >= 7 items) list of categories with ellipsis
-        ):
+    cat = Categorical(categories, transform="identity")
 
-        categories = list(categories)
-        cat = Categorical(categories, transform="identity")
-
-        print(cat)
+    print(cat)
 
 @pytest.mark.fast_test
 def test_categorical_distance():

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -378,13 +378,11 @@ def test_categorical_identity():
     assert_array_equal(samples, cat.inverse_transform(transformed))
 
 @pytest.mark.fast_test
-def test_categorical_repr():
+def test_categorical_repr(capsys):
 
     # ensure printing of Categorical objects does not
     # raise an exception. Hhowever we do not insist
     # on the exact output format.
-
-    import cStringIO as StringIO
 
     for categories in (
         range(3), # short ( < 7 items) list of categories
@@ -394,10 +392,7 @@ def test_categorical_repr():
         categories = list(categories)
         cat = Categorical(categories, transform="identity")
 
-        out = StringIO.StringIO()
-
-        print(cat, file = out)
-
+        print(cat)
 
 @pytest.mark.fast_test
 def test_categorical_distance():


### PR DESCRIPTION
as reported and discussed in #539 .

The test implemented in the first commit 57b1336 fails (which is expected) but passes with the second commit (a78c6ba, actual fix for printing the categories themselves).

Please do not merge yet because there are still some remaining questions on how to deal with the `prior` argument.

