### PR TITLE
[MRG+1] Fix copy for ask and tell with computation time

### DIFF
--- a/skopt/benchmarks.py
+++ b/skopt/benchmarks.py
@@ -14,6 +14,11 @@ def bench1(x):
     return x[0] ** 2
 
 
+def bench1_with_time(x):
+    """Same as bench1 but returns the computation time (constant)."""
+    return x[0] ** 2, 2.22
+
+
 def bench2(x):
     """A benchmark function for test purposes.
 

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -402,6 +402,7 @@ class Optimizer(object):
         check_x_in_space(x, self.space)
         self._check_y_is_valid(x, y)
 
+        # take the logarithm of the computation times
         if "ps" in self.acq_func:
             if is_2Dlistlike(x):
                 y = [[val, log(t)] for (val, t) in y]
@@ -523,24 +524,22 @@ class Optimizer(object):
 
         if "ps" in self.acq_func:
             if is_2Dlistlike(x):
-                if np.ndim(y) == 2 and np.shape(y)[1] == 2:
-                    # TODO: refactor
-                    pass
-                else:
+                if not (np.ndim(y) == 2 and np.shape(y)[1] == 2):
                     raise TypeError("expcted y to be a list of (func_val, t)")
             elif is_listlike(x):
-                if np.ndim(y) == 1 and len(y) == 2:
-                    # TODO: refactor
-                    pass
-                else:
+                if not (np.ndim(y) == 1 and len(y) == 2):
                     raise TypeError("expected y to be (func_val, t)")
+
         # if y isn't a scalar it means we have been handed a batch of points
         elif is_listlike(y) and is_2Dlistlike(x):
-            # TODO: why no check here?
-            pass
+            for y_value in y:
+                if not isinstance(y_value, Number):
+                    raise ValueError("expected y to be a list a scalars")
+
         elif is_listlike(x):
             if not isinstance(y, Number):
                 raise ValueError("`func` should return a scalar")
+
         else:
             raise ValueError("Type of arguments `x` (%s) and `y` (%s) "
                              "not compatible." % (type(x), type(y)))

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -413,8 +413,11 @@ class Optimizer(object):
         return self._tell(x, y, fit=fit)
 
     def _tell(self, x, y, fit=True):
-        """Same as `tell()` but without checks and without any modification
-        of x or y."""
+        """Perform the actual work of incorporating one or more new points.
+        See `tell()` for the full description.
+
+        This method exists to give access to the internals of adding points
+        by side stepping all input validation and transformation."""
 
         if "ps" in self.acq_func:
             if is_2Dlistlike(x):
@@ -438,7 +441,7 @@ class Optimizer(object):
             raise ValueError("Type of arguments `x` (%s) and `y` (%s) "
                              "not compatible." % (type(x), type(y)))
 
-        # optimizer learned somethnig new - discard cache
+        # optimizer learned something new - discard cache
         self.cache_ = {}
 
         # after being "told" n_initial_points we switch from sampling
@@ -521,12 +524,12 @@ class Optimizer(object):
                              models=self.models)
 
     def _check_y_is_valid(self, x, y):
-        """Checks if y is valid (with respect to x in some cases)."""
+        """Check if the shape and types of x and y are consistent."""
 
         if "ps" in self.acq_func:
             if is_2Dlistlike(x):
                 if not (np.ndim(y) == 2 and np.shape(y)[1] == 2):
-                    raise TypeError("expcted y to be a list of (func_val, t)")
+                    raise TypeError("expected y to be a list of (func_val, t)")
             elif is_listlike(x):
                 if not (np.ndim(y) == 1 and len(y) == 2):
                     raise TypeError("expected y to be (func_val, t)")
@@ -535,7 +538,7 @@ class Optimizer(object):
         elif is_listlike(y) and is_2Dlistlike(x):
             for y_value in y:
                 if not isinstance(y_value, Number):
-                    raise ValueError("expected y to be a list a scalars")
+                    raise ValueError("expected y to be a list of scalars")
 
         elif is_listlike(x):
             if not isinstance(y, Number):

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -402,6 +402,13 @@ class Optimizer(object):
         check_x_in_space(x, self.space)
         self._check_y_is_valid(x, y)
 
+        if "ps" in self.acq_func:
+            if is_2Dlistlike(x):
+                y = [[val, log(t)] for (val, t) in y]
+            elif is_listlike(x):
+                y = list(y)
+                y[1] = log(y[1])
+
         return self._tell(x, y, fit=fit)
 
     def _tell(self, x, y, fit=True):
@@ -530,6 +537,7 @@ class Optimizer(object):
         # if y isn't a scalar it means we have been handed a batch of points
         elif is_listlike(y) and is_2Dlistlike(x):
             # TODO: why no check here?
+            pass
         elif is_listlike(x):
             if not isinstance(y, Number):
                 raise ValueError("`func` should return a scalar")

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -413,7 +413,8 @@ class Optimizer(object):
         return self._tell(x, y, fit=fit)
 
     def _tell(self, x, y, fit=True):
-        """Same as `tell()` but without checks and without modification of x or y."""
+        """Same as `tell()` but without checks and without any modification
+        of x or y."""
 
         if "ps" in self.acq_func:
             if is_2Dlistlike(x):

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -57,6 +57,15 @@ def test_invalid_tell_arguments():
 
 
 @pytest.mark.fast_test
+def test_invalid_tell_arguments_list():
+    base_estimator = ExtraTreesRegressor(random_state=2)
+    opt = Optimizer([(-2.0, 2.0)], base_estimator, n_initial_points=1,
+                    acq_optimizer="sampling")
+
+    assert_raises(ValueError, opt.tell, [[1.], [2.]], [1., None])
+
+
+@pytest.mark.fast_test
 def test_bounds_checking_1D():
     low = -2.
     high = 2.


### PR DESCRIPTION
I just noticed the optimizer's `copy()` method tampers with the objective values `yi`. Only affects acquisition functions with computation time.

This is required for #574.

Short explanation:
* The values in `yi` are in this case tuples of `objective_value` and `time`
* Each copy would again apply the logarithm on the time values