### PR TITLE
[MRG] add new callback `CheckpointSaver`

### DIFF
--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -263,7 +263,7 @@ class CheckpointSaver(object):
     Example usage:
         import skopt
 
-        checkpoint_callback = skopt.callbacks.CheckpointCallback("./result.pkl")
+        checkpoint_callback = skopt.callbacks.CheckpointSaver("./result.pkl")
         skopt.gp_minimize(obj_fun, dims, callback=[checkpoint_callback])
 
     Parameters

--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -269,8 +269,9 @@ class CheckpointSaver(object):
     Parameters
     ----------
     * `checkpoint_path`: location where checkpoint will be saved to;
+    * `dump_options`: options to pass on to `skopt.dump`, like `compress=9`
     """
-    def __init__(self, checkpoint_path, dump_options=dict()):
+    def __init__(self, checkpoint_path, **dump_options):
         self.checkpoint_path = checkpoint_path
         self.dump_options = dump_options
 
@@ -281,4 +282,4 @@ class CheckpointSaver(object):
         * `res` [`OptimizeResult`, scipy object]:
             The optimization as a OptimizeResult object.
         """
-        dump(res, self.checkpoint_path, self.dump_options)
+        dump(res, self.checkpoint_path, **self.dump_options)

--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -18,6 +18,7 @@ from time import time
 
 import numpy as np
 
+from skopt.utils import dump
 
 def check_callback(callback):
     """
@@ -252,3 +253,32 @@ class DeadlineStopper(EarlyStopper):
             return time_remaining <= np.max(self.iter_time)
         else:
             return None
+
+
+class CheckpointSaver(object):
+    """
+    Save current state after each iteration with `skopt.dump`.
+
+
+    Example usage:
+        import skopt
+
+        checkpoint_callback = skopt.callbacks.CheckpointCallback("./result.pkl")
+        skopt.gp_minimize(obj_fun, dims, callback=[checkpoint_callback])
+
+    Parameters
+    ----------
+    * `checkpoint_path`: location where checkpoint will be saved to;
+    """
+    def __init__(self, checkpoint_path, dump_options=dict()):
+        self.checkpoint_path = checkpoint_path
+        self.dump_options = dump_options
+
+    def __call__(self, res):
+        """
+        Parameters
+        ----------
+        * `res` [`OptimizeResult`, scipy object]:
+            The optimization as a OptimizeResult object.
+        """
+        dump(res, self.checkpoint_path, self.dump_options)

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -58,10 +58,13 @@ def test_checkpoint_saver():
         os.remove(checkpoint_path)
 
     checkpoint_saver = CheckpointSaver(checkpoint_path)
-    result = dummy_minimize(bench1, [(-1.0, 1.0)], callback=checkpoint_saver, n_calls=10)
+    result = dummy_minimize(bench1,
+        [(-1.0, 1.0)],
+        callback=checkpoint_saver,
+        n_calls=10)
 
     assert os.path.exists(checkpoint_path)
-    assert load(checkpoint_path).x == result.x, "not able to restore checkpoint"
+    assert load(checkpoint_path).x == result.x
 
     if os.path.isfile(checkpoint_path):
         os.remove(checkpoint_path)

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -1,6 +1,7 @@
 import pytest
 
 import numpy as np
+import os
 from collections import namedtuple
 
 from sklearn.utils.testing import assert_equal
@@ -13,7 +14,9 @@ from skopt.benchmarks import bench3
 from skopt.callbacks import TimerCallback
 from skopt.callbacks import DeltaYStopper
 from skopt.callbacks import DeadlineStopper
+from skopt.callbacks import CheckpointSaver
 
+from skopt.utils import load
 
 @pytest.mark.fast_test
 def test_timer_callback():
@@ -45,3 +48,20 @@ def test_deadline_stopper():
     gp_minimize(bench3, [(-1.0, 1.0)], callback=deadline, n_calls=10, random_state=1)
     assert len(deadline.iter_time) == 10
     assert np.sum(deadline.iter_time) < deadline.total_time
+
+
+@pytest.mark.fast_test
+def test_checkpoint_saver():
+    checkpoint_path = "./test_checkpoint.pkl"
+
+    if os.path.isfile(checkpoint_path):
+        os.remove(checkpoint_path)
+
+    checkpoint_saver = CheckpointSaver(checkpoint_path)
+    result = dummy_minimize(bench1, [(-1.0, 1.0)], callback=checkpoint_saver, n_calls=10)
+
+    assert os.path.exists(checkpoint_path)
+    assert load(checkpoint_path).x == result.x, "not able to restore checkpoint"
+
+    if os.path.isfile(checkpoint_path):
+        os.remove(checkpoint_path)

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -57,7 +57,7 @@ def test_checkpoint_saver():
     if os.path.isfile(checkpoint_path):
         os.remove(checkpoint_path)
 
-    checkpoint_saver = CheckpointSaver(checkpoint_path)
+    checkpoint_saver = CheckpointSaver(checkpoint_path, compress=9)
     result = dummy_minimize(bench1,
         [(-1.0, 1.0)],
         callback=checkpoint_saver,


### PR DESCRIPTION
Adds a new callback that can be used to save a checkpoint after each iteration with `skopt.dump`.