### PR TITLE
[MRG] Ask and tell for runtime optimization

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -339,17 +339,16 @@ class Optimizer(object):
 
             if strategy == "cl_min":
                 y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie
-                t_lie = np.min(ti) if ti else sys.float_info.max
+                t_lie = np.min(ti) if ti is not None else log(sys.float_info.max)
             elif strategy == "cl_mean":
                 y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-mean lie
-                t_lie = np.mean(ti) if ti else sys.float_info.max
+                t_lie = np.mean(ti) if ti is not None else log(sys.float_info.max)
             else:
                 y_lie = np.max(opt.yi) if opt.yi else 0.0  # CL-max lie
-                t_lie = np.max(ti) if ti else sys.float_info.max
+                t_lie = np.max(ti) if ti is not None else log(sys.float_info.max)
 
             # Lie to the optimizer.
             if "ps" in self.acq_func:
-
                 # Use `_tell()` instead of `tell()` to prevent repeated
                 # log transformations of the computation times.
                 opt._tell(x, (y_lie, t_lie))

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -335,7 +335,8 @@ class Optimizer(object):
             x = opt.ask()
             X.append(x)
 
-            ti = [t for (_, t) in opt.yi] if "ps" in self.acq_func else None
+            ti_available = "ps" in self.acq_func and len(opt.yi) > 0
+            ti = [t for (_, t) in opt.yi] if ti_available else None
 
             if strategy == "cl_min":
                 y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -1,3 +1,4 @@
+import sys
 import warnings
 from math import log
 from numbers import Number
@@ -333,13 +334,27 @@ class Optimizer(object):
         for i in range(n_points):
             x = opt.ask()
             X.append(x)
+
+            ti = [t for (_, t) in opt.yi] if "ps" in self.acq_func else None
+
             if strategy == "cl_min":
                 y_lie = np.min(opt.yi) if opt.yi else 0.0  # CL-min lie
+                t_lie = np.min(ti) if ti else sys.float_info.max
             elif strategy == "cl_mean":
                 y_lie = np.mean(opt.yi) if opt.yi else 0.0  # CL-mean lie
+                t_lie = np.mean(ti) if ti else sys.float_info.max
             else:
                 y_lie = np.max(opt.yi) if opt.yi else 0.0  # CL-max lie
-            opt.tell(x, y_lie)  # lie to the optimizer
+                t_lie = np.max(ti) if ti else sys.float_info.max
+
+            # Lie to the optimizer.
+            if "ps" in self.acq_func:
+
+                # Use `_tell()` instead of `tell()` to prevent repeated
+                # log transformations of the computation times.
+                opt._tell(x, (y_lie, t_lie))
+            else:
+                opt._tell(x, y_lie)
 
         self.cache_ = {(n_points, strategy): X}  # cache_ the result
 

--- a/skopt/tests/test_parallel_cl.py
+++ b/skopt/tests/test_parallel_cl.py
@@ -50,6 +50,7 @@ def test_constant_liar_runs(strategy, surrogate, acq_func):
     optimizer = Optimizer(
         base_estimator=surrogate(),
         dimensions=[Real(-5.0, 10.0), Real(0.0, 15.0)],
+        acq_func=acq_func,
         acq_optimizer='sampling',
         random_state=0
     )

--- a/skopt/tests/test_parallel_cl.py
+++ b/skopt/tests/test_parallel_cl.py
@@ -16,6 +16,10 @@ import pytest
 
 # list of all strategies for parallelization
 supported_strategies = ["cl_min", "cl_mean", "cl_max"]
+
+# test one acq function that incorporates the runtime, and one that does not
+supported_acq_functions = ["EI", "EIps"]
+
 # Extract available surrogates, so that new ones are used automatically
 available_surrogates = [
     getattr(sol, name) for name in sol.__all__
@@ -29,7 +33,8 @@ n_points = 4  # number of points to evaluate at a single step
 
 @pytest.mark.parametrize("strategy", supported_strategies)
 @pytest.mark.parametrize("surrogate", available_surrogates)
-def test_constant_liar_runs(strategy, surrogate):
+@pytest.mark.parametrize("acq_func", supported_acq_functions)
+def test_constant_liar_runs(strategy, surrogate, acq_func):
     """
     Tests whether the optimizer runs properly during the random
     initialization phase and beyond
@@ -58,7 +63,11 @@ def test_constant_liar_runs(strategy, surrogate):
         x = optimizer.ask(n_points=n_points, strategy=strategy)
         # check if actually n_points was generated
         assert_equal(len(x), n_points)
-        optimizer.tell(x, [branin(v) for v in x])
+
+        if "ps" in acq_func:
+            optimizer.tell(x, [[branin(v), 1.1] for v in x])
+        else:
+            optimizer.tell(x, [branin(v) for v in x])
 
 
 @pytest.mark.parametrize("strategy", supported_strategies)


### PR DESCRIPTION
**Update:**

*Description:*
This PR aims to solve the issue discussed in #560. Basically, it should fix the ask and tell API for the cases, where an acquisiton function that incorporates time is used.

*Status:*
- [x] (Unit) Tests
- [x] Code changes
- [x] At least some manual test runs
- ~~Adapt the comments~~ (--> separate task)

*Changes:*
- Most of the work has been done in #572 and #593 
- This issue changes the lying step so that it also generates a time value when lying.
- The time value is generated in a similar way as the lie for objective value. However, when no previous evaluations exist, then the maximum possible runtime time `log(float.max)` is used.

***

Current state:
* I provided (or rather extended) a test which demonstrates the failure

Problems:
* During the lying step the time values are not considered at all (correct me if i am wrong)
* Within the tell step they are somewhat considered, but the result creation fails.

~~Additional Suggestion: The result object built by `create_result` (skopt.utils) should probably contain information about the runtimes as well.~~ (Update: This is already present. Maybe we should explicitly state this in the docstrings.)

(Sorry for the ugly commit history, i mixed up the branches.)