### PR TITLE
setup.py now reflects that skopt needs sklearn that has MaskedArray in its fixes.py

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -146,6 +146,10 @@ The scikit-optimize project was made possible with the support of
     :alt: NSF
     :target: https://www.nsf.gov
 
+.. image:: https://i.imgur.com/3enQ6S8.jpg
+    :alt: Northrop Grumman
+    :target: http://www.northropgrumman.com/Pages/default.aspx
+
 If your employer allows you to work on scikit-optimize during the day and would like
 recognition, feel free to add them to the "Made possible by" list.
 

--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,6 @@ setup(name='scikit-optimize',
       author='The scikit-optimize contributors',
       packages=['skopt', 'skopt.learning', 'skopt.optimizer', 'skopt.space',
                 'skopt.learning.gaussian_process'],
-      install_requires=["numpy", "scipy>=0.14.0", "scikit-learn>=0.18",
+      install_requires=["numpy", "scipy>=0.14.0", "scikit-learn>=0.18.2",
                         "matplotlib"]
       )


### PR DESCRIPTION
This is my first pull request to you and my first contribution to anything open source where I don't know the owners personally. It's mostly to familiarize myself with the fact I have to fork the repo and push to a branch I own (because permissions) and other minutiae, but it also solves #569 by letting potential users know they can't use scikit-learn 0.18.0. Hopefully more substantial changes to come, since I've opened several issues I don't expect anyone else will fix for me.