### PR TITLE
refactor: RandomForestRegressor.__init__()

### DIFF
--- a/skopt/learning/forest.py
+++ b/skopt/learning/forest.py
@@ -368,23 +368,9 @@ class ExtraTreesRegressor(_sk_ExtraTreesRegressor):
     ----------
     .. [1] L. Breiman, "Random Forests", Machine Learning, 45(1), 5-32, 2001.
     """
-    def __init__(self, n_estimators=10, criterion='mse', max_depth=None,
-                 min_samples_split=2, min_samples_leaf=1,
-                 min_weight_fraction_leaf=0.0, max_features='auto',
-                 max_leaf_nodes=None, bootstrap=False, oob_score=False,
-                 n_jobs=1, random_state=None, verbose=0, warm_start=False,
-                 min_variance=0.0):
+    def __init__(self, min_variance=0.0, **kwargs):
         self.min_variance = min_variance
-        super(ExtraTreesRegressor, self).__init__(
-            n_estimators=n_estimators, criterion=criterion,
-            max_depth=max_depth,
-            min_samples_split=min_samples_split,
-            min_samples_leaf=min_samples_leaf,
-            min_weight_fraction_leaf=min_weight_fraction_leaf,
-            max_features=max_features, max_leaf_nodes=max_leaf_nodes,
-            bootstrap=bootstrap, oob_score=oob_score,
-            n_jobs=n_jobs, random_state=random_state,
-            verbose=verbose, warm_start=warm_start)
+        super(ExtraTreesRegressor, self).__init__(**kwargs)
 
     def predict(self, X, return_std=False):
         """


### PR DESCRIPTION
- remove hard-coded keyword arguments, some of which are now deprecated by sklearn's underlying RandomForestRegressor and allow passing of newer ones such as `min_impurity_decrease` that have been introduced between this file's last commit (3 Nov 2017) and now
- this is particularly important for people who want to hyperoptimize these new parameters