### PR TITLE
[MRG] Update docs regarding `n_calls`, `x0`, `y0` in `*_minimize`

### DIFF
--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -57,7 +57,7 @@ def base_minimize(func, dimensions, base_estimator,
 
     * `n_calls` [int, default=100]:
         Maximum number of calls to `func`. An objective fucntion will
-        always be evaluated this number of times; Various options to 
+        always be evaluated this number of times; Various options to
         supply initialization points do not affect this value.
 
     * `n_random_starts` [int, default=10]:
@@ -94,15 +94,15 @@ def base_minimize(func, dimensions, base_estimator,
               - The optimal of these local minima is used to update the prior.
 
     * `x0` [list, list of lists or `None`]:
-        Initial input points. 
+        Initial input points.
 
-        - If it is a list of lists, use it as a list of input points. If no 
+        - If it is a list of lists, use it as a list of input points. If no
           corresponding outputs `y0` are supplied, then len(x0) of total
           calls to the objective function will be spent evaluating the points
           in `x0`. If the corresponding outputs are provided, then they will
           be used together with evaluated points during a run of the algorithm
           to construct a surrogate.
-        - If it is a list, use it as a single initial input point. The 
+        - If it is a list, use it as a single initial input point. The
           algorithm will spend 1 call to evaluate the initial point, if the
           outputs are not provided.
         - If it is `None`, no initial input points are used.


### PR DESCRIPTION
Originates from #707 .
Make it a bit more clear that various initialization strategies do not affect `n_calls`.
If everyone is ok with these changes, I will copy them in other optimizers. 