### PR TITLE
Initialization for Optimizer and BayesCV

### DIFF
--- a/examples/optimizer-bcv-initial-points.ipynb
+++ b/examples/optimizer-bcv-initial-points.ipynb
@@ -1,0 +1,319 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# How to provide intial points to the Optimizer and BayesSearchCV class\n",
+    "\n",
+    "Iaroslav Shcherbatyi, June 2018."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 1,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import numpy as np\n",
+    "np.random.seed(123)\n",
+    "\n",
+    "%matplotlib inline\n",
+    "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Problem statement\n",
+    "\n",
+    "Sometimes for your black box optimization problem $$x^* = \\arg \\min_{x \\in X} f(x)$$ you either have a bunch of points $x_i \\in X, i = 1...k$ that you want to evaluate first because you have a good reason to think they will result in good objective values, or you already have a few points $x_j \\in X, j = 1...m$ for which you already have the values of the objective $f(x_j) \\in \\mathbb{R}$ and you would like to use them to initialize your optimizer.\n"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Providing initial points for the `Optimizer` to be evaluated\n",
+    "\n",
+    "For that, use `x0` argument of the optimizer class constructor. An example is given below."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Parallel mode:\n",
+      "Suggested points: [[0.0], [0.5], [1.0], [0.043422101727152]]\n",
+      "Sequencial mode:\n",
+      "Suggested point [0.0]\n",
+      "Suggested point [0.5]\n",
+      "Suggested point [1.0]\n",
+      "Suggested point [0.5652137360964778]\n",
+      "Suggested point [0.05901570160283677]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from skopt import Optimizer\n",
+    "opt = Optimizer(dimensions=[(0.0, 1.0)], x0=[[0.0], [0.5], [1.0]])\n",
+    "\n",
+    "print(\"Parallel mode:\")\n",
+    "\n",
+    "# you can use parallel interface\n",
+    "# notice that first the 3 initial points are provided\n",
+    "print(\"Suggested points:\", opt.ask(4))\n",
+    "\n",
+    "opt = Optimizer(dimensions=[(0.0, 1.0)], x0=[[0.0], [0.5], [1.0]])\n",
+    "\n",
+    "print(\"Sequencial mode:\")\n",
+    "\n",
+    "# or sequencial - it all works!\n",
+    "for i in range(5):\n",
+    "    r = opt.ask()\n",
+    "    opt.tell(r, i/2.0)\n",
+    "    print('Suggested point', r)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "**Important**: specifying `x0` does not change the number of points that the algorithm will try at random. To adjust  this number, set the `n_initial_points` accordingly. That is, the total number of initialization iterations including `x0` is `n_initial_points + len(x0)`."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Two ways to provide already evaluated points to `Optimizer`\n",
+    "\n",
+    "In some situations, you already have some objective values already evaluated, and you would like to use those to \"bootstrap\" your algorithm. One way is to simply `tell` these points to `Optimizer` instance as it is instantiated, like in the cell below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 23,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "          fun: 0.0\n",
+       "    func_vals: array([0. , 0.1])\n",
+       "       models: []\n",
+       " random_state: <mtrand.RandomState object at 0x7f85980f2bd0>\n",
+       "        space: Space([Real(low=0.0, high=1.0, prior='uniform', transform='normalize')])\n",
+       "        specs: None\n",
+       "            x: [0.0]\n",
+       "      x_iters: [[0.0], [0.5]]"
+      ]
+     },
+     "execution_count": 23,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from skopt import Optimizer\n",
+    "\n",
+    "opt = Optimizer(dimensions=[(0.0, 1.0)])\n",
+    "\n",
+    "opt.tell(x=[[0.0], [0.5]], y=[0.0, 0.1])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Another way is to provide the initialization points via the `xy0` property of Optimizer constructor. This way you do not need an extra call to the `tell` function."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "<skopt.optimizer.optimizer.Optimizer at 0x7f6865cec9b0>"
+      ]
+     },
+     "execution_count": 16,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from skopt import Optimizer\n",
+    "\n",
+    "Optimizer(dimensions=[(0.0, 1.0)], xy0=[\n",
+    "    [[0.0], 0.0],\n",
+    "    [[1.0], 0.1],\n",
+    "])"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "You can also combine both, so that you provide some points which are already evaluated, and the ones that are to be evaluated:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 2,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "[[0.5], [0.7], [0.038396889140708386], [0.7224627817380277], [0.5105514975437424]]\n"
+     ]
+    }
+   ],
+   "source": [
+    "from skopt import Optimizer\n",
+    "\n",
+    "opt = Optimizer(dimensions=[(0.0, 1.0)], \n",
+    "        xy0=[\n",
+    "            [[0.0], 0.0],\n",
+    "            [[1.0], 0.1],\n",
+    "        ],\n",
+    "        x0=[\n",
+    "            [0.5],\n",
+    "            [0.7]\n",
+    "        ]\n",
+    ")\n",
+    "\n",
+    "print(opt.ask(5))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Specifying initial points for `BayesSearchCV`\n",
+    "\n",
+    "You can set the `optimizer_kwargs` to specify which parameters of your pipeline the optimizer should try first. For this, you need to use a few helper functions from `skopt` package."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 3,
+   "metadata": {},
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "C= 0.2 gamma= 0.1\n",
+      "C= 0.2 gamma= 0.1\n",
+      "C= 0.2 gamma= 0.1\n",
+      "C= 0.4 gamma= 0.2\n",
+      "C= 0.4 gamma= 0.2\n",
+      "C= 0.4 gamma= 0.2\n",
+      "C= 3.857733300809835 gamma= 0.27385219988077025\n",
+      "C= 3.857733300809835 gamma= 0.27385219988077025\n",
+      "C= 3.857733300809835 gamma= 0.27385219988077025\n",
+      "C= 7.870432808673247 gamma= 0.18827444863361564\n",
+      "C= 7.870432808673247 gamma= 0.18827444863361564\n",
+      "C= 7.870432808673247 gamma= 0.18827444863361564\n",
+      "C= 1.1523854167021892 gamma= 1.4253617857743606\n",
+      "C= 1.1523854167021892 gamma= 1.4253617857743606\n",
+      "C= 1.1523854167021892 gamma= 1.4253617857743606\n",
+      "C= 6.50979320286485 gamma= 4.140545264744949\n",
+      "C= 6.50979320286485 gamma= 4.140545264744949\n",
+      "C= 6.50979320286485 gamma= 4.140545264744949\n",
+      "C= 7.870432808673247 gamma= 0.18827444863361564\n"
+     ]
+    },
+    {
+     "data": {
+      "text/plain": [
+       "BayesSearchCV(cv=3, error_score='raise',\n",
+       "       estimator=MyModel(C=1.0, cache_size=200, class_weight=None, coef0=0.0,\n",
+       "    decision_function_shape='ovr', degree=3, gamma='auto', kernel='rbf',\n",
+       "    max_iter=-1, probability=False, random_state=None, shrinking=True,\n",
+       "    tol=0.001, verbose=False),\n",
+       "       fit_params=None, iid=True, n_iter=6, n_jobs=1, n_points=1,\n",
+       "       optimizer_kwargs={'x0': [[0.2, 0.1], [0.4, 0.2]]},\n",
+       "       pre_dispatch='2*n_jobs', random_state=None, refit=True,\n",
+       "       return_train_score=False, scoring=None,\n",
+       "       search_spaces={'C': (0.1, 10.0), 'gamma': (0.1, 10.0)}, verbose=0)"
+      ]
+     },
+     "execution_count": 3,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
+   "source": [
+    "from skopt import BayesSearchCV\n",
+    "from skopt.utils import dimensions_aslist\n",
+    "\n",
+    "from sklearn.svm import SVC\n",
+    "from sklearn.datasets import load_iris\n",
+    "\n",
+    "x0 = [\n",
+    "    {'C': 0.2, 'gamma': 0.1},\n",
+    "    {'C': 0.4, 'gamma': 0.2}\n",
+    "]\n",
+    "\n",
+    "x0 = [dimensions_aslist(v) for v in x0]\n",
+    "\n",
+    "# this class is simply used to print the values provided to the class\n",
+    "class MyModel(SVC):\n",
+    "    def fit(self, *args, **kwargs):\n",
+    "        print('C=', self.C, 'gamma=', self.gamma)\n",
+    "        super(MyModel, self).fit(*args, **kwargs)\n",
+    "\n",
+    "X, y = load_iris(True)\n",
+    "\n",
+    "bcv = BayesSearchCV(\n",
+    "    estimator=MyModel(),\n",
+    "    search_spaces={\n",
+    "        'C': (0.1, 10.0),\n",
+    "        'gamma': (0.1, 10.0),\n",
+    "    },\n",
+    "    n_iter=6,\n",
+    "    optimizer_kwargs={\n",
+    "        'x0': x0,  # initialization done here!\n",
+    "    },\n",
+    "    cv=3  # note that 3 folds are used for cross - validation, hence output is repeated 3 times\n",
+    ")\n",
+    "\n",
+    "bcv.fit(X, y)"
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "Python 3",
+   "language": "python",
+   "name": "python3"
+  },
+  "language_info": {
+   "codemirror_mode": {
+    "name": "ipython",
+    "version": 3
+   },
+   "file_extension": ".py",
+   "mimetype": "text/x-python",
+   "name": "python",
+   "nbconvert_exporter": "python",
+   "pygments_lexer": "ipython3",
+   "version": "3.5.2"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 1
+}

--- a/examples/optimizer-bcv-initial-points.ipynb
+++ b/examples/optimizer-bcv-initial-points.ipynb
@@ -72,7 +72,7 @@
     "\n",
     "opt = Optimizer(dimensions=[(0.0, 1.0)], x0=[[0.0], [0.5], [1.0]])\n",
     "\n",
-    "print(\"Sequencial mode:\")\n",
+    "print(\"Sequential mode:\")\n",
     "\n",
     "# or sequencial - it all works!\n",
     "for i in range(5):\n",

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -263,9 +263,6 @@ class Optimizer(object):
             else:
                 self._non_cat_inds.append(ind)
 
-
-        # Configure counters of points
-
         # Check `n_random_starts` deprecation first
         if n_random_starts is not None:
             warnings.warn(("n_random_starts will be removed in favour of "
@@ -300,7 +297,7 @@ class Optimizer(object):
         if not isinstance(x0, list):
             raise ValueError("`xy0` should be a list, but got %s" % type(xy0))
         # check if the list of points are provided or just one point
-        if len(xy0)>0:
+        if len(xy0) > 0:
             if not isinstance(xy0[0][0], (list, tuple)):
                 xy0 = [xy0]
             for v in xy0:
@@ -311,14 +308,11 @@ class Optimizer(object):
                 if not v[0] in self.space:
                     raise ValueError(
                         "Initial point %s in `xy0` input that does not "
-                        "belong to space. %s" %(v, self.space)
+                        "belong to space. %s" % (v, self.space)
                     )
-
+        # Configure counters of points
         # update the size of initialization
-        n_initial_points = n_initial_points + len(x0)
-
-        #
-        n_initial_points = n_initial_points + len(xy0)
+        n_initial_points = n_initial_points + len(x0) + len(xy0)
 
         self._n_initial_points = n_initial_points
         self.n_initial_points_ = n_initial_points
@@ -475,19 +469,20 @@ class Optimizer(object):
         to determine the next point.
         """
 
-        if self.x0 is not None and len(self.x0) > 0 and len(self.Xi) < self._n_initial_points:
-            # if no points have been evaluated - return an initialization one
-            if len(self.Xi) == 0:
-                return self.x0[0]
+        if self.x0 is not None and len(self.x0) > 0:
+            if len(self.Xi) < self._n_initial_points:
+                # if no points have been evaluated - return first from x0
+                if len(self.Xi) == 0:
+                    return self.x0[0]
 
-            Xi = np.array(self.Xi)
+                Xi = np.array(self.Xi)
 
-            # check if all the inital points have been evaluated.
-            # if not, return the ones that are not yet evaluated
-            for x in self.x0:
-                if np.any(np.any(Xi == x, axis=1)):
-                    continue
-                return x
+                # check if all the inital points have been evaluated.
+                # if not, return the ones that are not yet evaluated
+                for x in self.x0:
+                    if np.any(np.any(Xi == x, axis=1)):
+                        continue
+                    return x
 
         if self._n_initial_points > 0 or self.base_estimator_ is None:
             # this will not make a copy of `self.rng` and hence keep advancing

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -284,6 +284,8 @@ class Optimizer(object):
         if (n_initial_points <= 0) and not x0:
             raise ValueError("Either set `n_initial_points` > 0,"
                              " or provide `x0`")
+
+        check_x_in_space(x0, self.space)
         # check if point is withing the search space
         for v in x0:
             if v not in self.space:
@@ -305,11 +307,9 @@ class Optimizer(object):
                     raise ValueError(
                         "`xy0` should contain pairs of x, f(x), got %s" % v
                     )
-                if not v[0] in self.space:
-                    raise ValueError(
-                        "Initial point %s in `xy0` input that does not "
-                        "belong to space. %s" % (v, self.space)
-                    )
+            xx0 = [v[0] for v in xy0]
+            check_x_in_space(xx0, self.space)
+
         # Configure counters of points
         # update the size of initialization
         n_initial_points = n_initial_points + len(x0) + len(xy0)

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -760,8 +760,6 @@ class Space(object):
         """Check that `point` is within the bounds of the space."""
         # assert that the length of the point is the same as
         # the length of the space
-        if len(point) != len(self.dimensions):
-            return False
 
         for component, dim in zip(point, self.dimensions):
             if component not in dim:

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -758,6 +758,11 @@ class Space(object):
 
     def __contains__(self, point):
         """Check that `point` is within the bounds of the space."""
+        # assert that the length of the point is the same as
+        # the length of the space
+        if len(point) != len(self.dimensions):
+            return False
+
         for component, dim in zip(point, self.dimensions):
             if component not in dim:
                 return False

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -304,6 +304,7 @@ def test_defaults_are_equivalent():
     assert np.allclose(res_min.x_iters, res_opt.x_iters)#, atol=1e-5)
     assert np.allclose(res_min.x, res_opt.x)#, atol=1e-5)
 
+
 def test_initial_points():
     space = [Real(0.0, 1.0), Integer(0, 3), Categorical(['a', 'b', 'c'])]
 

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -316,6 +316,7 @@ def test_searchcv_total_iterations():
 
     assert opt.total_iterations == 10 + 5
 
+
 def test_initial_values():
     # Test whether everything is working with providing initial points
     from sklearn.svm import SVC


### PR DESCRIPTION
This PR adds feature of initial points to the Optimizer class. Fixes #686 . 

The initialization interface is similar to *_minimize functions in x0 argument. The differences are:
* in xy0 argument, which should contain a list of pairs of (point, objective). The reason I make this interface is to enable providing evaluated and not evaluated points at the same time, which afaik is not possible with *_minimize functions.
* the number of initial points for the optimizer is n_initial_points + len(x0) + len(xy0). This is done in order to ensure that the algorithm will work same as if no initialization was done, in order to avoid unexpected behavior, where e.g. some points from x0 are quitely skipped due to insufficient n_initial_points.

Let me know if you have any concerns.

This PR contains update to code + example + tests.
