### PR TITLE
[MRG] Add example notebook for checkpoint callback

### DIFF
--- a/examples/interruptible-optimization.ipynb
+++ b/examples/interruptible-optimization.ipynb
@@ -1,0 +1,188 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Interruptible optimization runs with checkpoints\n",
+    "\n",
+    "Christian Schell, Mai 2018"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-05-06T16:17:54.334861Z",
+     "start_time": "2018-05-06T16:17:54.060277Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "np.random.seed(777)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Problem statement\n",
+    "\n",
+    "Optimization runs can take a very long time and even run for multiple days. If for some reason the process has to be interrupted results are irreversibly lost, and the routine has to start over from the beginning.\n",
+    "\n",
+    "With the help of the `CheckpointSaver` callback the optimizer's current state can be saved after each iteration, allowing to restart from that point at any time.\n",
+    "\n",
+    "This is useful, for example,\n",
+    "\n",
+    "* if you don't know how long the process will take and cannot hog computational resources forever\n",
+    "* if there might be system failures due to shaky infrastructure (or colleagues...)\n",
+    "* if you want to adjust some parameters and continue with the already obtained results"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Simple example\n",
+    "\n",
+    "We will use pretty much the same optimization problem as in the [`bayesian-optimization.ipynb`](https://github.com/scikit-optimize/scikit-optimize/blob/master/examples/bayesian-optimization.ipynb) notebook. Additionaly we will instantiate the `CheckpointSaver` and pass it to the minimizer:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-05-06T16:17:55.603207Z",
+     "start_time": "2018-05-06T16:17:54.338812Z"
+    },
+    "scrolled": false
+   },
+   "outputs": [],
+   "source": [
+    "from skopt import gp_minimize\n",
+    "from skopt import callbacks\n",
+    "from skopt.callbacks import CheckpointSaver\n",
+    "\n",
+    "noise_level = 0.1\n",
+    "\n",
+    "def obj_fun(x, noise_level=noise_level):\n",
+    "    return np.sin(5 * x[0]) * (1 - np.tanh(x[0] ** 2)) + np.random.randn() * noise_level\n",
+    "\n",
+    "checkpoint_saver = CheckpointSaver(\"./checkpoint.pkl\", compress=9) # keyword arguments will be passed to `skopt.dump`\n",
+    "\n",
+    "gp_minimize(obj_fun,                       # the function to minimize\n",
+    "              [(-20.0, 20.0)],             # the bounds on each dimension of x\n",
+    "              x0=[-20.],                     # the starting point\n",
+    "              acq_func=\"LCB\",              # the acquisition function (optional)\n",
+    "              n_calls=10,                   # the number of evaluations of f including at x0\n",
+    "              n_random_starts=0,           # the number of random initialization points\n",
+    "              callback=[checkpoint_saver], # a list of callbacks including the checkpoint saver\n",
+    "              random_state=777);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Now let's assume this did not finish at once but took some long time: you started this on Friday night, went out for the weekend and now, Monday morning, you're eager to see the results. However, instead of the notebook server you only see a blank page and your colleague Garry tells you that he had had an update scheduled for Sunday noon – who doesn't like updates?\n",
+    "\n",
+    "TL;DR: `gp_minimize` did not finish, and there is no `res` variable with the actual results!"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Restoring the last checkpoint\n",
+    "\n",
+    "Luckily we employed the `CheckpointSaver` and can now restore the latest result with `skopt.load` (see [store and load results](./store-and-load-results.ipynb) for more information on that)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-05-06T16:17:55.645661Z",
+     "start_time": "2018-05-06T16:17:55.607150Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "from skopt import load\n",
+    "\n",
+    "res = load('./checkpoint.pkl')\n",
+    "\n",
+    "res.fun"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Continue the search\n",
+    "\n",
+    "The previous results can then be used to continue the optimization process:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "ExecuteTime": {
+     "end_time": "2018-05-06T16:17:56.193074Z",
+     "start_time": "2018-05-06T16:17:55.650992Z"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "x0 = res.x_iters\n",
+    "y0 = res.func_vals\n",
+    "\n",
+    "gp_minimize(obj_fun,            # the function to minimize\n",
+    "              [(-20.0, 20.0)],    # the bounds on each dimension of x\n",
+    "              x0=x0,              # already examined values for x\n",
+    "              y0=y0,              # observed values for x0\n",
+    "              acq_func=\"LCB\",     # the acquisition function (optional)\n",
+    "              n_calls=10,         # the number of evaluations of f including at x0\n",
+    "              n_random_starts=0,  # the number of random initialization points\n",
+    "              callback=[checkpoint_saver],\n",
+    "              random_state=777);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Possible problems\n",
+    "\n",
+    "* __changes in search space:__ You can use this technique to interrupt the search, tune the search space and continue the optimization. Note that the optimizers will complain if `x0` contains parameter values not covered by the dimension definitions, so in many cases shrinking the search space will not work without deleting the offending runs from `x0` and `y0`.\n",
+    "* see [store and load results](./store-and-load-results.ipynb) for more information on how the results get saved and possible caveats"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.6.4"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}


### PR DESCRIPTION
After adding the `CallbackSaver` callback in #665 I figured that a short example would be nice, so here it is. I followed the style of the [store-and-load-results](https://github.com/scikit-optimize/scikit-optimize/blob/master/examples/store-and-load-results.ipynb) example, so I hope the format is appropriate.