### PR TITLE
[MRG] Added checking-functions for clarity and reusability.

### DIFF
--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -501,6 +501,71 @@ def normalize_dimensions(dimensions):
     return Space(transformed_dimensions)
 
 
+def check_list_types(x, types):
+    """
+    Check whether all elements of a list `x` are of the correct type(s)
+    and raise a ValueError if they are not.
+    
+    Note that `types` can be either a single object-type or a tuple
+    of object-types.
+    
+    Parameters
+    ----------
+    * `x` [list]:
+        List of objects.
+
+    * `types` [object or list(object)]:
+        Either a single object-type or a tuple of object-types.
+
+    Exceptions
+    ----------
+    * `ValueError`:
+        If one or more element in the list `x` is not of the correct type(s).
+
+    Returns
+    -------
+    * Nothing.
+    """
+
+    # List of the elements in the list that are incorrectly typed.
+    err = list(filter(lambda a: not isinstance(a, types), x))
+
+    # If the list is non-empty then raise an exception.
+    if len(err) > 0:
+        msg = "All elements in list must be instances of {}, but found: {}"
+        msg = msg.format(types, err)
+        raise ValueError(msg)
+
+
+def check_dimension_names(dimensions):
+    """
+    Check whether all dimensions have names.
+
+    Parameters
+    ----------
+    * `dimensions` [list(Dimension)]:
+        List of Dimension-objects.
+
+    Exceptions
+    ----------
+    * `ValueError`:
+        If one or more dimensions are unnamed.
+
+    Returns
+    -------
+    * Nothing.
+    """
+
+    # List of the dimensions that have no names.
+    err_dims = list(filter(lambda dim: dim.name is None, dimensions))
+
+    # If the list is non-empty then raise an exception.
+    if len(err_dims) > 0:
+        msg = "All dimensions must have names, but found: {}"
+        msg = msg.format(err_dims)
+        raise ValueError(msg)
+
+
 def use_named_args(dimensions):
     """
     Wrapper / decorator for an objective function that uses named arguments
@@ -579,25 +644,10 @@ def use_named_args(dimensions):
         """
 
         # Ensure all dimensions are correctly typed.
-        if not all(isinstance(dim, Dimension) for dim in dimensions):
-            # List of the dimensions that are incorrectly typed.
-            err_dims = list(filter(lambda dim: not isinstance(dim, Dimension),
-                                   dimensions))
-
-            # Error message.
-            msg = "All dimensions must be instances of the Dimension-class, but found: {}"
-            msg = msg.format(err_dims)
-            raise ValueError(msg)
+        check_list_types(dimensions, Dimension)
 
         # Ensure all dimensions have names.
-        if any(dim.name is None for dim in dimensions):
-            # List of the dimensions that have no names.
-            err_dims = list(filter(lambda dim: dim.name is None, dimensions))
-
-            # Error message.
-            msg = "All dimensions must have names, but found: {}"
-            msg = msg.format(err_dims)
-            raise ValueError(msg)
+        check_dimension_names(dimensions)
 
         @wraps(func)
         def wrapper(x):


### PR DESCRIPTION
This is a quick PR which moves some exception-handling into separate functions for clarity and reusability. It currently only affects `@use_named_args()` that I recently added.

I searched for the proper module to place these in and noticed that `utils.py` already has `check_x_in_space()` so I placed them in `utils.py` as well.

It can be tested with the following code:

    from skopt.space import Real, Integer, Dimension
    from skopt.utils import check_list_types
    
    dim1 = Real(name='foo', low=0.0, high=1.0)
    dim2 = Real(name='bar', low=0.0, high=1.0)
    dim3 = Real(name='baz', low=0.0, high=1.0)
    
    dimensions = [dim1, dim2, dim3, 'Hello']
    
    check_list_types(dimensions, (Integer, Dimension))

This fails and prints:

    ValueError: All elements in list must be instances of (<class 'skopt.space.space.Integer'>, <class 'skopt.space.space.Dimension'>), but found: ['Hello']

And the following code:

    from skopt.space import Real
    from skopt.utils import check_dimension_names
    
    dim1 = Real(name='foo', low=0.0, high=1.0)
    dim2 = Real(name=None, low=0.0, high=1.0)
    dim3 = Real(name='baz', low=0.0, high=1.0)
    
    dimensions = [dim1, dim2, dim3]
    
    check_dimension_names(dimensions)

This fails and prints:

    ValueError: All dimensions must have names, but found: [Real(low=0.0, high=1.0, prior='uniform', transform='identity')]

Note that PR #579 changes the semantics of dimension-names, so that all dimensions are now given default names if the user has not supplied a name, so you can argue this check is not really needed after that. But there is an ongoing discussion about naming dimensions, so I think it is wise to keep this check for now.
