### PR TITLE
[MRG] Fix bad indentation in test_gaussian_acquisition_check_inputs

### DIFF
--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -148,7 +148,7 @@ def test_gaussian_acquisition_check_inputs():
     model = ConstantGPRSurrogate(Space(((1.0, 9.0),)))
     with pytest.raises(ValueError) as err:
         vals = _gaussian_acquisition(np.arange(1, 5), model)
-        assert("it must be 2-dimensional" in exc.value.args[0])
+    assert("it must be 2-dimensional" in err.value.args[0])
 
 
 @pytest.mark.fast_test


### PR DESCRIPTION
The unit test I wrote earlier had an indentation bug. This PR fixes it.
cc @betatim 