### PR TITLE
Use joblib instead of sklearn.externals.joblib

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+**Disclaimer**: This project is no longer actively maintained! *Help is welcome to take over*.
+
 |Logo|
 
 |Travis Status| |CircleCI Status| |binder| |gitter| |Zenodo DOI|

--- a/benchmarks/bench_ml.py
+++ b/benchmarks/bench_ml.py
@@ -32,8 +32,8 @@ from sklearn.datasets import fetch_california_housing
 from sklearn.datasets import fetch_mldata
 from sklearn.datasets import load_boston
 from sklearn.datasets import load_digits
-from sklearn.externals.joblib import delayed
-from sklearn.externals.joblib import Parallel
+from joblib import delayed
+from joblib import Parallel
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC

--- a/benchmarks/bench_ml.py
+++ b/benchmarks/bench_ml.py
@@ -25,6 +25,8 @@ else:
     from urllib.error import HTTPError
     from urllib import urlopen
 
+from joblib import delayed
+from joblib import Parallel
 import numpy as np
 from sklearn.base import ClassifierMixin
 from sklearn.base import RegressorMixin
@@ -32,8 +34,6 @@ from sklearn.datasets import fetch_california_housing
 from sklearn.datasets import fetch_mldata
 from sklearn.datasets import load_boston
 from sklearn.datasets import load_digits
-from joblib import delayed
-from joblib import Parallel
 from sklearn.model_selection import train_test_split
 from sklearn.preprocessing import StandardScaler
 from sklearn.svm import SVC

--- a/examples/parallel-optimization.ipynb
+++ b/examples/parallel-optimization.ipynb
@@ -46,7 +46,7 @@
       "source": [
         "from skopt import Optimizer\n",
         "from skopt.space import Real\n",
-        "from sklearn.externals.joblib import Parallel, delayed\n",
+        "from joblib import Parallel, delayed\n",
         "# example objective taken from skopt\n",
         "from skopt.benchmarks import branin\n",
         "\n",

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(name='scikit-optimize',
       author='The scikit-optimize contributors',
       packages=['skopt', 'skopt.learning', 'skopt.optimizer', 'skopt.space',
                 'skopt.learning.gaussian_process'],
-      install_requires=['pyaml', 'numpy', 'scipy>=0.14.0',
+      install_requires=['joblib', 'pyaml', 'numpy', 'scipy>=0.14.0',
                         'scikit-learn>=0.19.1'],
       extras_require={
         'plots':  ["matplotlib"]

--- a/skopt/learning/gbrt.py
+++ b/skopt/learning/gbrt.py
@@ -4,7 +4,7 @@ from sklearn.base import clone
 from sklearn.base import BaseEstimator, RegressorMixin
 from sklearn.ensemble import GradientBoostingRegressor
 from sklearn.utils import check_random_state
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 
 
 def _parallel_fit(regressor, X, y):

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -9,7 +9,7 @@ from scipy.optimize import fmin_l_bfgs_b
 
 from sklearn.base import clone
 from sklearn.base import is_regressor
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 from sklearn.multioutput import MultiOutputRegressor
 from sklearn.utils import check_random_state
 

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -6,7 +6,7 @@ from scipy.stats import rankdata
 
 import sklearn
 from sklearn.base import is_classifier, clone
-from sklearn.externals.joblib import Parallel, delayed
+from joblib import Parallel, delayed
 from sklearn.model_selection._search import BaseSearchCV
 from sklearn.utils import check_random_state
 from sklearn.utils.fixes import MaskedArray

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -289,9 +289,14 @@ class BayesSearchCV(BaseSearchCV):
         self.random_state = random_state
         self.optimizer_kwargs = optimizer_kwargs
         self._check_search_space(self.search_spaces)
+        # Temporary fix for compatibility with sklearn 0.20 and 0.21
+        # See scikit-optimize#762
+        # To be consistent with sklearn 0.21+, fit_params should be deprecated
+        # in the constructor and be passed in ``fit``.
+        self.fit_params = fit_params
 
         super(BayesSearchCV, self).__init__(
-             estimator=estimator, scoring=scoring, fit_params=fit_params,
+             estimator=estimator, scoring=scoring,
              n_jobs=n_jobs, iid=iid, refit=refit, cv=cv, verbose=verbose,
              pre_dispatch=pre_dispatch, error_score=error_score,
              return_train_score=return_train_score)

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -410,7 +410,11 @@ class Categorical(Dimension):
         * `name` [str or None]:
             Name associated with dimension, e.g., "colors".
         """
-        self.categories = tuple(categories)
+        if transform == 'identity':
+            self.categories = tuple([str(c) for c in categories])
+        else:
+            self.categories = tuple(categories)
+
         self.name = name
 
         if transform is None:
@@ -423,7 +427,8 @@ class Categorical(Dimension):
             self.transformer = CategoricalEncoder()
             self.transformer.fit(self.categories)
         else:
-            self.transformer = Identity()
+            self.transformer = Identity(dtype=type(categories[0]))
+
         self.prior = prior
 
         if prior is None:

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -16,13 +16,24 @@ class Transformer(object):
 
 
 class Identity(Transformer):
-    """Identity transform."""
+    """Identity transform.
+    If dtype is different from None the transform will cast everything to a
+    string and the inverse transform will cast to the type defined in dtype."""
+
+    def __init__(self, dtype=None):
+        super(Identity, self).__init__()
+        self.dtype = dtype
 
     def transform(self, X):
-        return X
+        if self.dtype is None:
+            return X
+        return [str(x) for x in X]
+
 
     def inverse_transform(self, Xt):
-        return Xt
+        if self.dtype is None:
+            return Xt
+        return [self.dtype(x) for x in Xt]
 
 
 class Log10(Transformer):

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -13,7 +13,7 @@ from sklearn.svm import SVC, LinearSVC
 from sklearn.tree import DecisionTreeClassifier
 from sklearn.base import clone
 from sklearn.base import BaseEstimator
-from sklearn.externals.joblib import cpu_count
+from joblib import cpu_count
 
 from skopt.space import Real, Categorical, Integer
 from skopt import BayesSearchCV

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -157,6 +157,14 @@ def test_normalize_dimensions_all_categorical():
 
 
 @pytest.mark.fast_test
+def test_categoricals_mixed_types():
+    domain = [[1, 2, 3, 4], ['a', 'b', 'c'], [True, False]]
+    x = [1, 'a', True]
+    space = normalize_dimensions(domain)
+    assert (space.inverse_transform(space.transform([x])) == [x])
+
+
+@pytest.mark.fast_test
 @pytest.mark.parametrize("dimensions, normalizations",
                          [(((1, 3), (1., 3.)),
                            ('normalize', 'normalize')

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -6,8 +6,8 @@ from scipy.optimize import OptimizeResult
 from scipy.optimize import minimize as sp_minimize
 from sklearn.base import is_regressor
 from sklearn.ensemble import GradientBoostingRegressor
-from sklearn.externals.joblib import dump as dump_
-from sklearn.externals.joblib import load as load_
+from joblib import dump as dump_
+from joblib import load as load_
 
 from .learning import ExtraTreesRegressor
 from .learning import GaussianProcessRegressor


### PR DESCRIPTION
Fixing `DeprecationWarning: sklearn.externals.joblib is deprecated in 0.21 and will be removed in 0.23. Please import this functionality directly from joblib, which can be installed with: pip install joblib. If this warning is raised when loading pickled models, you may need to re-serialize those models with scikit-learn 0.21+.`

Should resolve [#774](https://github.com/scikit-optimize/scikit-optimize/issues/774)

