### PR TITLE
[MRG] Prevent the base_estimator from being wrapped multiple times

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -213,7 +213,8 @@ class Optimizer(object):
             raise ValueError(
                 "%s has to be a regressor." % base_estimator)
 
-        if "ps" in self.acq_func:
+        is_multi_regressor = isinstance(base_estimator, MultiOutputRegressor)
+        if "ps" in self.acq_func and not is_multi_regressor:
             self.base_estimator_ = MultiOutputRegressor(base_estimator)
         else:
             self.base_estimator_ = base_estimator

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -196,13 +196,14 @@ def test_optimizer_copy(acq_func):
     opt = Optimizer([(-2.0, 2.0)], acq_func=acq_func)
     opt_copy = opt.copy()
 
+    base_est = opt_copy.base_estimator_
+
     if "ps" in acq_func:
-        base_est = opt_copy.base_estimator_
         assert_true(isinstance(base_est, MultiOutputRegressor))
         # check that the base_estimator is not wrapped multiple times
         assert_false(isinstance(base_est.estimator, MultiOutputRegressor))
     else:
-        assert not isinstance(opt_copy.base_estimator_, MultiOutputRegressor)
+        assert_false(isinstance(base_est, MultiOutputRegressor))
 
 
 @pytest.mark.parametrize("base_estimator", ESTIMATOR_STRINGS)

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -1,10 +1,12 @@
 import numpy as np
 import pytest
 
+from sklearn.multioutput import MultiOutputRegressor
 from sklearn.utils.testing import assert_array_equal
 from sklearn.utils.testing import assert_equal
 from sklearn.utils.testing import assert_raises
 from sklearn.utils.testing import assert_true
+from sklearn.utils.testing import assert_false
 
 from skopt import gp_minimize
 from skopt import forest_minimize
@@ -20,6 +22,7 @@ TREE_REGRESSORS = (ExtraTreesRegressor(random_state=2),
                    RandomForestRegressor(random_state=2),
                    GradientBoostingQuantileRegressor(random_state=2))
 ACQ_FUNCS_PS = ["EIps", "PIps"]
+ACQ_FUNCS_MIXED = ["EI", "EIps"]
 ESTIMATOR_STRINGS = ["GP", "RF", "ET", "GBRT", "DUMMY",
                      "gp", "rf", "et", "gbrt", "dummy"]
 
@@ -185,6 +188,21 @@ def test_acq_optimizer_with_time_api(base_estimator, acq_func):
 
     with pytest.raises(TypeError) as e:
         opt.tell(x2, bench1(x2))
+
+
+@pytest.mark.fast_test
+@pytest.mark.parametrize("acq_func", ACQ_FUNCS_MIXED)
+def test_optimizer_copy(acq_func):
+    opt = Optimizer([(-2.0, 2.0)], acq_func=acq_func)
+    opt_copy = opt.copy()
+
+    if "ps" in acq_func:
+        base_est = opt_copy.base_estimator_
+        assert_true(isinstance(base_est, MultiOutputRegressor))
+        # check that the base_estimator is not wrapped multiple times
+        assert_false(isinstance(base_est.estimator, MultiOutputRegressor))
+    else:
+        assert not isinstance(opt_copy.base_estimator_, MultiOutputRegressor)
 
 
 @pytest.mark.parametrize("base_estimator", ESTIMATOR_STRINGS)

--- a/skopt/tests/test_parallel_cl.py
+++ b/skopt/tests/test_parallel_cl.py
@@ -16,10 +16,6 @@ import pytest
 
 # list of all strategies for parallelization
 supported_strategies = ["cl_min", "cl_mean", "cl_max"]
-
-# test one acquisition function that incorporates the runtime, and one that does not
-supported_acq_functions = ["EI", "EIps"]
-
 # Extract available surrogates, so that new ones are used automatically
 available_surrogates = [
     getattr(sol, name) for name in sol.__all__
@@ -33,8 +29,7 @@ n_points = 4  # number of points to evaluate at a single step
 
 @pytest.mark.parametrize("strategy", supported_strategies)
 @pytest.mark.parametrize("surrogate", available_surrogates)
-@pytest.mark.parametrize("acq_func", supported_acq_functions)
-def test_constant_liar_runs(strategy, surrogate, acq_func):
+def test_constant_liar_runs(strategy, surrogate):
     """
     Tests whether the optimizer runs properly during the random
     initialization phase and beyond
@@ -63,11 +58,7 @@ def test_constant_liar_runs(strategy, surrogate, acq_func):
         x = optimizer.ask(n_points=n_points, strategy=strategy)
         # check if actually n_points was generated
         assert_equal(len(x), n_points)
-
-        if "ps" in acq_func:
-            optimizer.tell(x, [[branin(v), 1.1] for v in x])
-        else:
-            optimizer.tell(x, [branin(v) for v in x])
+        optimizer.tell(x, [branin(v) for v in x])
 
 
 @pytest.mark.parametrize("strategy", supported_strategies)

--- a/skopt/tests/test_parallel_cl.py
+++ b/skopt/tests/test_parallel_cl.py
@@ -16,6 +16,10 @@ import pytest
 
 # list of all strategies for parallelization
 supported_strategies = ["cl_min", "cl_mean", "cl_max"]
+
+# test one acquisition function that incorporates the runtime, and one that does not
+supported_acq_functions = ["EI", "EIps"]
+
 # Extract available surrogates, so that new ones are used automatically
 available_surrogates = [
     getattr(sol, name) for name in sol.__all__
@@ -29,7 +33,8 @@ n_points = 4  # number of points to evaluate at a single step
 
 @pytest.mark.parametrize("strategy", supported_strategies)
 @pytest.mark.parametrize("surrogate", available_surrogates)
-def test_constant_liar_runs(strategy, surrogate):
+@pytest.mark.parametrize("acq_func", supported_acq_functions)
+def test_constant_liar_runs(strategy, surrogate, acq_func):
     """
     Tests whether the optimizer runs properly during the random
     initialization phase and beyond
@@ -58,7 +63,11 @@ def test_constant_liar_runs(strategy, surrogate):
         x = optimizer.ask(n_points=n_points, strategy=strategy)
         # check if actually n_points was generated
         assert_equal(len(x), n_points)
-        optimizer.tell(x, [branin(v) for v in x])
+
+        if "ps" in acq_func:
+            optimizer.tell(x, [[branin(v), 1.1] for v in x])
+        else:
+            optimizer.tell(x, [branin(v) for v in x])
 
 
 @pytest.mark.parametrize("strategy", supported_strategies)


### PR DESCRIPTION
The previous version used to create copies of the optimizer, which looked like this:

```
MultiOutputRegressor(estimator=MultiOutputRegressor(estimator=GaussianProcessRegressor(alpha=1e-10, copy_X_train=True,
             kernel=1**2 * Matern(length_scale=1, nu=2.5),
             n_restarts_optimizer=2, noise='gaussian', normalize_y=True,
             optimizer='fmin_l_bfgs_b', random_state=2061968400),
           n_jobs=1),
           n_jobs=1)
```
The estimator inside `MultiOutputRegressor` is again a `MultiOutputRegressor`, which is automatically added for acquisition functions that incorporate time (EIps, PIps).

Basically, each call to copy() would wrap another `MultiOutputRegressor` around the base_estimator.
This affects at least #560.