### PR TITLE
[MRG] Support for plotting categorical dimensions

### DIFF
--- a/skopt/tests/test_plots.py
+++ b/skopt/tests/test_plots.py
@@ -1,0 +1,44 @@
+"""Scikit-optimize plotting tests."""
+import numpy as np
+import pytest
+from sklearn.datasets import load_breast_cancer
+from sklearn.tree import DecisionTreeClassifier
+from sklearn.model_selection import cross_val_score
+
+from skopt.space import Integer, Categorical
+from skopt import plots, gp_minimize
+import matplotlib.pyplot as plt
+
+
+def save_axes(ax, filename):
+    """Save matplotlib axes `ax` to an image `filename`."""
+    fig = plt.gcf()
+    fig.add_axes(ax)
+    fig.savefig(filename)
+
+
+@pytest.mark.slow_test
+def test_plots_work():
+    """Basic smoke tests to make sure plotting doesn't crash."""
+    SPACE = [
+        Integer(1, 20, name='max_depth'),
+        Integer(2, 100, name='min_samples_split'),
+        Integer(5, 30, name='min_samples_leaf'),
+        Integer(1, 30, name='max_features'),
+        Categorical(['gini', 'entropy'], name='criterion'),
+        Categorical(list('abcdefghij'), name='dummy'),
+    ]
+
+    def objective(params):
+        clf = DecisionTreeClassifier(random_state=3, **{dim.name: val
+                for dim, val in zip(SPACE, params) if dim.name != 'dummy'})
+        return -np.mean(cross_val_score(clf, *load_breast_cancer(True)))
+
+    res = gp_minimize(objective, SPACE, n_calls=10, random_state=3)
+    plots.plot_convergence(res)
+    plots.plot_evaluations(res)
+    plots.plot_objective(res)
+    plots.plot_regret(res)
+
+    # TODO: Compare plots to known good results?
+    # Look into how matplotlib does this.


### PR DESCRIPTION
This adds support for categorical dimensions in `plot_evaluations()` and
`plot_objective()`.  It maps categorical values to their indices in the
Dimension for making plots, and labels the ticks with categories. For computing
partial dependence, it accounts for categoricals being one-hot encoded when
transformed.

We manually handle mapping and labeling categoricals rather than letting
matplotlib do it because a) matplotlib only supports categorical plots in recent
versions (2.1+), b) it doesn't guarantee consistent ordering of categories
across plots, and c) it's nice to preserve the original order of categories
given by the user.

`plot_evaluations()`:

We make one histogram bin per categorical value.  We just have to be careful to
preserve categoricals when making arrays with `dtype=object`, and let matplotlib
automatically set the histogram range.

I added a `_map_categories()` helper function that takes an array of points and
converts categories to their integer indices, while also converting the minimum
point and returning an array indicating which dimensions are categorical.

`plot_objective()`:

The plotting function itself just needs to use the mapped integer
representations for categoricals; computing the `partial_dependence` needed some
generalization. Conceptually it's straightforward, the implementation just takes
a little care. While in `plot_evaluations()` we plot every category, here we
sample categories, because the function explicitly requests it, there is a
not-unreasonable interpretation, and it could be computationally prohibitive
otherwise.  Basically, we take the order of the categories in the Dimension, and
choose (up to) `n_points` approximately-evenly-spaced integer indices of those
categories.  Since there was some repeated code to choose these points, I
factored it out into a `_evenly_sample()` helper function.  The remaining
wrinkle was that the code assumed a 1:1 mapping from number of raw Space
dimensions to number of transformed dimensions, but Categoricals break that
assumption by being one-to-many (they are one-hot encoded).  So when we fix a
value for Dimension _i_, we need to figure out where in the transformed space
_i_ went.

`_format_scatter_plot_axes()` needed a few changes to handle categorical
dimensions.  Axis limits should not be set with the dimension bounds since
they're not meaningful.  Categorical axes get a custom tick formatter that maps
integer ticks back to category names.  For locating ticks, we still use
`MaxNLocator`, but set it to only locate ticks at integer locations for
categoricals.

I added simple smoke tests for plots, just testing that they don't crash.  To
use matplotlib non-interactively, the backend needs to be set to Agg early,
before anything else using matplotlib is imported.  This is done in plots.py by
detecting if running under pytest.