### PR TITLE
[WIP] Provide option to center objective plots around minimum

### DIFF
--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -9,6 +9,8 @@ from matplotlib.ticker import MaxNLocator
 
 from scipy.optimize import OptimizeResult
 
+from .utils import expected_minimum
+
 
 def plot_convergence(*args, **kwargs):
     """Plot one or several convergence traces.
@@ -289,7 +291,8 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
 
     * `n_samples` [int, default=250]
         Number of random samples to use for averaging the model function
-        at each of the `n_points`.
+        at each of the `n_points`. If 0, the partial dependence is 
+        evaluated along a cross section containing the expected minimum.
 
     * `size` [float, default=2]
         Height (in inches) of each facet.
@@ -309,7 +312,11 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
     """
     space = result.space
     samples = np.asarray(result.x_iters)
-    rvs_transformed = space.transform(space.rvs(n_samples=n_samples))
+    if n_samples:
+        rvs_transformed = space.transform(space.rvs(n_samples=n_samples))
+    else:
+        exp_min = np.array(expected_minimum(result)[0]).reshape(1, -1)
+        rvs_transformed = space.transform(exp_min)
 
     if zscale == 'log':
         locator = LogLocator()


### PR DESCRIPTION
Today, the plot_objective function always evaluates the partial dependence across a random sampling of the space. For my project, this is undesired behavior, because the values of the function far from the minimum vary wildly, causing the partial dependence plots to be useless at best and misleading at worst. I only care about the behavior in cross sections that include the minimum of the function.

I suspect this may be the case for other projects too, so I put together this PR. Let me know if this feature is something you'd like to add -- I'd be happy to modify the way this feature is triggered, add a test, and/or make any necessary clean ups.