### PR TITLE
[MRG] Fix not positive definitive matrix in parallel optimisation

### DIFF
--- a/examples/parallel-optimization.ipynb
+++ b/examples/parallel-optimization.ipynb
@@ -1,129 +1,132 @@
 {
- "cells": [
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "# Parallel optimization\n",
-    "\n",
-    "Iaroslav Shcherbatyi, May 2017.\n",
-    "\n",
-    "Reviewed by Manoj Kumar and Tim Head."
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Introduction\n",
-    "\n",
-    "For many practical black box optimization problems expensive objective can be evaluated in parallel at multiple points. This allows to get more objective evaluations per unit of time, which reduces the time necessary to reach good objective values when appropriate optimization algorithms are used, see for example results in [1] and the references therein. \n",
-    " \n",
-    " \n",
-    "One such example task is a selection of number and activation function of a neural network which results in highest accuracy for some machine learning problem. For such task, multiple neural networks with different combinations of number of neurons and activation function type can be evaluated at the same time in parallel on different cpu cores / computational nodes. \n",
-    " \n",
-    " \n",
-    "The “ask and tell” API of scikit-optimize exposes functionality that allows to obtain multiple points for evaluation in parallel. Intended usage of this interface is as follows:\n",
-    "\n",
-    "\n",
-    "0. Initialize instance of the `Optimizer` class from skopt\n",
-    "1. Obtain n points for evaluation in parallel by calling the `ask` method of an optimizer instance with the `n_points` argument set to n > 0\n",
-    "2. Evaluate points\n",
-    "3. Provide points and corresponding objectives using the `tell` method of an optimizer instance\n",
-    "4. Continue from step 2 until eg maximum number of evaluations reached\n",
-    "\n",
-    "## Example\n",
-    " \n",
-    "A minimalistic example that uses joblib to parallelize evaluation of the objective function is given below.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
-   "outputs": [
+  "cells": [
     {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0.415551669691\n"
-     ]
+      "cell_type": "markdown",
+      "source": [
+        "# Parallel optimization\n",
+        "\n",
+        "Iaroslav Shcherbatyi, May 2017.\n",
+        "\nReviewed by Manoj Kumar and Tim Head."
+      ],
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "## Introduction\n",
+        "\n",
+        "For many practical black box optimization problems expensive objective can be evaluated in parallel at multiple points. This allows to get more objective evaluations per unit of time, which reduces the time necessary to reach good objective values when appropriate optimization algorithms are used, see for example results in [1] and the references therein. \n",
+        " \n",
+        " \n",
+        "One such example task is a selection of number and activation function of a neural network which results in highest accuracy for some machine learning problem. For such task, multiple neural networks with different combinations of number of neurons and activation function type can be evaluated at the same time in parallel on different cpu cores / computational nodes. \n",
+        " \n",
+        " \n",
+        "The “ask and tell” API of scikit-optimize exposes functionality that allows to obtain multiple points for evaluation in parallel. Intended usage of this interface is as follows:\n",
+        "\n\n",
+        "0. Initialize instance of the `Optimizer` class from skopt\n",
+        "1. Obtain n points for evaluation in parallel by calling the `ask` method of an optimizer instance with the `n_points` argument set to n > 0\n",
+        "2. Evaluate points\n",
+        "3. Provide points and corresponding objectives using the `tell` method of an optimizer instance\n",
+        "4. Continue from step 2 until eg maximum number of evaluations reached\n",
+        "\n",
+        "## Example\n",
+        " \n",
+        "A minimalistic example that uses joblib to parallelize evaluation of the objective function is given below.\n"
+      ],
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      }
+    },
+    {
+      "cell_type": "code",
+      "source": [
+        "from skopt import Optimizer\n",
+        "from skopt.learning import GaussianProcessRegressor\n",
+        "from skopt.space import Real\n",
+        "from sklearn.externals.joblib import Parallel, delayed\n",
+        "# example objective taken from skopt\n",
+        "from skopt.benchmarks import branin\n",
+        "\n",
+        "optimizer = Optimizer(\n",
+        "    dimensions=[Real(-5.0, 10.0), Real(0.0, 15.0)],\n",
+        "    random_state=1\n",
+        ")\n",
+        "\n",
+        "for i in range(10): \n",
+        "    x = optimizer.ask(n_points=4)  # x is a list of n_points points    \n",
+        "    y = Parallel()(delayed(branin)(v) for v in x)  # evaluate points in parallel\n",
+        "    optimizer.tell(x, y)\n",
+        "\n",
+        "# takes ~ 20 sec to get here\n",
+        "print(min(optimizer.yi))  # print the best objective found "
+      ],
+      "outputs": [
+        {
+          "output_type": "stream",
+          "name": "stdout",
+          "text": [
+            "0.398231443101\n"
+          ]
+        }
+      ],
+      "execution_count": 1,
+      "metadata": {
+        "collapsed": false,
+        "deletable": true,
+        "editable": true
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "Note that if `n_points` is set to some integer > 0 for the `ask` method, the result will be a list of points, even for `n_points`=1. If the argument is set to `None` (default value) then a single point (but not a list of points) will be returned.\n",
+        "\nThe default \"minimum constant liar\" [1] parallelization strategy is used in the example, which allows to obtain multiple points for evaluation with a single call to the `ask` method with any surrogate or acquisition function. Paralellization strategy can be set using the \"strategy\" argument of `ask`. For supported parallelization strategies see the documentation of scikit-optimize. "
+      ],
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      }
+    },
+    {
+      "cell_type": "markdown",
+      "source": [
+        "[1] [https://hal.archives-ouvertes.fr/hal-00732512/document](https://hal.archives-ouvertes.fr/hal-00732512/document) ."
+      ],
+      "metadata": {
+        "deletable": true,
+        "editable": true
+      }
     }
