### PR TITLE
[MRG] Improve error message if input check fails in _gaussian_acquisition

### DIFF
--- a/skopt/acquisition.py
+++ b/skopt/acquisition.py
@@ -26,7 +26,8 @@ def _gaussian_acquisition(X, model, y_opt=None, acq_func="LCB",
     # Check inputs
     X = np.asarray(X)
     if X.ndim != 2:
-        raise ValueError("X should be 2-dimensional.")
+        raise ValueError("X is {}-dimensional, however,"
+                         " it must be 2-dimensional.".format(X.ndim))
 
     if acq_func_kwargs is None:
         acq_func_kwargs = dict()

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -144,6 +144,13 @@ def test_acquisition_per_second(acq_func):
     assert_array_almost_equal(acq_wo_time / acq_with_time, np.ravel(X), 2)
 
 
+def test_gaussian_acquisition_check_inputs():
+    model = ConstantGPRSurrogate(Space(((1.0, 9.0),)))
+    with pytest.raises(ValueError) as err:
+        vals = _gaussian_acquisition(np.arange(1, 5), model)
+        assert("it must be 2-dimensional" in exc.value.args[0])
+
+
 @pytest.mark.fast_test
 @pytest.mark.parametrize("acq_func", ["EIps", "PIps"])
 def test_acquisition_per_second_gradient(acq_func):


### PR DESCRIPTION
This PR adds a slightly more informational error message for the input checking in ``_gaussian_acquisition``.