### PR TITLE
[MRG] Extend contributing guidelines to encourage non code contributions

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -3,9 +3,21 @@
 Scikit-Optimize is an open-source project and contributions of all kinds
 are welcome.
 
+You can contribute with documentation, examples, reviewing pull requests, code,
+helping answer questions in issues, creating visualizations, maintaining project
+infrastructure, and writing user stories. All of these are equally important
+and the current contributors don't (yet) cover all of these topics. Code
+contributions are our strong point, so help us help you to make other types of
+contributions.
+
 Contributions should follow these guidelines:
 
 * all changes by pull request (PR);
+* please prefix the title of your pull request with `[MRG]` if the contribution
+  is complete and should be subjected to a detailed review;
+* create a PR as early as possible, marking it with `[WIP]` while you work on
+  it (good to avoid duplicated work, get broad review of functionality or API,
+  or seek collaborators);
 * a PR solves one problem (do not mix problems together in one PR) with the
   minimal set of changes;
 * describe why you are proposing the changes you are proposing;


### PR DESCRIPTION
This PR adds two sentences I kept repeating in PRs by newcomers (use of WIP and MRG) and tries to add a paragraph outlining other ways of contributing to the code base. We are good at adding code, reviewing code, and all things code but not so good at all of the other things. Do you think this paragraph will encourage people who add to our skill set to start contributing?