-   ],
-   "source": [
-    "from skopt import Optimizer\n",
-    "from skopt.learning import GaussianProcessRegressor\n",
-    "from skopt.space import Real\n",
-    "from sklearn.externals.joblib import Parallel, delayed\n",
-    "# example objective taken from skopt\n",
-    "from skopt.benchmarks import branin\n",
-    "\n",
-    "optimizer = Optimizer(\n",
-    "    base_estimator=GaussianProcessRegressor(),\n",
-    "    dimensions=[Real(-5.0, 10.0), Real(0.0, 15.0)]\n",
-    ")\n",
-    "\n",
-    "for i in range(10): \n",
-    "    x = optimizer.ask(n_points=4)  # x is a list of n_points points    \n",
-    "    y = Parallel()(delayed(branin)(v) for v in x)  # evaluate points in parallel\n",
-    "    optimizer.tell(x, y)\n",
-    "\n",
-    "# takes ~ 20 sec to get here\n",
-    "print(min(optimizer.yi))  # print the best objective found "
-   ]
+  ],
+  "metadata": {
+    "kernelspec": {
+      "name": "python3",
+      "language": "python",
+      "display_name": "Python 3"
+    },
+    "language_info": {
+      "version": "3.5.2",
+      "file_extension": ".py",
+      "codemirror_mode": {
+        "version": 3,
+        "name": "ipython"
+      },
+      "mimetype": "text/x-python",
+      "nbconvert_exporter": "python",
+      "name": "python",
+      "pygments_lexer": "ipython3"
+    },
+    "kernel_info": {
+      "name": "python3"
+    },
+    "nteract": {
+      "version": "0.3.2"
+    }
   },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "Note that if `n_points` is set to some integer > 0 for the `ask` method, the result will be a list of points, even for `n_points`=1. If the argument is set to `None` (default value) then a single point (but not a list of points) will be returned.\n",
-    "\n",
-    "The default \"minimum constant liar\" [1] parallelization strategy is used in the example, which allows to obtain multiple points for evaluation with a single call to the `ask` method with any surrogate or acquisition function. Paralellization strategy can be set using the \"strategy\" argument of `ask`. For supported parallelization strategies see the documentation of scikit-optimize. "
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "[1] [https://hal.archives-ouvertes.fr/hal-00732512/document](https://hal.archives-ouvertes.fr/hal-00732512/document) ."
-   ]
-  }
- ],
- "metadata": {
-  "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
-   "name": "python3"
-  },
-  "language_info": {
-   "codemirror_mode": {
-    "name": "ipython",
-    "version": 3
-   },
-   "file_extension": ".py",
-   "mimetype": "text/x-python",
-   "name": "python",
-   "nbconvert_exporter": "python",
-   "pygments_lexer": "ipython3",
-   "version": "3.5.2"
-  }
- },
- "nbformat": 4,
- "nbformat_minor": 0
+  "nbformat": 4,
+  "nbformat_minor": 0
 }

--- a/skopt/learning/gaussian_process/gpr.py
+++ b/skopt/learning/gaussian_process/gpr.py
@@ -152,7 +152,7 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
         Estimate of the gaussian noise. Useful only when noise is set to
         "gaussian".
     """
-    def __init__(self, kernel=None, alpha=0.0,
+    def __init__(self, kernel=None, alpha=1e-10,
                  optimizer="fmin_l_bfgs_b", n_restarts_optimizer=0,
                  normalize_y=False, copy_X_train=True, random_state=None,
                  noise=None):

--- a/skopt/learning/gaussian_process/tests/test_gpr.py
+++ b/skopt/learning/gaussian_process/tests/test_gpr.py
@@ -98,3 +98,26 @@ def test_std_gradient():
     num_grad = optimize.approx_fprime(
         X_new, lambda x: predict_wrapper(x, gpr)[1], 1e-4)
     assert_array_almost_equal(std_grad, num_grad, decimal=3)
+
+
+def test_gpr_handles_similar_points():
+    """
+    This tests whether our implementation of GPR
+    does not crash when the covariance matrix whose
+    inverse is calculated during fitting of the
+    regressor is singular.
+    Singular covariance matrix often indicates
+    that same or very close points are explored
+    during the optimization procedure.
+
+    Essentially checks that the default value of `alpha` is non zero.
+    """
+    X = np.random.rand(8, 3)
+    y = np.random.rand(8)
+
+    X[:3, :] = 0.0
+    y[:3] = 1.0
+
+    model = GaussianProcessRegressor()
+    # this fails if singular matrix is not handled
+    model.fit(X, y)

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -325,7 +325,8 @@ class Optimizer(object):
         # Copy of the optimizer is made in order to manage the
         # deletion of points with "lie" objective (the copy of
         # oiptimizer is simply discarded)
-        opt = self.copy()
+        opt = self.copy(random_state=self.rng.randint(0,
+                                                      np.iinfo(np.int32).max))
 
         X = []
         for i in range(n_points):

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -334,7 +334,7 @@ def cook_estimator(base_estimator, space=None, **kwargs):
 
         base_estimator = GaussianProcessRegressor(
             kernel=cov_amplitude * other_kernel,
-            normalize_y=True, alpha=0.0, noise="gaussian",
+            normalize_y=True, noise="gaussian",
             n_restarts_optimizer=2)
     elif base_estimator == "RF":
         base_estimator = RandomForestRegressor(n_estimators=100,


### PR DESCRIPTION
This does two things: tries to fix the Circlie CI error we keep seeing about "not pos def matrix" in the parallel evaluation example and makes the calls with a parallel strategy reproducible by fixing the seed.