### PR TITLE
[MRG] Add clipping of inverse_transform values

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -240,14 +240,17 @@ class Real(Dimension):
                 self.transform_ == other.transform_)
 
     def __repr__(self):
-        return "Real(low={}, high={}, prior={}, transform={})".format(
+        return "Real(low={}, high={}, prior='{}', transform='{}')".format(
             self.low, self.high, self.prior, self.transform_)
 
     def inverse_transform(self, Xt):
         """Inverse transform samples from the warped space back into the
            orignal space.
         """
-        return super(Real, self).inverse_transform(Xt).astype(np.float)
+        return np.clip(
+            super(Real, self).inverse_transform(Xt).astype(np.float),
+            self.low, self.high
+            )
 
     @property
     def bounds(self):

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -51,6 +51,20 @@ def test_dimensions():
 
 
 @pytest.mark.fast_test
+def test_real_log_sampling_in_bounds():
+    dim = Real(low=1, high=32, prior='log-uniform', transform='normalize')
+
+    # round trip a value that is within the bounds of the space
+    #
+    # x = dim.inverse_transform(dim.transform(31.999999999999999))
+    for n in (32., 31.999999999999999):
+        round_tripped = dim.inverse_transform(dim.transform([n]))
+        assert np.allclose([n], round_tripped)
+        assert n in dim
+        assert round_tripped in dim
+
+
+@pytest.mark.fast_test
 def test_real():
     a = Real(1, 25)
     for i in range(50):


### PR DESCRIPTION
Fixes #586 fixes #470 

Round tripping values using the log10 transform for a Real dimension
can lead to a value that was within the bounds of the space being
outside of the bounds. We now force values to be within bounds by
clipping the return value of inverse_transform() to (low, high).