### PR TITLE
[MRG] Add iteration callback to BayesSearchCV, fixed value dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Release history
 
+## Version 0.5
+
+High five!
+
+## New features
+
+* Single element dimension definition, which can be used to 
+fix the value of a dimension during optimization.
+* `total_iterations` function of `BayesSearchCV` that 
+counts total iterations needed to explore all subspaces. 
+* Add iteration event handler for `BayesSearchCV`, useful 
+for early stopping inside `BayesSearchCV` search loop.
+
+### Bug fixes
+
+* Removed redundant estimator fitting inside `BayesSearchCV`
 
 ## Version 0.4
 

--- a/examples/sklearn-gridsearchcv-replacement.ipynb
+++ b/examples/sklearn-gridsearchcv-replacement.ipynb
@@ -23,9 +23,9 @@
     "\n",
     "This example assumes basic familiarity with [scikit-learn](http://scikit-learn.org/stable/index.html). \n",
     "\n",
-    "Search for parameters of machine learning models that result in best cross-validation performance is necessary in almost all practical cases to get a model with best generalization estimate. A standard approach in scikit-learn is using `GridSearchCV` class, which takes a set of values for every parameter to try, and simply enumerates all combinations of parameter values. The complexity of such search grows exponentially with addition of new parameters. A more scalable approach is using `RandomizedSearchCV`, which however does not take advantage of the structure of a search space.\n",
+    "Search for parameters of machine learning models that result in best cross-validation performance is necessary in almost all practical cases to get a model with best generalization estimate. A standard approach in scikit-learn is using `GridSearchCV` class, which takes a set of values for every parameter to try, and simply enumerates all combinations of parameter values. The complexity of such search grows exponentially with the addition of new parameters. A more scalable approach is using `RandomizedSearchCV`, which however does not take advantage of the structure of a search space.\n",
     "\n",
-    "Scikit-optimize provides a drop in replacement for `GridSearchCV`, which utilizes Bayesian Optimization where a predictive model reffered to as \"surrogate\" is used to model the search space and utilized in order to arrive at good parameter values combination as soon as possible.\n",
+    "Scikit-optimize provides a drop-in replacement for `GridSearchCV`, which utilizes Bayesian Optimization where a predictive model referred to as \"surrogate\" is used to model the search space and utilized to arrive at good parameter values combination as soon as possible.\n",
     "\n",
     "Note: for a manual hyperparameter optimization example, see \"Hyperparameter Optimization\" notebook.\n",
     "\n",
@@ -88,7 +88,7 @@
    "source": [
     "## Advanced example \n",
     "\n",
-    "In practice, one wants to enumerate over multiple predictive model classes, with different search spaces and number of evaluations per class. An example of such search over parameters of Linear SVM, Kernel SVM and decision trees is given below. "
+    "In practice, one wants to enumerate over multiple predictive model classes, with different search spaces and number of evaluations per class. An example of such search over parameters of Linear SVM, Kernel SVM, and decision trees is given below. "
    ]
   },
   {
@@ -159,7 +159,7 @@
    "source": [
     "## Progress monitoring and control using `callback` argument of `fit` method\n",
     "\n",
-    "It is possible to monitor the progress of BayesSearchCV with event handler that is called on every step of subspace exploration. For single job mode, this is called on every evaluation of model configuration, and for parallel mode this is called when n_jobs model configurations are evaluated in parallel.\n",
+    "It is possible to monitor the progress of BayesSearchCV with an event handler that is called on every step of subspace exploration. For single job mode, this is called on every evaluation of model configuration, and for parallel mode, this is called when n_jobs model configurations are evaluated in parallel.\n",
     "\n",
     "Additionally, exploration can be stopped if the callback returns `True`. This can be used to stop the exploration early, for instance when the accuracy that you get is sufficiently high. \n",
     "\n",
@@ -214,6 +214,48 @@
     "\n",
     "\n",
     "searchcv.fit(X, y, callback=on_step)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Counting total iterations that will be used to explore all subspaces\n",
+    "\n",
+    "Subspaces in previous examples can further increase in complexity if you add new model subspaces or dimensions for feature extraction pipelines. For monitoring of progress, you would like to know the total number of iterations it will take to explore all subspaces. This can be calculated with `total_iterations` property, as in the code below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "42\n"
+     ]
+    }
+   ],
+   "source": [
+    "from skopt import BayesSearchCV\n",
+    "\n",
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.svm import SVC\n",
+    "\n",
+    "X, y = load_iris(True)\n",
+    "\n",
+    "searchcv = BayesSearchCV(\n",
+    "    SVC(),\n",
+    "    search_spaces=[\n",
+    "        ({'C': (0.1, 1.0)}, 19),  # 19 iterations for this subspace\n",
+    "        {'gamma':(0.1, 1.0)}\n",
+    "    ],\n",
+    "    n_iter=23\n",
+    ")\n",
+    "\n",
+    "print(searchcv.total_iterations)"
    ]
   }
  ],

