### PR TITLE
[MRG] Configure coverage creation and checks

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -1,3 +1,10 @@
+# show coverage in CI status, not as a comment. 
+comment: off
 coverage:
-  ignore:
-    - "skopt/tests/*"
+  status:
+    project:
+      default:
+        target: auto
+    patch:
+      default:
+        target: 20% 

--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,6 @@
+[run]
+omit =
+    # this file comes from versioneer and we don’t test it
+    */_version.py
+    # these are our tests, don't count them towards coverage
+    skopt/tests/*


### PR DESCRIPTION
This setups the codecov check so that it doesn't comment in a PR thread and passes unless a PR reduces coverage.

Also changes where we exclude files from the coverage accounting.