### PR TITLE
[MRG+1] Added support for named arguments with objective function (NEW version)

### DIFF
--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -28,7 +28,7 @@ def base_minimize(func, dimensions, base_estimator,
     ----------
     * `func` [callable]:
         Function to minimize. Should take a single list of parameters
-        and return the objective value as a scalar of type `float`.
+        and return the objective value.
     
         If you have a search-space where all dimensions have names,
         then you can use `skopt.utils.use_named_args` as a decorator

--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -27,8 +27,13 @@ def base_minimize(func, dimensions, base_estimator,
     Parameters
     ----------
     * `func` [callable]:
-        Function to minimize. Should take a array of parameters and
-        return the function values.
+        Function to minimize. Should take a single list of parameters
+        and return the objective value as a scalar of type `float`.
+    
+        If you have a search-space where all dimensions have names,
+        then you can use `skopt.utils.use_named_args` as a decorator
+        on your objective function, in order to call it directly
+        with the named arguments. See `use_named_args` for an example.
 
     * `dimensions` [list, shape=(n_dims,)]:
         List of search space dimensions.

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -10,8 +10,13 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
     Parameters
     ----------
     * `func` [callable]:
-        Function to minimize. Should take a array of parameters and
-        return the function values.
+        Function to minimize. Should take a single list of parameters
+        and return the objective value as a scalar of type `float`.
+    
+        If you have a search-space where all dimensions have names,
+        then you can use `skopt.utils.use_named_args` as a decorator
+        on your objective function, in order to call it directly
+        with the named arguments. See `use_named_args` for an example.
 
     * `dimensions` [list, shape=(n_dims,)]:
         List of search space dimensions.

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -11,7 +11,7 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
     ----------
     * `func` [callable]:
         Function to minimize. Should take a single list of parameters
-        and return the objective value as a scalar of type `float`.
+        and return the objective value.
     
         If you have a search-space where all dimensions have names,
         then you can use `skopt.utils.use_named_args` as a decorator

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -32,7 +32,7 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
     ----------
     * `func` [callable]:
         Function to minimize. Should take a single list of parameters
-        and return the objective value as a scalar of type `float`.
+        and return the objective value.
     
         If you have a search-space where all dimensions have names,
         then you can use `skopt.utils.use_named_args` as a decorator

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -31,8 +31,13 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
     Parameters
     ----------
     * `func` [callable]:
-        Function to minimize. Should take a array of parameters and
-        return the function values.
+        Function to minimize. Should take a single list of parameters
+        and return the objective value as a scalar of type `float`.
+    
+        If you have a search-space where all dimensions have names,
+        then you can use `skopt.utils.use_named_args` as a decorator
+        on your objective function, in order to call it directly
+        with the named arguments. See `use_named_args` for an example.
 
     * `dimensions` [list, shape=(n_dims,)]:
         List of search space dimensions.

--- a/skopt/optimizer/gbrt.py
+++ b/skopt/optimizer/gbrt.py
@@ -32,7 +32,7 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
     ----------
     * `func` [callable]:
         Function to minimize. Should take a single list of parameters
-        and return the objective value as a scalar of type `float`.
+        and return the objective value.
     
         If you have a search-space where all dimensions have names,
         then you can use `skopt.utils.use_named_args` as a decorator

--- a/skopt/optimizer/gbrt.py
+++ b/skopt/optimizer/gbrt.py
@@ -31,8 +31,13 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
     Parameters
     ----------
     * `func` [callable]:
-        Function to minimize. Should take a array of parameters and
-        return the function values.
+        Function to minimize. Should take a single list of parameters
+        and return the objective value as a scalar of type `float`.
+    
+        If you have a search-space where all dimensions have names,
+        then you can use `skopt.utils.use_named_args` as a decorator
+        on your objective function, in order to call it directly
+        with the named arguments. See `use_named_args` for an example.
 
     * `dimensions` [list, shape=(n_dims,)]:
         List of search space dimensions.

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -43,7 +43,7 @@ def gp_minimize(func, dimensions, base_estimator=None,
     ----------
     * `func` [callable]:
         Function to minimize. Should take a single list of parameters
-        and return the objective value as a scalar of type `float`.
+        and return the objective value.
     
         If you have a search-space where all dimensions have names,
         then you can use `skopt.utils.use_named_args` as a decorator

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -42,8 +42,13 @@ def gp_minimize(func, dimensions, base_estimator=None,
     Parameters
     ----------
     * `func` [callable]:
-        Function to minimize. Should take a array of parameters and
-        return the function values.
+        Function to minimize. Should take a single list of parameters
+        and return the objective value as a scalar of type `float`.
+    
+        If you have a search-space where all dimensions have names,
+        then you can use `skopt.utils.use_named_args` as a decorator
+        on your objective function, in order to call it directly
+        with the named arguments. See `use_named_args` for an example.
 
     * `dimensions` [list, shape=(n_dims,)]:
         List of search space dimensions.

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -240,8 +240,8 @@ class Real(Dimension):
                 self.transform_ == other.transform_)
 
     def __repr__(self):
-        return "Real(low={}, high={}, prior='{}', transform='{}', name='{}')".format(
-            self.low, self.high, self.prior, self.transform_, self.name)
+        return "Real(low={}, high={}, prior='{}', transform='{}')".format(
+            self.low, self.high, self.prior, self.transform_)
 
     def inverse_transform(self, Xt):
         """Inverse transform samples from the warped space back into the

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -240,8 +240,8 @@ class Real(Dimension):
                 self.transform_ == other.transform_)
 
     def __repr__(self):
-        return "Real(low={}, high={}, prior='{}', transform='{}')".format(
-            self.low, self.high, self.prior, self.transform_)
+        return "Real(low={}, high={}, prior='{}', transform='{}', name='{}')".format(
+            self.low, self.high, self.prior, self.transform_, self.name)
 
     def inverse_transform(self, Xt):
         """Inverse transform samples from the warped space back into the

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -1,4 +1,5 @@
 from copy import deepcopy
+from functools import wraps
 
 import numpy as np
 from scipy.optimize import OptimizeResult
@@ -16,10 +17,7 @@ from .learning.gaussian_process.kernels import ConstantKernel
 from .learning.gaussian_process.kernels import HammingKernel
 from .learning.gaussian_process.kernels import Matern
 
-from .space import Categorical
-from .space import Integer
-from .space import Real
-from .space import Space
+from .space import Space, Categorical, Integer, Real, Dimension
 
 __all__ = (
     "load",
@@ -501,3 +499,104 @@ def normalize_dimensions(dimensions):
                                    "(%s)" % type(dimension))
 
     return Space(transformed_dimensions)
+
+
+def wrap_named_args(dimensions):
+    """
+    Wrapper for an objective function that uses named arguments to make it
+    compatible with optimizers that use a single list of parameters.
+
+    Your objective function can be defined as being callable using named
+    arguments: `func(foo=123, bar=3.0, baz='hello')` for a search-space
+    with dimensions named `['foo', 'bar', 'baz']`. But the optimizer
+    will only pass a single list `x` of unnamed arguments when calling
+    the objective function: `func(x=[123, 3.0, 'hello'])`. This wrapper
+    converts your objective function with named arguments into one that
+    accepts a list as argument, while doing the conversion automatically.
+
+    The advantage of this is that you don't have to unpack the list of
+    arguments `x` yourself, which makes the code easier to read and
+    also reduces the risk of bugs if you change the number of dimensions
+    or their order in the search-space.
+
+    Example Usage
+    -------------
+    # Define the search-space dimensions. They must all have names!
+    dim1 = Real(name='foo', low=0.0, high=1.0)
+    dim2 = Real(name='bar', low=0.0, high=1.0)
+    dim3 = Real(name='baz', low=0.0, high=1.0)
+
+    # Gather the search-space dimensions in a list.
+    dimensions = [dim1, dim2, dim3]
+
+    # Define the objective function with named arguments
+    # and use this function-decorator to specify the search-space dimensions.
+    @wrap_named_args(dimensions=dimensions)
+    def my_objective_function(foo, bar, baz):
+        return foo ** 2 + bar ** 4 + baz ** 8
+
+    # Now the function is callable from the outside as
+    # `my_objective_function(x)` where `x` is a list of unnamed arguments,
+    # which then wraps your objective function that is callable as
+    # `my_objective_function(foo, bar, baz)`.
+    # The conversion from a list `x` to named parameters `foo`, `bar`, `baz`
+    # is done automatically.
+
+    # Run the optimizer on the wrapped objective function which is called as
+    # `my_objective_function(x)` as expected by `forest_minimize()`.
+    result = forest_minimize(func=my_objective_function, dimensions=dimensions,
+                             n_calls=20, base_estimator="ET", random_state=4)
+
+    # Print the best-found results.
+    print("Best fitness:", result.fun)
+    print("Best parameters:", result.x)
+
+    Parameters
+    ----------
+    * `dimensions` [list(Dimension)]:
+        List of `Dimension`-objects for the search-space dimensions.
+
+    Returns
+    -------
+    * `wrapped_func` [callable] 
+        Wrapped objective function.
+    """
+
+    def decorator(func):
+        """
+        This uses more advanced Python features to wrap `func` using a
+        function-decorator. To get explanations of how this works in Python,
+        please do an internet search for e.g.:
+        Python function decorator with additional arguments.
+        """
+
+        # Ensure all dimensions are correctly typed.
+        if not all(isinstance(dim, Dimension) for dim in dimensions):
+            raise ValueError("All dimensions must be instances of the Dimension-class.")
+
+        # Ensure all dimensions have names.
+        if any(dim.name is None for dim in dimensions):
+            raise ValueError("All dimensions must have names.")
+
+        @wraps(func)
+        def wrapper(x):
+            # Ensure the number of dimensions match
+            # the number of parameters in the list x.
+            if len(x) != len(dimensions):
+                msg = "Mismatch in number of search-space dimensions. " \
+                      "len(dimensions)=={} and len(x)=={}"
+                msg = msg.format(len(dimensions), len(x))
+                raise ValueError(msg)
+
+            # Create a dict where the keys are the names of the dimensions
+            # and the values are taken from the list of parameters x.
+            arg_dict = {dim.name: value for dim, value in zip(dimensions, x)}
+
+            # Call the wrapped objective function with the named arguments.
+            objective_value = func(**arg_dict)
+
+            return objective_value
+
+        return wrapper
+
+    return decorator

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -565,21 +565,61 @@ def use_named_args(dimensions):
     def decorator(func):
         """
         This uses more advanced Python features to wrap `func` using a
-        function-decorator. To get explanations of how this works in Python,
-        please do an internet search for e.g.:
-        Python function decorator with additional arguments.
+        function-decorator, which are not explained so well in the
+        official Python documentation.
+
+        A good video tutorial explaining how this works is found here:
+        https://www.youtube.com/watch?v=KlBPCzcQNU8
+
+        Parameters
+        ----------
+        * `func` [callable]:
+            Function to minimize. Should take *named arguments*
+            and return the objective value.
         """
 
         # Ensure all dimensions are correctly typed.
         if not all(isinstance(dim, Dimension) for dim in dimensions):
-            raise ValueError("All dimensions must be instances of the Dimension-class.")
+            # List of the dimensions that are incorrectly typed.
+            err_dims = list(filter(lambda dim: not isinstance(dim, Dimension),
+                                   dimensions))
+
+            # Error message.
+            msg = "All dimensions must be instances of the Dimension-class, but found: {}"
+            msg = msg.format(err_dims)
+            raise ValueError(msg)
 
         # Ensure all dimensions have names.
         if any(dim.name is None for dim in dimensions):
-            raise ValueError("All dimensions must have names.")
+            # List of the dimensions that have no names.
+            err_dims = list(filter(lambda dim: dim.name is None, dimensions))
+
+            # Error message.
+            msg = "All dimensions must have names, but found: {}"
+            msg = msg.format(err_dims)
+            raise ValueError(msg)
 
         @wraps(func)
         def wrapper(x):
+            """
+            This is the code that will be executed every time the
+            wrapped / decorated `func` is being called.
+            It takes `x` as a single list of parameters and
+            converts them to named arguments and calls `func` with them.
+            
+            Parameters
+            ----------
+            * `x` [list]:
+                A single list of parameters e.g. `[123, 3.0, 'linear']`
+                which will be converted to named arguments and passed
+                to `func`.
+        
+            Returns
+            -------
+            * `objective_value` 
+                The objective value returned by `func`.
+            """
+
             # Ensure the number of dimensions match
             # the number of parameters in the list x.
             if len(x) != len(dimensions):

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -501,10 +501,10 @@ def normalize_dimensions(dimensions):
     return Space(transformed_dimensions)
 
 
-def wrap_named_args(dimensions):
+def use_named_args(dimensions):
     """
-    Wrapper for an objective function that uses named arguments to make it
-    compatible with optimizers that use a single list of parameters.
+    Wrapper / decorator for an objective function that uses named arguments
+    to make it compatible with optimizers that use a single list of parameters.
 
     Your objective function can be defined as being callable using named
     arguments: `func(foo=123, bar=3.0, baz='hello')` for a search-space
@@ -531,7 +531,7 @@ def wrap_named_args(dimensions):
 
     # Define the objective function with named arguments
     # and use this function-decorator to specify the search-space dimensions.
-    @wrap_named_args(dimensions=dimensions)
+    @use_named_args(dimensions=dimensions)
     def my_objective_function(foo, bar, baz):
         return foo ** 2 + bar ** 4 + baz ** 8
 


### PR DESCRIPTION
This is a much improved version of PR #590 which was also discussed in various issues including #570 and #583.

It might be a good idea if I update the doc-strings of all optimizers to briefly describe that `func` can be wrapped using this decorator so as to use named arguments. Do you agree?

Thanks to @betatim for suggesting the use of a decorator which made this version very elegant.

I have not worked very much with decorators and this is a fairly advanced usage scenario, so I think it is better to direct the interested user to do an internet search if they want an explanation on how advanced decorators work in Python. See my comments in the code.

However, I do hope you appreciate the otherwise detailed level of commenting I have added, which is what I have been discussing in my other issues and PRs. It really makes it so much easier for others to understand the intention of the code in case there a bugs, or in case they want to modify the code in the future.

It is extremely important to try and polish and document the code when it is first added to the library. If I had not polished and documented this code properly and left it for others to do, then they would have had to guess at the intended semantics, and they would have spent maybe 10x as long as it has now taken me to polish and document this code - and they would have been pissed off that I hadn't done it properly in the first place.

I admit openly that this version is superior to what any of us suggested individually, and I suppose this shows how great the design and implementation can be under collaboration - but it requires for each person to properly polish and document his additions to the code. That is what I understand to be real collaboration, and not cutting corners which creates a much larger burden for future developers.

You can test this addition with this code:

    from skopt.space import Real
    from skopt.optimizer import forest_minimize
    from skopt.utils import wrap_named_args
    
    dim1 = Real(name='foo', low=0.0, high=1.0)
    dim2 = Real(name='bar', low=0.0, high=1.0)
    dim3 = Real(name='baz', low=0.0, high=1.0)
    
    dimensions = [dim1, dim2, dim3]
    
    @wrap_named_args(dimensions=dimensions)
    def my_objective_function(foo, bar, baz):
        # print("foo", foo)
        # print("bar", bar)
        # print("baz", baz)
        return foo ** 2 + bar ** 4 + baz ** 8
    
    # Test that the wrapped objective function is now callable
    # using a list x instead of named arguments.
    print("Test 1:", my_objective_function(x=[0.1, 1.0, 0.5]))
    print("Test 2:", my_objective_function([0.1, 1.0, 0.5]))
    
    result = forest_minimize(my_objective_function, dimensions=dimensions,
                             n_calls=20, base_estimator="ET", random_state=4)
    
    print("Best objective value:", result.fun)
    print("Best parameters:", result.x)