--- a/examples/sklearn-gridsearchcv-replacement.ipynb
+++ b/examples/sklearn-gridsearchcv-replacement.ipynb
@@ -93,7 +93,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 12,
    "metadata": {
     "collapsed": false,
     "deletable": true,
@@ -104,8 +104,7 @@
      "name": "stdout",
      "output_type": "stream",
      "text": [
-      "val. score: 0.985894580549\n",
-      "test score: 0.982222222222\n"
+      "val. score: 0.983667409057\ntest score: 0.982222222222\n"
      ]
     }
    ],
@@ -113,32 +112,28 @@
     "from skopt import BayesSearchCV\n",
     "from skopt.space import Real, Categorical, Integer\n",
     "\n",
-    "from sklearn.datasets import load_iris, load_digits\n",
-    "from sklearn.svm import SVC, LinearSVC\n",
-    "from sklearn.tree import DecisionTreeClassifier\n",
+    "from sklearn.datasets import load_digits\n",
+    "from sklearn.svm import LinearSVC, SVC\n",
     "from sklearn.pipeline import Pipeline\n",
     "from sklearn.model_selection import train_test_split\n",
     "\n",
     "X, y = load_digits(10, True)\n",
-    "X_train, X_test, y_train, y_test = train_test_split(X, y, train_size=0.75, random_state=0)\n",
+    "X_train, X_test, y_train, y_test = train_test_split(X, y, random_state=0)\n",
     "\n",
-    "# used to try different model classes\n",
+    "# pipeline class is used as estimator to enable \n",
+    "# search over different model types\n",
     "pipe = Pipeline([\n",
     "    ('model', SVC())\n",
     "])\n",
     "\n",
-    "# single categorical value of 'model' parameter is used  to set the model class\n",
-    "lin_search = {\n",
-    "    'model': Categorical([LinearSVC()]),\n",
-    "    'model__C': Real(1e-6, 1e+6, prior='log-uniform'),\n",
+    "# single categorical value of 'model' parameter is \n",
+    "# sets the model class\n",
+    "linsvc_search = {\n",
+    "    'model': [LinearSVC(max_iter=10000)],\n",
+    "    'model__C': (1e-6, 1e+6, 'log-uniform'),\n",
     "}\n",
     "\n",
-    "dtc_search = {\n",
-    "    'model': Categorical([DecisionTreeClassifier()]),\n",
-    "    'model__max_depth': Integer(1,32),\n",
-    "    'model__min_samples_split': Real(1e-3, 1.0, prior='log-uniform'),\n",
-    "}\n",
-    "\n",
+    "# explicit dimension classes can be specified like this\n",
     "svc_search = {\n",
     "    'model': Categorical([SVC()]),\n",
     "    'model__C': Real(1e-6, 1e+6, prior='log-uniform'),\n",
@@ -149,13 +144,76 @@
     "\n",
     "opt = BayesSearchCV(\n",
     "    pipe,\n",
-    "    [(lin_search, 16), (dtc_search, 24), (svc_search, 32)], # (parameter space, # of evaluations)\n",
+    "    [(svc_search, 20), (linsvc_search, 16)], # (parameter space, # of evaluations)\n",
     ")\n",
     "\n",
     "opt.fit(X_train, y_train)\n",
     "\n",
     "print(\"val. score: %s\" % opt.best_score_)\n",
     "print(\"test score: %s\" % opt.score(X_test, y_test))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Progress monitoring and control using `callback` argument of `fit` method\n",
