### PR TITLE
Added support for named arguments to objective function.

### DIFF
--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -3,7 +3,8 @@
 from .base import base_minimize
 
 
-def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
+def dummy_minimize(func, dimensions, use_arg_names=False,
+                   n_calls=100, x0=None, y0=None,
                    random_state=None, verbose=False, callback=None):
     """Random search by uniform sampling within the given bounds.
 
@@ -24,6 +25,13 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
         - as a list of categories (for `Categorical` dimensions), or
         - an instance of a `Dimension` object (`Real`, `Integer` or
           `Categorical`).
+
+    * `use_arg_names` [bool, default=False]:
+        Whether to use use names for the search-space dimensions
+        when calling `func()`.
+        For example, instead of calling `func([123, 3.0, 'hello'])`,
+        it calls `func(foo=123, bar=3.0, baz='hello')` for a search-space
+        with dimensions named `['foo', 'bar', 'baz']`
 
     * `n_calls` [int, default=100]:
         Number of calls to `func` to find the minimum.
@@ -84,9 +92,12 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
     else:
         n_random_calls = n_calls
 
-    return base_minimize(func, dimensions, base_estimator="dummy",
-                         # explicitly set optimizer to sampling as "dummy"
-                         # minimizer does not provide gradients.
+    # TODO: I don't understand this comment.
+    # explicitly set optimizer to sampling as "dummy"
+    # minimizer does not provide gradients.
+    return base_minimize(func=func, dimensions=dimensions,
+                         base_estimator="dummy",
+                         use_arg_names=use_arg_names,
                          acq_optimizer="sampling",
                          n_calls=n_calls, n_random_starts=n_random_calls,
                          x0=x0, y0=y0, random_state=random_state,

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -7,7 +7,8 @@ from ..utils import cook_estimator
 
 
 
-def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
+def forest_minimize(func, dimensions, use_arg_names=False,
+                    base_estimator="ET", n_calls=100,
                     n_random_starts=10, acq_func="EI",
                     x0=None, y0=None, random_state=None, verbose=False,
                     callback=None, n_points=10000, xi=0.01, kappa=1.96,
@@ -48,6 +49,13 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
 
          NOTE: The upper and lower bounds are inclusive for `Integer`
          dimensions.
+
+    * `use_arg_names` [bool, default=False]:
+        Whether to use use names for the search-space dimensions
+        when calling `func()`.
+        For example, instead of calling `func([123, 3.0, 'hello'])`,
+        it calls `func(foo=123, bar=3.0, baz='hello')` for a search-space
+        with dimensions named `['foo', 'bar', 'baz']`
 
     * `base_estimator` [string or `Regressor`, default=`"ET"`]:
         The regressor to use as surrogate model. Can be either
@@ -147,7 +155,9 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
         For more details related to the OptimizeResult object, refer
         http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.OptimizeResult.html
     """
