### PR TITLE
[MRG] Return optimizer results in BayesSearchCV

### DIFF
--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -663,7 +663,7 @@ class BayesSearchCV(BaseSearchCV):
 
                 if eval_callbacks(callbacks, optim_result):
                     break
-            
+
             self.optimizer_results_[optimizer] = optim_result
 
         # Refit the best model on the the whole dataset

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -638,6 +638,7 @@ class BayesSearchCV(BaseSearchCV):
         self.cv_results_ = defaultdict(list)
         self.best_index_ = None
         self.multimetric_ = False
+        self.optimizer_results_ = {}
 
         n_points = self.n_points
 
@@ -662,6 +663,8 @@ class BayesSearchCV(BaseSearchCV):
 
                 if eval_callbacks(callbacks, optim_result):
                     break
+            
+            self.optimizer_results_[optimizer] = optim_result
 
         # Refit the best model on the the whole dataset
         if self.refit:


### PR DESCRIPTION
This partially solves #566 
I've created a dictionary called optimizer_results_ that stores the optimizer results as value and the optimizer as key. This makes it work if the user specifies multiple optimizers.