### PR TITLE
[MRG] Models list is now a customizable size.

### DIFF
--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -155,6 +155,10 @@ def base_minimize(func, dimensions, base_estimator,
         `acq_optimizer` is set to "lbfgs."
         Defaults to 1 core. If `n_jobs=-1`, then number of jobs is set
         to number of cores.
+    
+    * `model_history` [int or None, default=None]
+        Keeps list of models only as long as the argument given. In the 
+        case of None, the list has no capped length.
 
     Returns
     -------

--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -22,7 +22,7 @@ def base_minimize(func, dimensions, base_estimator,
                   acq_func="EI", acq_optimizer="lbfgs",
                   x0=None, y0=None, random_state=None, verbose=False,
                   callback=None, n_points=10000, n_restarts_optimizer=5,
-                  xi=0.01, kappa=1.96, n_jobs=1):
+                  xi=0.01, kappa=1.96, n_jobs=1, model_history=None):
     """
     Parameters
     ----------
@@ -215,7 +215,7 @@ def base_minimize(func, dimensions, base_estimator,
     optimizer = Optimizer(dimensions, base_estimator,
                           n_initial_points=n_initial_points,
                           acq_func=acq_func, acq_optimizer=acq_optimizer,
-                          random_state=random_state,
+                          random_state=random_state, model_history=model_history,
                           acq_optimizer_kwargs=acq_optimizer_kwargs,
                           acq_func_kwargs=acq_func_kwargs)
     # check x0: element-wise data type, dimensionality

--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -215,7 +215,8 @@ def base_minimize(func, dimensions, base_estimator,
     optimizer = Optimizer(dimensions, base_estimator,
                           n_initial_points=n_initial_points,
                           acq_func=acq_func, acq_optimizer=acq_optimizer,
-                          random_state=random_state, model_history=model_history,
+                          random_state=random_state, 
+                          model_history=model_history,
                           acq_optimizer_kwargs=acq_optimizer_kwargs,
                           acq_func_kwargs=acq_func_kwargs)
     # check x0: element-wise data type, dimensionality

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -4,7 +4,8 @@ from .base import base_minimize
 
 
 def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
-                   random_state=None, verbose=False, callback=None):
+                   random_state=None, verbose=False, callback=None, 
+                   model_history=None):
     """Random search by uniform sampling within the given bounds.
 
     Parameters
@@ -96,4 +97,4 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
                          n_calls=n_calls, n_random_starts=n_random_calls,
                          x0=x0, y0=y0, random_state=random_state,
                          verbose=verbose,
-                         callback=callback)
+                         callback=callback, model_history=model_history)

--- a/skopt/optimizer/dummy.py
+++ b/skopt/optimizer/dummy.py
@@ -64,6 +64,10 @@ def dummy_minimize(func, dimensions, n_calls=100, x0=None, y0=None,
         If callable then `callback(res)` is called after each call to `func`.
         If list of callables, then each callable in the list is called.
 
+    * `model_history` [int or None, default=None]
+        Keeps list of models only as long as the argument given. In the 
+        case of None, the list has no capped length.
+
     Returns
     -------
     * `res` [`OptimizeResult`, scipy object]:

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -134,6 +134,10 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
         The number of jobs to run in parallel for `fit` and `predict`.
         If -1, then the number of jobs is set to the number of cores.
 
+    * `model_history` [int or None, default=None]
+        Keeps list of models only as long as the argument given. In the 
+        case of None, the list has no capped length.
+
     Returns
     -------
     * `res` [`OptimizeResult`, scipy object]:

--- a/skopt/optimizer/forest.py
+++ b/skopt/optimizer/forest.py
@@ -11,7 +11,7 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
                     n_random_starts=10, acq_func="EI",
                     x0=None, y0=None, random_state=None, verbose=False,
                     callback=None, n_points=10000, xi=0.01, kappa=1.96,
-                    n_jobs=1):
+                    n_jobs=1, model_history=None):
     """Sequential optimisation using decision trees.
 
     A tree based regression model is used to model the expensive to evaluate
@@ -158,4 +158,5 @@ def forest_minimize(func, dimensions, base_estimator="ET", n_calls=100,
                          x0=x0, y0=y0, random_state=random_state,
                          acq_func=acq_func,
                          xi=xi, kappa=kappa, verbose=verbose,
-                         callback=callback, acq_optimizer="sampling")
+                         callback=callback, acq_optimizer="sampling",
+                         model_history=model_history)

--- a/skopt/optimizer/gbrt.py
+++ b/skopt/optimizer/gbrt.py
@@ -119,6 +119,10 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
         The number of jobs to run in parallel for `fit` and `predict`.
         If -1, then the number of jobs is set to the number of cores.
 
+    * `model_history` [int or None, default=None]
+        Keeps list of models only as long as the argument given. In the 
+        case of None, the list has no capped length.
+
     Returns
     -------
     * `res` [`OptimizeResult`, scipy object]:

--- a/skopt/optimizer/gbrt.py
+++ b/skopt/optimizer/gbrt.py
@@ -10,7 +10,7 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
                   acq_func="EI", acq_optimizer="auto",
                   x0=None, y0=None, random_state=None, verbose=False,
                   callback=None, n_points=10000, xi=0.01, kappa=1.96,
-                  n_jobs=1):
+                  n_jobs=1, model_history=None):
     """Sequential optimization using gradient boosted trees.
 
     Gradient boosted regression trees are used to model the (very)
