### PR TITLE
[MRG] Fix bug with categorical spaces with different types of ca…

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -410,7 +410,11 @@ class Categorical(Dimension):
         * `name` [str or None]:
             Name associated with dimension, e.g., "colors".
         """
-        self.categories = tuple(categories)
+        if transform == 'identity':
+            self.categories = tuple([str(c) for c in categories])
+        else:
+            self.categories = tuple(categories)
+
         self.name = name
 
         if transform is None:
@@ -423,7 +427,8 @@ class Categorical(Dimension):
             self.transformer = CategoricalEncoder()
             self.transformer.fit(self.categories)
         else:
-            self.transformer = Identity()
+            self.transformer = Identity(dtype=type(categories[0]))
+
         self.prior = prior
 
         if prior is None:

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -21,7 +21,7 @@ class Identity(Transformer):
     string and the inverse transform will cast to the type defined in dtype."""
 
     def __init__(self, dtype=None):
-        super().__init__()
+        super(Identity, self).__init__()
         self.dtype = dtype
 
     def transform(self, X):

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -16,13 +16,24 @@ class Transformer(object):
 
 
 class Identity(Transformer):
-    """Identity transform."""
+    """Identity transform.
+    If dtype is different from None the transform will cast everything to a
+    string and the inverse transform will cast to the type defined in dtype."""
+
+    def __init__(self, dtype=None):
+        super().__init__()
+        self.dtype = dtype
 
     def transform(self, X):
-        return X
+        if self.dtype is None:
+            return X
+        return [str(x) for x in X]
+
 
     def inverse_transform(self, Xt):
-        return Xt
+        if self.dtype is None:
+            return Xt
+        return [self.dtype(x) for x in Xt]
 
 
 class Log10(Transformer):

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -157,6 +157,14 @@ def test_normalize_dimensions_all_categorical():
 
 
 @pytest.mark.fast_test
+def test_categoricals_mixed_types():
+    domain = [[1, 2, 3, 4], ['a', 'b', 'c'], [True, False]]
+    x = [1, 'a', True]
+    space = normalize_dimensions(domain)
+    assert (space.inverse_transform(space.transform([x])) == [x])
+
+
+@pytest.mark.fast_test
 @pytest.mark.parametrize("dimensions, normalizations",
                          [(((1, 3), (1., 3.)),
                            ('normalize', 'normalize')


### PR DESCRIPTION
Closes #704 
The problem happened with categorical domains with different data types, like [['a', 'b'], [True, False]].
When the space is categorical the transformer is an identity, so the data keep their type. When stacking different types into a numpy array, they all become strings, losing their types.
The identity transformer is now able to translate everything into a string and then transform back into the original data type.
However, mixed categories like [['a', True]] are (still) not supported.