### PR TITLE
[MRG+1] Fix compatibility with sklearn

### DIFF
--- a/examples/sklearn-gridsearchcv-replacement.ipynb
+++ b/examples/sklearn-gridsearchcv-replacement.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Scikit-learn hyperparameter search wrapper\n",
     "\n",
@@ -11,7 +14,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Introduction\n",
     "\n",
@@ -31,7 +37,11 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -71,7 +81,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Advanced example \n",
     "\n",
@@ -81,7 +94,11 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {},
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [
     {
      "name": "stdout",
@@ -144,8 +161,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (Spyder)",
-   "language": "python3",
+   "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -158,9 +175,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/examples/sklearn-gridsearchcv-replacement.ipynb
+++ b/examples/sklearn-gridsearchcv-replacement.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Scikit-learn hyperparameter search wrapper\n",
     "\n",
@@ -14,10 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Introduction\n",
     "\n",
@@ -36,24 +30,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 6,
+   "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/lib/python3.6/site-packages/sklearn/model_selection/_split.py:2026: FutureWarning: From version 0.21, test_size will always complement train_size unless both are specified.\n",
+      "  FutureWarning)\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "val. score: 0.983667409057\n",
+      "val. score: 0.985894580549\n",
       "test score: 0.982222222222\n"
      ]
     }
    ],
    "source": [
-    "from skopt import BayesSearchCV\n",
     "from sklearn.datasets import load_digits\n",
     "from sklearn.svm import SVC\n",
     "from sklearn.model_selection import train_test_split\n",
@@ -81,10 +78,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Advanced example \n",
     "\n",
@@ -93,19 +87,23 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "execution_count": 7,
+   "metadata": {},
    "outputs": [
+    {
+     "name": "stderr",
+     "output_type": "stream",
+     "text": [
+      "/usr/lib/python3.6/site-packages/sklearn/model_selection/_split.py:2026: FutureWarning: From version 0.21, test_size will always complement train_size unless both are specified.\n",
+      "  FutureWarning)\n"
+     ]
+    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "val. score: 0.985894580549\n",
-      "test score: 0.982222222222\n"
+      "val. score: 0.991833704529\n",
+      "test score: 0.993333333333\n"
      ]
     }
    ],
@@ -161,8 +159,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -175,9 +173,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/sklearn-gridsearchcv-replacement.ipynb
+++ b/examples/sklearn-gridsearchcv-replacement.ipynb
@@ -2,10 +2,7 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "# Scikit-learn hyperparameter search wrapper\n",
     "\n",
@@ -14,10 +11,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Introduction\n",
     "\n",