@@ -150,4 +150,5 @@ def gbrt_minimize(func, dimensions, base_estimator=None,
                          n_random_starts=n_random_starts,
                          x0=x0, y0=y0, random_state=random_state, xi=xi,
                          kappa=kappa, acq_func=acq_func, verbose=verbose,
-                         callback=callback, acq_optimizer="sampling")
+                         callback=callback, acq_optimizer="sampling",
+                         model_history=model_history)

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -14,7 +14,7 @@ def gp_minimize(func, dimensions, base_estimator=None,
                 acq_func="gp_hedge", acq_optimizer="auto", x0=None, y0=None,
                 random_state=None, verbose=False, callback=None,
                 n_points=10000, n_restarts_optimizer=5, xi=0.01, kappa=1.96,
-                noise="gaussian", n_jobs=1):
+                noise="gaussian", n_jobs=1, model_history=None):
     """Bayesian optimization using Gaussian Processes.
 
     If every function evaluation is expensive, for instance
@@ -225,4 +225,4 @@ def gp_minimize(func, dimensions, base_estimator=None,
         n_points=n_points, n_random_starts=n_random_starts,
         n_restarts_optimizer=n_restarts_optimizer,
         x0=x0, y0=y0, random_state=rng, verbose=verbose,
-        callback=callback, n_jobs=n_jobs)
+        callback=callback, n_jobs=n_jobs, model_history=model_history)

--- a/skopt/optimizer/gp.py
+++ b/skopt/optimizer/gp.py
@@ -189,6 +189,10 @@ def gp_minimize(func, dimensions, base_estimator=None,
         Defaults to 1 core. If `n_jobs=-1`, then number of jobs is set
         to number of cores.
 
+    * `model_history` [int or None, default=None]
+        Keeps list of models only as long as the argument given. In the 
+        case of None, the list has no capped length.
+
     Returns
     -------
     * `res` [`OptimizeResult`, scipy object]:

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -253,7 +253,7 @@ class Optimizer(object):
                 self._non_cat_inds.append(ind)
 
         # Initialize storage for optimization
-        if not isinstance(model_history, (int, None)):
+        if not isinstance(model_history, (int, type(None))):
             raise TypeError("model_history should be an int or None,"
             "got {}".format(type(model_history)))
         self.history = model_history

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -138,7 +138,7 @@ class Optimizer(object):
                  n_random_starts=None, n_initial_points=10,
                  acq_func="gp_hedge",
                  acq_optimizer="auto",
-                 random_state=None, 
+                 random_state=None,
                  model_history=None,
                  acq_func_kwargs=None,
                  acq_optimizer_kwargs=None):
@@ -489,7 +489,7 @@ class Optimizer(object):
 
             if hasattr(self, "next_xs_") and self.acq_func == "gp_hedge":
                 self.gains_ -= est.predict(np.vstack(self.next_xs_))
-           
+            
             if self.history is None:
                 self.models.append(est)
             elif len(self.models) < self.history:

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -2,7 +2,6 @@ import sys
 import warnings
 from math import log
 from numbers import Number
-from collections import deque
 
 import numpy as np
 
@@ -251,8 +250,8 @@ class Optimizer(object):
                 self._non_cat_inds.append(ind)
 
         # Initialize storage for optimization
-
-        self.models = deque([], model_history)
+        self.history = model_history
+        self.models = []
         self.Xi = []
         self.yi = []
 
@@ -490,7 +489,12 @@ class Optimizer(object):
 
             if hasattr(self, "next_xs_") and self.acq_func == "gp_hedge":
                 self.gains_ -= est.predict(np.vstack(self.next_xs_))
-            self.models.extend(est)
+           
+            if len(self.models) < self.history or self.history is None:
+                self.models.append(est)
+            else:
+                self.models.pop(0)
+                self.models.append(est)
 
             # even with BFGS as optimizer we want to sample a large number
             # of points and then pick the best ones as starting points

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -253,7 +253,7 @@ class Optimizer(object):
                 self._non_cat_inds.append(ind)
 
         # Initialize storage for optimization
-        if not isinstance(model_history, (int, NoneType)):
+        if not isinstance(model_history, (int, None)):
             raise TypeError("model_history should be an int or None,"
             "got {}".format(type(model_history)))
         self.history = model_history

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -490,9 +490,12 @@ class Optimizer(object):
             if hasattr(self, "next_xs_") and self.acq_func == "gp_hedge":
                 self.gains_ -= est.predict(np.vstack(self.next_xs_))
            
-            if len(self.models) < self.history or self.history is None:
+            if self.history is None:
+                self.models.append(est)
+            elif len(self.models) < self.history:
                 self.models.append(est)
             else:
+                # Maximum list size obtained, remove oldest model.
                 self.models.pop(0)
                 self.models.append(est)
 

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -119,6 +119,9 @@ class Optimizer(object):
     * `acq_optimizer_kwargs` [dict]:
         Additional arguments to be passed to the acquistion optimizer.
 
+    * `model_history` [int or None, default=None]
+        Keeps list of models only as long as the argument given. In the 
+        case of None, the list has no capped length.
 
     Attributes
     ----------
@@ -250,6 +253,9 @@ class Optimizer(object):
                 self._non_cat_inds.append(ind)
 
         # Initialize storage for optimization
+        if not isinstance(model_history, (int, NoneType)):
+            raise TypeError("model_history should be an int or None,"
+            "got {}".format(type(model_history)))
         self.history = model_history
         self.models = []
         self.Xi = []

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -2,6 +2,7 @@ import sys
 import warnings
 from math import log
 from numbers import Number
+from collections import deque
 
 import numpy as np
 
@@ -138,7 +139,9 @@ class Optimizer(object):
                  n_random_starts=None, n_initial_points=10,
                  acq_func="gp_hedge",
                  acq_optimizer="auto",
-                 random_state=None, acq_func_kwargs=None,
+                 random_state=None, 
+                 model_history=None,
+                 acq_func_kwargs=None,
                  acq_optimizer_kwargs=None):
 
         self.rng = check_random_state(random_state)
@@ -249,7 +252,7 @@ class Optimizer(object):
 
         # Initialize storage for optimization
 
-        self.models = []
+        self.models = deque([], model_history)
         self.Xi = []
         self.yi = []
 
@@ -487,7 +490,7 @@ class Optimizer(object):
 
             if hasattr(self, "next_xs_") and self.acq_func == "gp_hedge":
                 self.gains_ -= est.predict(np.vstack(self.next_xs_))
-            self.models.append(est)
+            self.models.extend(est)
 
             # even with BFGS as optimizer we want to sample a large number
             # of points and then pick the best ones as starting points


### PR DESCRIPTION
I've modified the models list of the Optimizer class to be a deque (from collections). This allows a maximum list size to be set so that scripts don't get bloated as the number of iterations increases. This is meant to be a fix for issue #349.

The default value keeps the list as arbitrary in size, so as to keep the same functionality as before.

I can add these to the high-level cases (gbrt_minimize etc) if requested, and will update the Optimizer docstring if this is deemed a useful addition.