+    "\n",
+    "It is possible to monitor the progress of BayesSearchCV with event handler that is called on every step of subspace exploration. For single job mode, this is called on every evaluation of model configuration, and for parallel mode this is called when n_jobs model configurations are evaluated in parallel.\n",
+    "\n",
+    "Additionally, exploration can be stopped if the callback returns `True`. This can be used to stop the exploration early, for instance when the accuracy that you get is sufficiently high. \n",
+    "\n",
+    "An example usage is shown below. "
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 11,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "best score: 0.94\nbest score: 0.94\nbest score: 0.98\nInterrupting!\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "BayesSearchCV(cv=None, error_score='raise',\n       estimator=SVC(C=1.0, cache_size=200, class_weight=None, coef0=0.0,\n  decision_function_shape='ovr', degree=3, gamma='auto', kernel='rbf',\n  max_iter=-1, probability=False, random_state=None, shrinking=True,\n  tol=0.001, verbose=False),\n       fit_params=None, iid=True, n_iter=10, n_jobs=1,\n       optimizer_kwargs=None, pre_dispatch='2*n_jobs', random_state=None,\n       refit=True, return_train_score=True, scoring=None,\n       search_spaces={'C': (0.01, 100.0, 'log-uniform')}, verbose=0)"
+      ]
+     },
+     "execution_count": 11,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from skopt import BayesSearchCV\n",
+    "\n",
+    "from sklearn.datasets import load_iris\n",
+    "from sklearn.svm import SVC\n",
+    "\n",
+    "X, y = load_iris(True)\n",
+    "\n",
+    "searchcv = BayesSearchCV(\n",
+    "    SVC(),\n",
+    "    search_spaces={'C': (0.01, 100.0, 'log-uniform')},\n",
+    "    n_iter=10\n",
+    ")\n",
+    "\n",
+    "\n",
+    "# callback handler\n",
+    "def on_step(optim_result):\n",
+    "    score = searchcv.best_score_\n",
+    "    print(\"best score: %s\" % score)\n",
+    "    if score >= 0.98:\n",
+    "        print('Interrupting!')\n",
+    "        return True\n",
+    "\n",
+    "\n",
+    "searchcv.fit(X, y, callback=on_step)"
    ]
   }
  ],

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -566,8 +566,7 @@ class BayesSearchCV(BaseSearchCV):
         """
         total_iter = 0
 
-        for space_id in sorted(self.search_spaces.keys()):
-            elem = self.search_spaces[space_id]
+        for elem in self.search_spaces:
 
             if isinstance(elem, tuple):
                 space, n_iter = elem

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -69,6 +69,12 @@ def check_dimension(dimension, transform=None):
     if not isinstance(dimension, (list, tuple, np.ndarray)):
         raise ValueError("Dimension has to be a list or tuple.")
 
+    # Dimension description with single value is assumed to be used
+    # in order to fix dimension value. Is useful for BayesSearchCV,
+    # when you for example want to fix what model is used in Pipeline.
+    if len(dimension) == 1:
+        return Categorical(dimension, transform=transform)
+
     if len(dimension) == 2:
         if any([isinstance(d, (str, bool)) for d in dimension]):
             return Categorical(dimension, transform=transform)

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -69,9 +69,11 @@ def check_dimension(dimension, transform=None):
     if not isinstance(dimension, (list, tuple, np.ndarray)):
         raise ValueError("Dimension has to be a list or tuple.")
 
-    # Dimension description with single value is assumed to be used
-    # in order to fix dimension value. Is useful for BayesSearchCV,
-    # when you for example want to fix what model is used in Pipeline.
+    # A `Dimension` described by a single value is assumed to be
+    # a `Categorical` dimension. This can be used in `BayesSearchCV`
+    # to define subspaces that fix one value, e.g. to choose the
+    # model type, see "sklearn-gridsearchcv-replacement.ipynb"
+    # for examples.
     if len(dimension) == 1:
         return Categorical(dimension, transform=transform)
 

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -257,3 +257,18 @@ def test_searchcv_callback():
 
     # test whether final model was fit
     opt.score(X, y)
+
+
+def test_searchcv_total_iterations():
+    # Test the total iterations counting property of BayesSearchCV
+
+    opt = BayesSearchCV(
+        DecisionTreeClassifier(),
+        [
+            ({'max_depth': (1, 32)}, 10),  # 10 iterations here
+            {'min_samples_split': Real(0.1, 0.9)}  # 5 (default) iters here
+        ],
+        n_iter=5
+    )
+
+    assert opt.total_iterations == 10 + 5

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -224,3 +224,36 @@ def test_searchcv_reproducibility():
     assert getattr(best_est, 'gamma') == getattr(best_est2, 'gamma')
     assert getattr(best_est, 'degree') == getattr(best_est2, 'degree')
     assert getattr(best_est, 'kernel') == getattr(best_est2, 'kernel')
+
+
+def test_searchcv_callback():
+    # Test whether callback is used in BayesSearchCV and
+    # whether is can be used to interrupt the search loop
+
+    X, y = load_iris(True)
+    opt = BayesSearchCV(
+        DecisionTreeClassifier(),
+        {
+            'max_depth': [3],  # additional test for single dimension
+            'min_samples_split': Real(0.1, 0.9),
+        },
+        n_iter=5
+    )
+    total_iterations = [0]
+
+    def callback(opt_result):
+        # this simply counts iterations
+        total_iterations[0] += 1
+
+        # break the optimization loop at some point
+        if total_iterations[0] > 2:
+            return True  # True == stop optimization
+
+        return False
+
+    opt.fit(X, y, callback=callback)
+
+    assert total_iterations[0] == 3
+
+    # test whether final model was fit
+    opt.score(X, y)

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -375,8 +375,8 @@ def test_valid_transformation():
 def test_invalid_dimension():
     assert_raises_regex(ValueError, "has to be a list or tuple",
                         space_check_dimension, "23")
-    assert_raises_regex(ValueError, "Invalid dimension",
-                        space_check_dimension, (23,))
+    # single value fixes dimension of space
+    space_check_dimension((23,))
 
 
 @pytest.mark.fast_test


### PR DESCRIPTION
A continuation of #515 (seemed a bit easier to start a new PR). 
Additions in this PR:
* A new shiny iteration callback to BayesSearchCV!
* Dimensions can be defined by single element list / tuple, which is considered to be a dimension of Category type and fixes dimension value.

Tests / examples included. 