@@ -37,11 +31,7 @@
   {
    "cell_type": "code",
    "execution_count": 11,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -81,10 +71,7 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "source": [
     "## Advanced example \n",
     "\n",
@@ -94,11 +81,7 @@
   {
    "cell_type": "code",
    "execution_count": 1,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true
-   },
+   "metadata": {},
    "outputs": [
     {
      "name": "stdout",
@@ -157,87 +140,12 @@
     "print(\"val. score: %s\" % opt.best_score_)\n",
     "print(\"test score: %s\" % opt.score(X_test, y_test))"
    ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "deletable": true,
-    "editable": true
-   },
-   "source": [
-    "## Iterative search utilizing `step` function\n",
-    "\n",
-    "A single call to `step` function of the `BayesSearchCV` instance allows to perform partial search for at most `n_jobs` points in parallel. This allows to use custom stopping criterions and to pickle a parameter search class instance to the file for recovery in case of failures of any sort or in case computations need to be transported to a different machine. \n",
-    "\n",
-    "An example usage is shown below. "
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": 2,
-   "metadata": {
-    "collapsed": false,
-    "deletable": true,
-    "editable": true,
-    "scrolled": true
-   },
-   "outputs": [
-    {
-     "name": "stdout",
-     "output_type": "stream",
-     "text": [
-      "0 0.0955555555556\n",
-      "1 0.0955555555556\n",
-      "2 0.94\n",
-      "3 0.94\n",
-      "4 0.94\n",
-      "5 0.94\n",
-      "6 0.975555555556\n",
-      "7 0.975555555556\n",
-      "8 0.975555555556\n",
-      "9 0.971111111111\n",
-      "10 0.991111111111\n",
-      "11 0.993333333333\n",
-      "12 0.993333333333\n",
-      "13 0.993333333333\n",
-      "14 0.993333333333\n",
-      "15 0.993333333333\n"
-     ]
-    }
-   ],
-   "source": [
-    "from skopt.space import Real, Categorical, Integer\n",
-    "from skopt import BayesSearchCV\n",
-    "\n",
-    "from sklearn.datasets import load_digits\n",
-    "from sklearn.svm import SVC\n",
-    "from sklearn.model_selection import train_test_split\n",
-    "\n",
-    "X, y = load_digits(10, True)\n",
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.75, random_state=0)\n",
-    "\n",
-    "opt = BayesSearchCV(SVC())\n",
-    "\n",
-    "# add instance of a search space \n",
-    "opt.add_spaces('space_1', {\n",
-    "    'C': Real(1e-6, 1e+6, prior='log-uniform'),\n",
-    "    'gamma': Real(1e-6, 1e+1, prior='log-uniform'),\n",
-    "})\n",
-    "\n",
-    "for i in range(16):\n",
-    "    opt.step(X_train, y_train, 'space_1')\n",
-    "    # save the model or use custom stopping criterion here\n",
-    "    # model is updated after every step\n",
-    "    # ...\n",
-    "    score = opt.score(X_test, y_test)\n",
-    "    print(i, score)"
-   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
-   "language": "python",
+   "display_name": "Python 3 (Spyder)",
+   "language": "python3",
    "name": "python3"
   },
   "language_info": {
@@ -250,9 +158,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.5.2"
+   "version": "3.6.3"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 0
+ "nbformat_minor": 1
 }

--- a/examples/sklearn-gridsearchcv-replacement.ipynb
+++ b/examples/sklearn-gridsearchcv-replacement.ipynb
@@ -2,7 +2,10 @@
  "cells": [
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "# Scikit-learn hyperparameter search wrapper\n",
     "\n",
@@ -11,7 +14,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Introduction\n",
     "\n",
@@ -30,27 +36,24 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 6,
-   "metadata": {},
+   "execution_count": 11,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3.6/site-packages/sklearn/model_selection/_split.py:2026: FutureWarning: From version 0.21, test_size will always complement train_size unless both are specified.\n",
-      "  FutureWarning)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "val. score: 0.985894580549\n",
+      "val. score: 0.983667409057\n",
       "test score: 0.982222222222\n"
      ]
     }
    ],
    "source": [
+    "from skopt import BayesSearchCV\n",
     "from sklearn.datasets import load_digits\n",
     "from sklearn.svm import SVC\n",
     "from sklearn.model_selection import train_test_split\n",
@@ -78,7 +81,10 @@
   },
   {
    "cell_type": "markdown",
-   "metadata": {},
+   "metadata": {
+    "deletable": true,
+    "editable": true
+   },
    "source": [
     "## Advanced example \n",
     "\n",
@@ -87,23 +93,19 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 7,
-   "metadata": {},
+   "execution_count": 1,
+   "metadata": {
+    "collapsed": false,
+    "deletable": true,
+    "editable": true
+   },
    "outputs": [
-    {
-     "name": "stderr",
-     "output_type": "stream",
-     "text": [
-      "/usr/lib/python3.6/site-packages/sklearn/model_selection/_split.py:2026: FutureWarning: From version 0.21, test_size will always complement train_size unless both are specified.\n",
-      "  FutureWarning)\n"
-     ]
-    },
     {
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "val. score: 0.991833704529\n",
-      "test score: 0.993333333333\n"
+      "val. score: 0.985894580549\n",
+      "test score: 0.982222222222\n"
      ]
     }
    ],
@@ -159,8 +161,8 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3 (Spyder)",
-   "language": "python3",
+   "display_name": "Python 3",
+   "language": "python",
    "name": "python3"
   },
   "language_info": {
@@ -173,9 +175,9 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.3"
+   "version": "3.5.2"
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 0
 }

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -613,9 +613,6 @@ class BayesSearchCV(BaseSearchCV):
         params_dict: dictionary with parameter values.
         """
 
-        if not hasattr(self, 'search_spaces_'):
-            self.search_spaces_ = {}
-
         # convert n_jobst to int > 0 if necessary
         if n_jobs < 0:
             n_jobs = max(1, cpu_count() + n_jobs + 1)
@@ -684,7 +681,7 @@ class BayesSearchCV(BaseSearchCV):
             Group labels for the samples used while splitting the dataset into
             train/test set.
         """
-            
+
         # check if the list of parameter spaces is provided. If not, then
         # only step in manual mode can be used.
         # can be None if user intends to provide spaces manually with add_space before the fit()

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -288,6 +288,9 @@ class BayesSearchCV(BaseSearchCV):
     def _check_search_space(self, search_space):
         """Checks whether the search space argument is correct"""
 
+        search_spaces = [self.search_spaces] if isinstance(
+                self.search_spaces, dict) else self.search_spaces
+
         # check if the structure of the space is proper
         if isinstance(search_space, list):
             # convert to just a list of dicts

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -375,10 +375,11 @@ class BayesSearchCV(BaseSearchCV):
         
         self.optimizer_ = {} if not hasattr(self, 'optimizer_') else self.optimizer_
 
-        if self.optimizer_kwrgs is None:
-            self.optimizer_kwargs = {}
-        else:
-            self.optimizer_kwargs = self.optimizer_kwrgs
+        if not hasattr(self, 'optimizer_kwargs'):
+            if self.optimizer_kwrgs is None:
+                self.optimizer_kwargs = {}
+            else:
+                self.optimizer_kwargs = self.optimizer_kwrgs
 
         self._check_search_space(search_spaces)
 

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -44,7 +44,7 @@ class BayesSearchCV(BaseSearchCV):
         or ``scoring`` must be passed.
 
     search_spaces : dict, list of dict or list of tuple containing
-        (dict, int), or None.
+        (dict, int).
         One of 4 following cases:
         1. dictionary, where keys are parameter names (strings)
         and values are skopt.space.Dimension instances (Real, Integer
@@ -61,8 +61,6 @@ class BayesSearchCV(BaseSearchCV):
         some search subspace, similarly as in case 2, and second element
         is a number of iterations that will be spent optimizing over
         this subspace.
-        4. None, in which case it is assumed that a user will provide
-        search space via the `add_spaces` function.
 
     n_iter : int, default=128
         Number of parameter settings that are sampled. n_iter trades

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -276,8 +276,7 @@ class BayesSearchCV(BaseSearchCV):
         self.n_iter = n_iter
         self.random_state = random_state
         self.optimizer_kwargs = optimizer_kwargs
-        if self.search_spaces is not None:
-            self._check_search_space(self.search_spaces)
+        self._check_search_space(self.search_spaces)
 
         super(BayesSearchCV, self).__init__(
              estimator=estimator, scoring=scoring, fit_params=fit_params,
@@ -288,8 +287,9 @@ class BayesSearchCV(BaseSearchCV):
     def _check_search_space(self, search_space):
         """Checks whether the search space argument is correct"""
 
-        search_spaces = [self.search_spaces] if isinstance(
-                self.search_spaces, dict) else self.search_spaces
+        # check if space is a single dict, convert to list if so
+        if isinstance(search_space, dict):
+            search_space = [search_space]
 
         # check if the structure of the space is proper
         if isinstance(search_space, list):
@@ -574,8 +574,9 @@ class BayesSearchCV(BaseSearchCV):
             train/test set.
         """
 
-        search_spaces = [self.search_spaces] if isinstance(
-                self.search_spaces, dict) else self.search_spaces
+        # check if space is a single dict, convert to list if so
+        if isinstance(search_space, dict):
+            search_space = [search_space]
 
         self.search_spaces_ = {}
         for space, name in zip(search_spaces, list(range(len(search_spaces)))):

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -266,7 +266,7 @@ class BayesSearchCV(BaseSearchCV):
 
     """
 
-    def __init__(self, estimator, search_spaces=None, optimizer_kwargs=None,
+    def __init__(self, estimator, search_spaces, optimizer_kwargs=None,
                  n_iter=50, scoring=None, fit_params=None, n_jobs=1,
                  iid=True, refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', random_state=None,

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -619,6 +619,7 @@ class BayesSearchCV(BaseSearchCV):
         if not hasattr(self, 'search_spaces_') and self.search_spaces is not None:
             search_spaces = [self.search_spaces] if isinstance(self.search_spaces, dict) else self.search_spaces
             self.add_spaces(list(range(len(search_spaces))), search_spaces)
+        self.search_spaces_ = {} if not hasattr(self, 'search_spaces_') else self.search_spaces_
 
         self.cv_results_ = defaultdict(list) if not hasattr(self, 'cv_results_') else self.cv_results_
         self.best_index_ = None if not hasattr(self, 'best_index_') else self.best_index_
@@ -699,6 +700,8 @@ class BayesSearchCV(BaseSearchCV):
         if self.search_spaces is not None:
             search_spaces = [self.search_spaces] if isinstance(self.search_spaces, dict) else self.search_spaces
             self.add_spaces(list(range(len(search_spaces))), search_spaces)
+
+        self.search_spaces_ = {} if not hasattr(self, 'search_spaces_') else self.search_spaces_
 
         self.cv_results_ = defaultdict(list) if not hasattr(self, 'cv_results_') else self.cv_results_
         self.best_index_ = None if not hasattr(self, 'best_index_') else self.best_index_

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -578,7 +578,7 @@ class BayesSearchCV(BaseSearchCV):
         if self.optimizer_kwargs is None:
             self.optimizer_kwargs_ = {}
         else:
-            self.optimizer_kwargs_ = self.optimizer_kwargs
+            self.optimizer_kwargs_ = dict(self.optimizer_kwargs)
         random_state = check_random_state(self.random_state)
         self.optimizer_kwargs_['random_state'] = random_state
 

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -575,20 +575,23 @@ class BayesSearchCV(BaseSearchCV):
         """
 
         # check if space is a single dict, convert to list if so
-        if isinstance(search_space, dict):
-            search_space = [search_space]
+        search_spaces = self.search_spaces
+        if isinstance(search_spaces, dict):
+            search_spaces = [search_spaces]
 
         self.search_spaces_ = {}
         for space, name in zip(search_spaces, list(range(len(search_spaces)))):
             self.search_spaces_[name] = space
 
-        # Instanciate optimizers for all the search spaces.
-        self.optimizer_ = {}
-        for space_id in self.search_spaces_.keys():
-            self.optimizer_[space_id] = self._make_optimizer(search_spaces)
-
         self.optimizer_kwargs_ = {} if self.optimizer_kwargs is None else\
             self.optimizer_kwargs
+
+        # Instanciate optimizers for all the search spaces.
+        self.optimizer_ = {}
+        for space_id, search_space in self.search_spaces_.items():
+            if isinstance(search_space, tuple):
+                search_space = search_space[0]
+            self.optimizer_[space_id] = self._make_optimizer(search_space)
 
         self.cv_results_ = defaultdict(list)
         self.best_index_ = None
@@ -613,7 +616,7 @@ class BayesSearchCV(BaseSearchCV):
             # do the optimization for particular search space
             while n_iter > 0:
                 # when n_iter < n_jobs points left for evaluation
-                n_jobs_adjusted = min(n_iter, self.n_jobs)
+                n_jobs_adjusted = min(n_iter, n_jobs)
 
                 self._step(
                     X, y, space_id,

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -288,10 +288,6 @@ class BayesSearchCV(BaseSearchCV):
     def _check_search_space(self, search_space):
         """Checks whether the search space argument is correct"""
 
-        # check if space is a single dict, convert to list if so
-        if isinstance(search_space, dict):
-            search_space = [search_space]
-
         # check if the structure of the space is proper
         if isinstance(search_space, list):
             # convert to just a list of dicts

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -287,14 +287,14 @@ class BayesSearchCV(BaseSearchCV):
     def _check_search_space(self, search_space):
         """Checks whether the search space argument is correct"""
 
+        if len(search_space) == 0:
+            raise ValueError(
+                "Please provide at least one non-empty search space"
+            )
+
         # check if space is a single dict, convert to list if so
         if isinstance(search_space, dict):
             search_space = [search_space]
-
-        if len(self.search_spaces) == 0:
-            raise ValueError(
-                "Please provide at least one search space"
-            )
 
         # check if the structure of the space is proper
         if isinstance(search_space, list):

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -616,7 +616,7 @@ class BayesSearchCV(BaseSearchCV):
         # check if the list of parameter spaces is provided. If not, then
         # only step in manual mode can be used.
         # can be None if user intends to provide spaces manually with add_space before the fit()
-        if self.search_spaces is not None:
+        if not hasattr(self, 'search_spaces_') and self.search_spaces is not None:
             search_spaces = [self.search_spaces] if isinstance(self.search_spaces, dict) else self.search_spaces
             self.add_spaces(list(range(len(search_spaces))), search_spaces)
 

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -601,7 +601,6 @@ class BayesSearchCV(BaseSearchCV):
             # if not provided with search subspace, n_iter is taken as
             # self.n_iter
 
-            n_iter = self.n_iter
             if isinstance(search_space, tuple):
                 search_space, n_iter = search_space
             else:

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -291,7 +291,7 @@ class BayesSearchCV(BaseSearchCV):
         if isinstance(search_space, dict):
             search_space = [search_space]
 
-        if len(self.search_spaces_) == 0:
+        if len(self.search_spaces) == 0:
             raise ValueError(
                 "Please provide at least one search space"
             )
@@ -618,7 +618,7 @@ class BayesSearchCV(BaseSearchCV):
                 )
                 n_iter -= n_jobs
 
-        # fit the best model if necessary
+        # Refit the best model on the the whole dataset
         if self.refit:
             self._fit_best_model(X, y)
 

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -45,7 +45,7 @@ class BayesSearchCV(BaseSearchCV):
 
     search_spaces : dict, list of dict or list of tuple containing
         (dict, int).
-        One of 4 following cases:
+        One of these cases:
         1. dictionary, where keys are parameter names (strings)
         and values are skopt.space.Dimension instances (Real, Integer
         or Categorical) or any other valid value that defines skopt

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -517,10 +517,6 @@ class BayesSearchCV(BaseSearchCV):
 
     def _step(self, X, y, space_id, groups=None, n_jobs=1):
         """Generate n_jobs parameters and evaluate them in parallel.
-
-        Having a separate function for a single step for search allows to
-        save easily checkpoints for the parameter search and restore from
-        possible failures.
         """
 
         # get the search space for a step

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -268,7 +268,7 @@ class BayesSearchCV(BaseSearchCV):
 
     """
 
-    def __init__(self, estimator, search_spaces=None, optimizer_kwrgs=None,
+    def __init__(self, estimator, search_spaces=None, optimizer_kwargs=None,
                  n_iter=50, scoring=None, fit_params=None, n_jobs=1,
                  iid=True, refit=True, cv=None, verbose=0,
                  pre_dispatch='2*n_jobs', random_state=None,
@@ -277,7 +277,7 @@ class BayesSearchCV(BaseSearchCV):
         self.search_spaces = search_spaces
         self.n_iter = n_iter
         self.random_state = random_state
-        self.optimizer_kwrgs = optimizer_kwrgs
+        self.optimizer_kwargs = optimizer_kwargs
         if self.search_spaces is not None:
             self._check_search_space(self.search_spaces)
 
@@ -377,11 +377,11 @@ class BayesSearchCV(BaseSearchCV):
         
         self.optimizer_ = {} if not hasattr(self, 'optimizer_') else self.optimizer_
 
-        if not hasattr(self, 'optimizer_kwargs'):
-            if self.optimizer_kwrgs is None:
-                self.optimizer_kwargs = {}
+        if not hasattr(self, 'optimizer_kwargs_'):
+            if self.optimizer_kwargs is None:
+                self.optimizer_kwargs_ = {}
             else:
-                self.optimizer_kwargs = self.optimizer_kwrgs
+                self.optimizer_kwargs_ = self.optimizer_kwargs
 
         self._check_search_space(search_spaces)
 
@@ -577,7 +577,7 @@ class BayesSearchCV(BaseSearchCV):
 
         """
 
-        kwargs = self.optimizer_kwargs.copy()
+        kwargs = self.optimizer_kwargs_.copy()
         kwargs['dimensions'] = dimensions_aslist(params_space)
         optimizer = Optimizer(**kwargs)
 
@@ -619,14 +619,19 @@ class BayesSearchCV(BaseSearchCV):
         # only step in manual mode can be used.
         # can be None if user intends to provide spaces manually with add_space before the fit()
         if not hasattr(self, 'search_spaces_') and self.search_spaces is not None:
-            search_spaces = [self.search_spaces] if isinstance(self.search_spaces, dict) else self.search_spaces
+            search_spaces = [self.search_spaces] if isinstance(
+                self.search_spaces, dict) else self.search_spaces
             self.add_spaces(list(range(len(search_spaces))), search_spaces)
-        self.search_spaces_ = {} if not hasattr(self, 'search_spaces_') else self.search_spaces_
+        self.search_spaces_ = {} if not hasattr(
+            self, 'search_spaces_') else self.search_spaces_
 
-        self.cv_results_ = defaultdict(list) if not hasattr(self, 'cv_results_') else self.cv_results_
-        self.best_index_ = None if not hasattr(self, 'best_index_') else self.best_index_
-        self.multimetric_ = False if not hasattr(self, 'multimetric_') else self.multimetric_
-        
+        self.cv_results_ = defaultdict(list) if not hasattr(
+                self, 'cv_results_') else self.cv_results_
+        self.best_index_ = None if not hasattr(
+            self, 'best_index_') else self.best_index_
+        self.multimetric_ = False if not hasattr(
+            self, 'multimetric_') else self.multimetric_
+
         # convert n_jobst to int > 0 if necessary
         if n_jobs < 0:
             n_jobs = max(1, cpu_count() + n_jobs + 1)
@@ -699,16 +704,19 @@ class BayesSearchCV(BaseSearchCV):
         # check if the list of parameter spaces is provided. If not, then
         # only step in manual mode can be used.
         # can be None if user intends to provide spaces manually with add_space before the fit()
+        search_spaces = [self.search_spaces] if isinstance(
+            self.search_spaces, dict) else self.search_spaces
+
         if self.search_spaces is not None:
-            search_spaces = [self.search_spaces] if isinstance(self.search_spaces, dict) else self.search_spaces
             self.add_spaces(list(range(len(search_spaces))), search_spaces)
 
-        self.search_spaces_ = {} if not hasattr(self, 'search_spaces_') else self.search_spaces_
+        self.search_spaces_ = {} if not hasattr(
+            self, 'search_spaces_') else self.search_spaces_
 
-        self.cv_results_ = defaultdict(list) if not hasattr(self, 'cv_results_') else self.cv_results_
-        self.best_index_ = None if not hasattr(self, 'best_index_') else self.best_index_
-        self.multimetric_ = False if not hasattr(self, 'multimetric_') else self.multimetric_
-            
+        self.cv_results_ = defaultdict(list)
+        self.best_index_ = None
+        self.multimetric_ = False
+
         if len(self.search_spaces_) == 0:
             raise ValueError(
                 "Please provide search space using `add_spaces` first before"

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -686,9 +686,7 @@ class BayesSearchCV(BaseSearchCV):
         # only step in manual mode can be used.
         # can be None if user intends to provide spaces manually with add_space before the fit()
         if self.search_spaces is not None:
-            # account for the case when search space is a dict
-            if isinstance(self.search_spaces, dict):
-                search_spaces = [self.search_spaces]
+            search_spaces = [self.search_spaces] if isinstance(self.search_spaces, dict) else self.search_spaces
             self.add_spaces(list(range(len(search_spaces))), search_spaces)
 
         self.cv_results_ = defaultdict(list) if not hasattr(self, 'cv_results_') else self.cv_results_

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -727,3 +727,4 @@ class BayesSearchCV(BaseSearchCV):
                     groups=groups, n_jobs=n_jobs_adjusted
                 )
                 n_iter -= n_jobs
+        return self

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -582,11 +582,11 @@ class BayesSearchCV(BaseSearchCV):
             self.optimizer_kwargs_ = self.optimizer_kwargs
 
         # Instanciate optimizers for all the search spaces.
-        self.optimizer_ = {}
-        for space_id, search_space in enumerate(search_spaces):
+        self.optimizer_ = []
+        for search_space in search_spaces:
             if isinstance(search_space, tuple):
                 search_space = search_space[0]
-            self.optimizer_[space_id] = self._make_optimizer(search_space)
+            self.optimizer_.append(self._make_optimizer(search_space))
 
         self.cv_results_ = defaultdict(list)
         self.best_index_ = None

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -291,6 +291,11 @@ class BayesSearchCV(BaseSearchCV):
         if isinstance(search_space, dict):
             search_space = [search_space]
 
+        if len(self.search_spaces_) == 0:
+            raise ValueError(
+                "Please provide at least one search space"
+            )
+
         # check if the structure of the space is proper
         if isinstance(search_space, list):
             # convert to just a list of dicts

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -574,17 +574,16 @@ class BayesSearchCV(BaseSearchCV):
         search_spaces = self.search_spaces
         if isinstance(search_spaces, dict):
             search_spaces = [search_spaces]
+        self.search_spaces_ = search_spaces
 
-        self.search_spaces_ = {}
-        for space, name in zip(search_spaces, list(range(len(search_spaces)))):
-            self.search_spaces_[name] = space
-
-        self.optimizer_kwargs_ = {} if self.optimizer_kwargs is None else\
-            self.optimizer_kwargs
+        if self.optimizer_kwargs is None:
+            self.optimizer_kwargs_ = {}
+        else:
+            self.optimizer_kwargs_ = self.optimizer_kwargs
 
         # Instanciate optimizers for all the search spaces.
         self.optimizer_ = {}
-        for space_id, search_space in self.search_spaces_.items():
+        for space_id, search_space in enumerate(search_spaces):
             if isinstance(search_space, tuple):
                 search_space = search_space[0]
             self.optimizer_[space_id] = self._make_optimizer(search_space)
@@ -599,7 +598,7 @@ class BayesSearchCV(BaseSearchCV):
         if n_jobs < 0:
             n_jobs = max(1, cpu_count() + n_jobs + 1)
 
-        for space_id in sorted(self.search_spaces_.keys()):
+        for space_id in range(len(self.search_spaces_)):
             elem = self.search_spaces_[space_id]
 
             # if not provided with search subspace, n_iter is taken as

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -603,11 +603,11 @@ class BayesSearchCV(BaseSearchCV):
         for search_space, optimizer in zip(search_spaces, optimizers):
             # if not provided with search subspace, n_iter is taken as
             # self.n_iter
-
             if isinstance(search_space, tuple):
                 search_space, n_iter = search_space
             else:
                 n_iter = self.n_iter
+
             # do the optimization for particular search space
             while n_iter > 0:
                 # when n_iter < n_jobs points left for evaluation

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -278,6 +278,7 @@ class BayesSearchCV(BaseSearchCV):
         self.n_iter = n_iter
         self.random_state = random_state
         self.optimizer_kwrgs = optimizer_kwrgs
+        self._check_search_space(self.search_spaces)
 
         super(BayesSearchCV, self).__init__(
              estimator=estimator, scoring=scoring, fit_params=fit_params,

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -556,13 +556,11 @@ class BayesSearchCV(BaseSearchCV):
         Parameters
         ----------
         X : array-like or sparse matrix, shape = [n_samples, n_features]
-            The training input samples. Internally, it will be converted to
-            ``dtype=np.float32`` and if a sparse matrix is provided
-            to a sparse ``csc_matrix``.
+            The training input samples.
 
         y : array-like, shape = [n_samples] or [n_samples, n_output]
             Target relative to X for classification or regression (class
-            labels, as integers or strings).
+            labels should be integers or strings).
 
         groups : array-like, with shape (n_samples,), optional
             Group labels for the samples used while splitting the dataset into

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -613,6 +613,17 @@ class BayesSearchCV(BaseSearchCV):
         params_dict: dictionary with parameter values.
         """
 
+        # check if the list of parameter spaces is provided. If not, then
+        # only step in manual mode can be used.
+        # can be None if user intends to provide spaces manually with add_space before the fit()
+        if self.search_spaces is not None:
+            search_spaces = [self.search_spaces] if isinstance(self.search_spaces, dict) else self.search_spaces
+            self.add_spaces(list(range(len(search_spaces))), search_spaces)
+
+        self.cv_results_ = defaultdict(list) if not hasattr(self, 'cv_results_') else self.cv_results_
+        self.best_index_ = None if not hasattr(self, 'best_index_') else self.best_index_
+        self.multimetric_ = False if not hasattr(self, 'multimetric_') else self.multimetric_
+        
         # convert n_jobst to int > 0 if necessary
         if n_jobs < 0:
             n_jobs = max(1, cpu_count() + n_jobs + 1)

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -278,7 +278,8 @@ class BayesSearchCV(BaseSearchCV):
         self.n_iter = n_iter
         self.random_state = random_state
         self.optimizer_kwrgs = optimizer_kwrgs
-        self._check_search_space(self.search_spaces)
+        if self.search_spaces is not None:
+            self._check_search_space(self.search_spaces)
 
         super(BayesSearchCV, self).__init__(
              estimator=estimator, scoring=scoring, fit_params=fit_params,

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -8,6 +8,7 @@ import sklearn
 from sklearn.base import is_classifier, clone
 from sklearn.externals.joblib import Parallel, delayed, cpu_count
 from sklearn.model_selection._search import BaseSearchCV
+from sklearn.utils import check_random_state
 from sklearn.utils.fixes import MaskedArray
 from sklearn.utils.validation import indexable, check_is_fitted
 from sklearn.metrics.scorer import check_scoring
@@ -154,7 +155,8 @@ class BayesSearchCV(BaseSearchCV):
     from sklearn.model_selection import train_test_split
 
     X, y = load_iris(True)
-    X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.75, random_state=0)
+    X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.75,
+                                                        random_state=0)
 
     # log-uniform: understand as search over p = exp(x) by varying x
     opt = BayesSearchCV(
@@ -289,7 +291,8 @@ class BayesSearchCV(BaseSearchCV):
 
         if len(search_space) == 0:
             raise ValueError(
-                "Please provide at least one non-empty search space"
+                "The search_spaces parameter should contain at least one"
+                "non-empty search space, got %s" % search_space
             )
 
         # check if space is a single dict, convert to list if so
@@ -576,6 +579,8 @@ class BayesSearchCV(BaseSearchCV):
             self.optimizer_kwargs_ = {}
         else:
             self.optimizer_kwargs_ = self.optimizer_kwargs
+        random_state = check_random_state(self.random_state)
+        self.optimizer_kwargs_['random_state'] = random_state
 
         # Instantiate optimizers for all the search spaces.
         optimizers = []
@@ -603,7 +608,6 @@ class BayesSearchCV(BaseSearchCV):
                 search_space, n_iter = search_space
             else:
                 n_iter = self.n_iter
-
             # do the optimization for particular search space
             while n_iter > 0:
                 # when n_iter < n_jobs points left for evaluation

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -41,9 +41,6 @@ def test_searchcv_runs(surrogate, n_jobs):
         X, y, train_size=0.75, random_state=0
     )
 
-    # None search space is not supported
-    assert_raises(ValueError, BayesSearchCV(SVC(), None).fit, (X, y))
-
     # check if invalid dimensions are raising errors
     with pytest.raises(ValueError):
         BayesSearchCV(SVC(), {'C': '1 ... 100.0'})

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -9,6 +9,7 @@ from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.svm import SVC, LinearSVC
+from sklearn.ensemble import RandomForestClassifier
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.base import clone
 
@@ -126,7 +127,7 @@ def test_searchcv_runs_multiple_subspaces():
     assert total_evaluations == 1+1+2, "Not all spaces were explored!"
 
 
-def test_searchcv_sklearn_reproducibility():
+def test_searchcv_sklearn_compatibility():
     """
     Test whether the BayesSearchCV is compatible with base sklearn methods
     such as clone, set_params, get_params.
@@ -190,7 +191,7 @@ def test_searchcv_sklearn_reproducibility():
     assert total_evaluations_clone == 1+2
 
 
-def test_searchcv_sklearn_compatibility():
+def test_searchcv_sklearn_reproducibility():
     """
     Test whether results of BayesSearchCV can be reproduced with a fixed
     random state.
@@ -204,12 +205,10 @@ def test_searchcv_sklearn_compatibility():
     random_state = 42
 
     opt = BayesSearchCV(
-        SVC(random_state=random_state),
+        RandomForestClassifier(random_state=random_state),
         {
-            'C': Real(1e-6, 1e+6, prior='log-uniform'),
-            'gamma': Real(1e-6, 1e+1, prior='log-uniform'),
-            'degree': Integer(1, 8),
-            'kernel': Categorical(['linear', 'poly', 'rbf']),
+            'min_weight_fraction_leaf': Real(0, 0.5, prior='uniform'),
+            'min_impurity_decrease': Real(0, 1, prior='uniform'),
         },
         n_jobs=1, n_iter=11, random_state=random_state
     )

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -41,6 +41,10 @@ def test_searchcv_runs(surrogate, n_jobs):
         X, y, train_size=0.75, random_state=0
     )
 
+    # check if empty search space is raising errors
+    with pytest.raises(ValueError):
+        BayesSearchCV(SVC(), {})
+
     # check if invalid dimensions are raising errors
     with pytest.raises(ValueError):
         BayesSearchCV(SVC(), {'C': '1 ... 100.0'})

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -200,7 +200,7 @@ def test_searchcv_sklearn_compatibility():
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, train_size=0.75, random_state=0
     )
-    
+
     random_state = 42
 
     opt = BayesSearchCV(

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -215,11 +215,12 @@ def test_searchcv_reproducibility():
     )
 
     opt.fit(X_train, y_train)
-    best_estimator = opt.best_estimator_
+    best_est = opt.best_estimator_
 
     opt2 = clone(opt).fit(X_train, y_train)
-    best_estimator2 = opt2.best_estimator_
+    best_est2 = opt2.best_estimator_
 
-    for attr in ('C', 'gamma', 'degree', 'kernel'):
-        assert_equal(getattr(best_estimator, attr),
-                     getattr(best_estimator2, attr))
+    assert getattr(best_est, 'C') == getattr(best_est2, 'C')
+    assert getattr(best_est, 'gamma') == getattr(best_est2, 'gamma')
+    assert getattr(best_est, 'degree') == getattr(best_est2, 'degree')
+    assert getattr(best_est, 'kernel') == getattr(best_est2, 'kernel')

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -200,16 +200,18 @@ def test_searchcv_sklearn_compatibility():
     X_train, X_test, y_train, y_test = train_test_split(
         X, y, train_size=0.75, random_state=0
     )
+    
+    random_state = 42
 
     opt = BayesSearchCV(
-        SVC(),
+        SVC(random_state=random_state),
         {
             'C': Real(1e-6, 1e+6, prior='log-uniform'),
             'gamma': Real(1e-6, 1e+1, prior='log-uniform'),
             'degree': Integer(1, 8),
             'kernel': Categorical(['linear', 'poly', 'rbf']),
         },
-        n_jobs=1, n_iter=11, random_state=42
+        n_jobs=1, n_iter=11, random_state=random_state
     )
 
     opt.fit(X_train, y_train)

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -4,7 +4,6 @@ search with interface similar to those of GridSearchCV
 
 import pytest
 
-from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -11,6 +11,7 @@ from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
 from sklearn.svm import SVC, LinearSVC
 from sklearn.tree import DecisionTreeClassifier
+from sklearn.base import clone
 
 from skopt.space import Real, Categorical, Integer
 from skopt import BayesSearchCV
@@ -120,3 +121,67 @@ def test_searchcv_runs_multiple_subspaces():
     # test if all subspaces are explored
     total_evaluations = len(opt.cv_results_['mean_test_score'])
     assert total_evaluations == 1+1+2, "Not all spaces were explored!"
+
+
+def test_searchcv_sklearn_compatibility():
+    """
+    Test whether the BayesSearchCV is compatible with base sklearn methods
+    such as clone, set_params, get_params.
+    """
+
+    X, y = load_iris(True)
+    X_train, X_test, y_train, y_test = train_test_split(
+        X, y, train_size=0.75, random_state=0
+    )
+
+    # used to try different model classes
+    pipe = Pipeline([
+        ('model', SVC())
+    ])
+
+    # single categorical value of 'model' parameter sets the model class
+    lin_search = {
+        'model': Categorical([LinearSVC()]),
+        'model__C': Real(1e-6, 1e+6, prior='log-uniform'),
+    }
+
+    dtc_search = {
+        'model': Categorical([DecisionTreeClassifier()]),
+        'model__max_depth': Integer(1, 32),
+        'model__min_samples_split': Real(1e-3, 1.0, prior='log-uniform'),
+    }
+
+    svc_search = {
+        'model': Categorical([SVC()]),
+        'model__C': Real(1e-6, 1e+6, prior='log-uniform'),
+        'model__gamma': Real(1e-6, 1e+1, prior='log-uniform'),
+        'model__degree': Integer(1, 8),
+        'model__kernel': Categorical(['linear', 'poly', 'rbf']),
+    }
+
+    opt = BayesSearchCV(
+        pipe,
+        [(lin_search, 1), svc_search],
+        n_iter=2
+    )
+
+    opt_clone = clone(opt)
+
+    params, params_clone = opt.get_params(), opt_clone.get_params()
+    assert params.keys() == params_clone.keys()
+
+    for param, param_clone in zip(params.items(), params_clone.items()):
+        assert param[0] == param_clone[0]
+        assert isinstance(param[1], type(param_clone[1]))
+
+    opt.set_params(search_spaces=[(dtc_search, 1)])
+
+    opt.fit(X_train, y_train)
+    opt_clone.fit(X_train, y_train)
+
+    total_evaluations = len(opt.cv_results_['mean_test_score'])
+    total_evaluations_clone = len(opt_clone.cv_results_['mean_test_score'])
+
+    # test if expected number of subspaces is explored
+    assert total_evaluations == 1
+    assert total_evaluations_clone == 1+2

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -6,7 +6,6 @@ import pytest
 
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_equal
 from sklearn.datasets import load_iris
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
@@ -42,7 +41,7 @@ def test_searchcv_runs(surrogate, n_jobs):
         X, y, train_size=0.75, random_state=0
     )
 
-    # None search space is only supported when only `step` function is used
+    # None search space is not supported
     assert_raises(ValueError, BayesSearchCV(SVC(), None).fit, (X, y))
 
     # check if invalid dimensions are raising errors


### PR DESCRIPTION
Doing *anything* in the `__init__` method of a sklearn estimator will most of the time break his compatibility with sklearn's clone, get_params and set_params, or the ability to fit it several times. It is in fact the case here, it would break if used in a Pipeline or other meta-objects in sklearn.

This PR is a quick (for now, dirty) proposal to fix the compatibility issues.

I've basically moved every lines of code that are not `self.foo = foo`, where foo is an arg, inside the fit() and add_space() methods.

Fixes #550 #551