-    return base_minimize(func, dimensions, base_estimator,
+    return base_minimize(func=func, dimensions=dimensions,
+                         base_estimator=base_estimator,
+                         use_arg_names=use_arg_names,
                          n_calls=n_calls, n_points=n_points,
                          n_random_starts=n_random_starts,
                          x0=x0, y0=y0, random_state=random_state,

--- a/skopt/optimizer/gbrt.py
+++ b/skopt/optimizer/gbrt.py
@@ -5,7 +5,7 @@ from .base import base_minimize
 from ..utils import cook_estimator
 
 
-def gbrt_minimize(func, dimensions, base_estimator=None,
+def gbrt_minimize(func, dimensions, use_arg_names=False, base_estimator=None,
                   n_calls=100, n_random_starts=10,
                   acq_func="EI", acq_optimizer="auto",
                   x0=None, y0=None, random_state=None, verbose=False,
@@ -45,6 +45,13 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
         - as a list of categories (for `Categorical` dimensions), or
         - an instance of a `Dimension` object (`Real`, `Integer` or
           `Categorical`).
+
+    * `use_arg_names` [bool, default=False]:
+        Whether to use use names for the search-space dimensions
+        when calling `func()`.
+        For example, instead of calling `func([123, 3.0, 'hello'])`,
+        it calls `func(foo=123, bar=3.0, baz='hello')` for a search-space
+        with dimensions named `['foo', 'bar', 'baz']`
 
     * `base_estimator` [`GradientBoostingQuantileRegressor`]:
         The regressor to use as surrogate model
@@ -140,7 +147,9 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
     if base_estimator is None:
         base_estimator = cook_estimator("GBRT", random_state=rng,
                                         n_jobs=n_jobs)
-    return base_minimize(func, dimensions, base_estimator,
+    return base_minimize(func=func, dimensions=dimensions,
+                         base_estimator=base_estimator,
+                         use_arg_names=use_arg_names,
                          n_calls=n_calls, n_points=n_points,
                          n_random_starts=n_random_starts,
                          x0=x0, y0=y0, random_state=random_state, xi=xi,

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -9,7 +9,7 @@ from ..utils import cook_estimator
 from ..utils import normalize_dimensions
 
 
-def gp_minimize(func, dimensions, base_estimator=None,
+def gp_minimize(func, dimensions, use_arg_names=False, base_estimator=None,
                 n_calls=100, n_random_starts=10,
                 acq_func="gp_hedge", acq_optimizer="auto", x0=None, y0=None,
                 random_state=None, verbose=False, callback=None,
@@ -59,6 +59,13 @@ def gp_minimize(func, dimensions, base_estimator=None,
 
          NOTE: The upper and lower bounds are inclusive for `Integer`
          dimensions.
+
+    * `use_arg_names` [bool, default=False]:
+        Whether to use use names for the search-space dimensions
+        when calling `func()`.
+        For example, instead of calling `func([123, 3.0, 'hello'])`,
+        it calls `func(foo=123, bar=3.0, baz='hello')` for a search-space
+        with dimensions named `['foo', 'bar', 'baz']`
 
     * `base_estimator` [a Gaussian process estimator]:
         The Gaussian process estimator to use for optimization.
@@ -214,7 +221,9 @@ def gp_minimize(func, dimensions, base_estimator=None,
             noise=noise)
 
     return base_minimize(
-        func, space, base_estimator=base_estimator,
+        func=func, dimensions=space,
+        base_estimator=base_estimator,
+        use_arg_names=use_arg_names,
         acq_func=acq_func,
         xi=xi, kappa=kappa, acq_optimizer=acq_optimizer, n_calls=n_calls,
         n_points=n_points, n_random_starts=n_random_starts,


### PR DESCRIPTION
This is a solution for issue #570 about named arguments for the objective function.

@betatim proposed using the Python `inspect.signature()` function - first time I heard about it :-)

But I think this a simpler solution that also has backwards compatibility with the current calling style of `func(x)` where `x` is a list. The user just needs to give all dimensions proper names (otherwise an exception is raised), and then set `use_arg_names=True` when calling e.g. `gp_minimize()`. The `use_arg_names` is then passed all the way down to `base_minimize()` which wraps the objective-function so it will be called with the named arguments instead of a list `x` as usual.

I found the function `base_minimize()` very confusing. I added a few TODO-comments which is a hope that you will spend an hour cleaning and commenting this function before you merge the code. It is unlikely that anyone else can / will do it for you.

The code below tests the new feature. Try changing `use_arg_names` so it is called with both the old and new methods. You can also try changing the order of the arguments to `named_fitness()` and it should still work. Also try changing a name e.g. from `activation` to `activation2` and it should crash.

    import numpy as np
    from math import exp
    
    from skopt import gp_minimize
    from skopt.space import Real, Categorical, Integer
    
    dim_learning_rate = Real(name='learning_rate', low=1e-6, high=1e-2, prior='log-uniform')
    dim_num_dense_layers = Integer(name='num_dense_layers', low=1, high=5)
    dim_num_dense_nodes = Integer(name='num_dense_nodes', low=5, high=512)
    dim_activation = Categorical(name='activation', categories=['relu', 'sigmoid'])
    
    dimensions = [dim_learning_rate,
                  dim_num_dense_layers,
                  dim_num_dense_nodes,
                  dim_activation]
    
    default_parameters = [1e-4, 1, 64, 'relu']
    
    # TODO: Try changing the order of the args, which should work.
    # TODO: Also try renaming an arg, which should crash.
    def named_fitness(learning_rate, num_dense_layers, num_dense_nodes, activation):
        """New type of fitness function with named arguments."""
    
        fitness = ((exp(learning_rate) - 1.0) * 1000) ** 2 + \
                  (num_dense_layers) ** 2 + \
                  (num_dense_nodes/100) ** 2
    
        fitness *= 1.0 + 0.1 * np.random.rand()
    
        if activation == 'sigmoid':
            fitness += 10
    
        return fitness
    
    
    def model_fitness(x):
        """Typical fitness function with list-argument."""
        learning_rate, num_dense_layers, num_dense_nodes, activation = x
    
        fitness = named_fitness(learning_rate=learning_rate,
                                num_dense_layers=num_dense_layers,
                                num_dense_nodes=num_dense_nodes,
                                activation=activation)
    
        return fitness
    
    
    print(model_fitness(x=default_parameters))
    
    # TODO: Try changing this!
    use_arg_names = False
    
    func = named_fitness if use_arg_names else model_fitness
    
    search_result = gp_minimize(func=func,
                                dimensions=dimensions,
                                use_arg_names=use_arg_names,
                                n_calls=40,
                                x0=default_parameters)
    
    print(search_result.x)
    print(search_result.fun)
    
    for fitness, x in sorted(zip(search_result.func_vals, search_result.x_iters)):
        print(fitness, x)
