### PR TITLE
[MRG] Reduce the amount of  deprecation warnings in unit tests

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -4,3 +4,8 @@ omit =
     */_version.py
     # these are our tests, don't count them towards coverage
     skopt/tests/*
+
+[report]
+exclude_lines =
+   # Don't complain about packages we have installed
+   except ImportError

--- a/README.rst
+++ b/README.rst
@@ -1,3 +1,5 @@
+**Disclaimer**: This project is no longer actively maintained! *Help is welcome to take over*.
+
 |Logo|
 
 |Travis Status| |CircleCI Status| |binder| |gitter| |Zenodo DOI|

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,0 +1,6 @@
+[pytest]
+markers =
+    fast_test: marks tests as fast (deselect with '-m "not fast_test"')
+    slow_test: marks tests as slow (deselect with '-m "not slow_test"')
+    slow: marks tests as slow (deselect with '-m "not slow"')
+    serial

--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -13,7 +13,11 @@ Early stopping callbacks
 ------------------------
 * DeltaXStopper
 """
-from collections import Callable
+try:
+    from collections.abc import Callable
+except ImportError:
+    from collections import Callable
+
 from time import time
 
 import numpy as np

--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -7,7 +7,10 @@ It is sufficient that one re-implements the base estimator.
 import copy
 import inspect
 import numbers
-from collections import Iterable
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
 
 import numpy as np
 

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -1,4 +1,8 @@
-from collections import defaultdict, Sized
+try:
+    from collections.abc import Sized
+except ImportError:
+    from collections import Sized
+from collections import defaultdict
 from functools import partial
 
 import numpy as np
@@ -11,7 +15,10 @@ from sklearn.model_selection._search import BaseSearchCV
 from sklearn.utils import check_random_state
 from sklearn.utils.fixes import MaskedArray
 from sklearn.utils.validation import indexable, check_is_fitted
-from sklearn.metrics.scorer import check_scoring
+try:
+    from sklearn.metrics import check_scoring
+except ImportError:
+    from sklearn.metrics.scorer import check_scoring
 
 from . import Optimizer
 from .utils import point_asdict, dimensions_aslist, eval_callbacks
@@ -546,7 +553,7 @@ class BayesSearchCV(BaseSearchCV):
         params = optimizer.ask(n_points=n_points)
 
         # convert parameters to python native types
-        params = [[np.asscalar(np.array(v)) for v in p] for p in params]
+        params = [[np.array(v).item() for v in p] for p in params]
 
         # make lists into dictionaries
         params_dict = [point_asdict(search_space, p) for p in params]

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -355,7 +355,7 @@ class Integer(Dimension):
         """
         # The concatenation of all transformed dimensions makes Xt to be
         # of type float, hence the required cast back to int.
-        return super(Integer, self).inverse_transform(Xt).astype(np.int)
+        return super(Integer, self).inverse_transform(Xt).astype(np.int64)
 
     @property
     def bounds(self):
@@ -586,7 +586,7 @@ class Space(object):
            Instantiated Space object
         """
         with open(yml_path, 'rb') as f:
-            config = yaml.load(f)
+            config = yaml.safe_load(f)
 
         dimension_classes = {'real': Real,
                              'integer': Integer,

--- a/skopt/tests/test_acquisition.py
+++ b/skopt/tests/test_acquisition.py
@@ -5,10 +5,9 @@ import pytest
 from scipy import optimize
 
 from sklearn.multioutput import MultiOutputRegressor
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_greater
-from sklearn.utils.testing import assert_raises
+from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_raises
 
 from skopt.acquisition import _gaussian_acquisition
 from skopt.acquisition import gaussian_acquisition_1D
@@ -135,7 +134,7 @@ def test_acquisition_per_second(acq_func):
     indices = np.arange(6)
     vals = _gaussian_acquisition(X_pred, cgpr, y_opt=1.0, acq_func=acq_func)
     for fast, slow in zip(indices[:-1], indices[1:]):
-        assert_greater(vals[slow], vals[fast])
+        assert vals[slow] > vals[fast]
 
     acq_wo_time = _gaussian_acquisition(
         X, cgpr.estimators_[0], y_opt=1.2, acq_func=acq_func[:2])

--- a/skopt/tests/test_benchmarks.py
+++ b/skopt/tests/test_benchmarks.py
@@ -1,8 +1,8 @@
 import numpy as np
 import pytest
 
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_almost_equal
+from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_almost_equal
 
 from skopt.benchmarks import branin
 from skopt.benchmarks import hart6

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -4,9 +4,6 @@ import numpy as np
 import os
 from collections import namedtuple
 
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_less
-
 from skopt import dummy_minimize
 from skopt import gp_minimize
 from skopt.benchmarks import bench1
@@ -22,8 +19,8 @@ from skopt.utils import load
 def test_timer_callback():
     callback = TimerCallback()
     dummy_minimize(bench1, [(-1.0, 1.0)], callback=callback, n_calls=10)
-    assert_equal(len(callback.iter_time), 10)
-    assert_less(0.0, sum(callback.iter_time))
+    assert len(callback.iter_time) <= 10
+    assert 0.0 < sum(callback.iter_time)
 
 
 @pytest.mark.fast_test

--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -336,7 +336,8 @@ def test_invalid_n_calls_arguments(minimizer):
     # n_calls >= n_random_starts + len(x0)
     with pytest.raises(ValueError):
         minimizer(branin, [(-5.0, 10.0), (0.0, 15.0)], n_calls=1,
-                  x0=[[-1, 2], [-3, 3], [2, 5]], random_state=1, n_random_starts=7)
+                  x0=[[-1, 2], [-3, 3], [2, 5]], random_state=1,
+                  n_random_starts=7)
 
     # n_calls >= n_random_starts
     with pytest.raises(ValueError):

--- a/skopt/tests/test_dummy_opt.py
+++ b/skopt/tests/test_dummy_opt.py
@@ -1,7 +1,5 @@
 import pytest
 
-from sklearn.utils.testing import assert_less
-
 from skopt import dummy_minimize
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench2
@@ -10,7 +8,7 @@ from skopt.benchmarks import bench3
 
 def check_minimize(func, y_opt, dimensions, margin, n_calls):
     r = dummy_minimize(func, dimensions, n_calls=n_calls, random_state=1)
-    assert_less(r.fun, y_opt + margin)
+    assert r.fun < y_opt + margin
 
 
 @pytest.mark.slow_test

--- a/skopt/tests/test_forest_opt.py
+++ b/skopt/tests/test_forest_opt.py
@@ -1,8 +1,6 @@
 from functools import partial
 
 from sklearn.tree import DecisionTreeClassifier
-from sklearn.utils.testing import assert_less
-from sklearn.utils.testing import assert_raise_message
 import pytest
 
 from skopt import gbrt_minimize
@@ -22,16 +20,12 @@ MINIMIZERS = [("ET", partial(forest_minimize, base_estimator='ET')),
 @pytest.mark.parametrize("base_estimator", [42, DecisionTreeClassifier()])
 def test_forest_minimize_api(base_estimator):
     # invalid string value
-    assert_raise_message(ValueError,
-                         "Valid strings for the base_estimator parameter",
-                         forest_minimize, lambda x: 0., [],
-                         base_estimator='abc')
+    with pytest.raises(ValueError):
+        forest_minimize(lambda x: 0., [], base_estimator='abc')
 
     # not a string nor a regressor
-    assert_raise_message(ValueError,
-                         "has to be a regressor",
-                         forest_minimize, lambda x: 0., [],
-                         base_estimator=base_estimator)
+    with pytest.raises(ValueError):
+        forest_minimize(lambda x: 0., [], base_estimator=base_estimator)
 
 
 def check_minimize(minimizer, func, y_opt, dimensions, margin,
@@ -40,7 +34,7 @@ def check_minimize(minimizer, func, y_opt, dimensions, margin,
         r = minimizer(
             func, dimensions, n_calls=n_calls, random_state=n,
             n_random_starts=n_random_starts, x0=x0)
-        assert_less(r.fun, y_opt + margin)
+        assert r.fun < y_opt + margin
 
 
 @pytest.mark.slow_test

--- a/skopt/tests/test_gp_opt.py
+++ b/skopt/tests/test_gp_opt.py
@@ -1,5 +1,4 @@
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_less
+from numpy.testing import assert_array_equal
 import pytest
 
 from skopt import gp_minimize
@@ -17,7 +16,7 @@ def check_minimize(func, y_opt, bounds, acq_optimizer, acq_func,
                     acq_func=acq_func, n_random_starts=n_random_starts,
                     n_calls=n_calls, random_state=1,
                     noise=1e-10)
-    assert_less(r.fun, y_opt + margin)
+    assert r.fun < y_opt + margin
 
 
 SEARCH = ["sampling", "lbfgs"]

--- a/skopt/tests/test_optimizer.py
+++ b/skopt/tests/test_optimizer.py
@@ -2,11 +2,9 @@ import numpy as np
 import pytest
 
 from sklearn.multioutput import MultiOutputRegressor
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_raises
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_false
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_equal
+from numpy.testing import assert_raises
 
 from skopt import gp_minimize
 from skopt import forest_minimize
@@ -187,9 +185,9 @@ def test_acq_optimizer_with_time_api(base_estimator, acq_func):
     res = opt.tell(x2, (bench1(x2), 2.0))
 
     # x1 and x2 are random.
-    assert_true(x1 != x2)
+    assert x1 != x2
 
-    assert_true(len(res.models) == 1)
+    assert len(res.models) == 1
     assert_array_equal(res.func_vals.shape, (2,))
     assert_array_equal(res.log_time.shape, (2,))
 
@@ -220,13 +218,13 @@ def test_optimizer_copy(acq_func):
     copied_estimator = opt_copy.base_estimator_
 
     if "ps" in acq_func:
-        assert_true(isinstance(copied_estimator, MultiOutputRegressor))
+        assert isinstance(copied_estimator, MultiOutputRegressor)
         # check that the base_estimator is not wrapped multiple times
         is_multi = isinstance(copied_estimator.estimator,
                               MultiOutputRegressor)
-        assert_false(is_multi)
+        assert not is_multi
     else:
-        assert_false(isinstance(copied_estimator, MultiOutputRegressor))
+        assert not isinstance(copied_estimator, MultiOutputRegressor)
 
     assert_array_equal(opt_copy.Xi, opt.Xi)
     assert_array_equal(opt_copy.yi, opt.yi)

--- a/skopt/tests/test_searchcv.py
+++ b/skopt/tests/test_searchcv.py
@@ -5,7 +5,6 @@ search with interface similar to those of GridSearchCV
 import pytest
 import time
 
-from sklearn.utils.testing import assert_greater
 from sklearn.datasets import load_iris, make_classification
 from sklearn.model_selection import train_test_split
 from sklearn.pipeline import Pipeline
@@ -41,7 +40,7 @@ def _fit_svc(n_jobs=1, n_points=1, cv=None):
 
     opt.fit(X, y)
 
-    assert_greater(opt.score(X, y), 0.9)
+    assert opt.score(X, y) > 0.9
 
 
 def test_raise_errors():
@@ -107,7 +106,7 @@ def test_searchcv_runs(surrogate, n_jobs, n_points, cv=None):
 
     # this normally does not hold only if something is wrong
     # with the optimizaiton procedure as such
-    assert_greater(opt.score(X_test, y_test), 0.9)
+    assert opt.score(X_test, y_test) > 0.9
 
 
 @pytest.mark.slow_test

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -1,18 +1,14 @@
 import pytest
 import numbers
 import numpy as np
+import os
 import yaml
 from tempfile import NamedTemporaryFile
 
-from sklearn.utils.testing import assert_array_almost_equal
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_false
-from sklearn.utils.testing import assert_not_equal
-from sklearn.utils.testing import assert_less_equal
-from sklearn.utils.testing import assert_greater_equal
-from sklearn.utils.testing import assert_true
-from sklearn.utils.testing import assert_raises_regex
+from numpy.testing import assert_array_almost_equal
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_equal
+from numpy.testing import assert_raises_regex
 
 from skopt import Optimizer
 from skopt.space import Space
@@ -25,22 +21,22 @@ from skopt.space import check_dimension as space_check_dimension
 def check_dimension(Dimension, vals, random_val):
     x = Dimension(*vals)
     assert_equal(x, Dimension(*vals))
-    assert_not_equal(x, Dimension(vals[0], vals[1] + 1))
-    assert_not_equal(x, Dimension(vals[0] + 1, vals[1]))
+    assert x != Dimension(vals[0], vals[1] + 1)
+    assert x != Dimension(vals[0] + 1, vals[1])
     assert_equal(x.rvs(random_state=1), random_val)
 
 
 def check_categorical(vals, random_val):
     x = Categorical(vals)
     assert_equal(x, Categorical(vals))
-    assert_not_equal(x, Categorical(vals[:-1] + ("zzz",)))
+    assert x != Categorical(vals[:-1] + ("zzz",))
     assert_equal(x.rvs(random_state=1), random_val)
 
 
 def check_limits(value, low, high):
     # check if low <= value <= high
-    assert_less_equal(low, value)
-    assert_greater_equal(high, value)
+    assert low <= value
+    assert high >= value
 
 
 @pytest.mark.fast_test
@@ -73,7 +69,7 @@ def test_real():
     for i in range(50):
         r = a.rvs(random_state=i)
         check_limits(r, 1, 25)
-        assert_true(r in a)
+        assert r in a
 
     random_values = a.rvs(random_state=0, n_samples=10)
     assert_array_equal(random_values.shape, (10))
@@ -81,7 +77,7 @@ def test_real():
     assert_array_equal(a.inverse_transform(random_values), random_values)
 
     log_uniform = Real(10**-5, 10**5, prior="log-uniform")
-    assert_not_equal(log_uniform, Real(10**-5, 10**5))
+    assert log_uniform != Real(10**-5, 10**5)
     for i in range(50):
         random_val = log_uniform.rvs(random_state=i)
         check_limits(random_val, 10**-5, 10**5)
@@ -98,11 +94,11 @@ def test_real_bounds():
     # should give same answer as using check_limits() but this is easier
     # to read
     a = Real(1., 2.1)
-    assert_false(0.99 in a)
-    assert_true(1. in a)
-    assert_true(2.09 in a)
-    assert_true(2.1 in a)
-    assert_false(np.nextafter(2.1, 3.) in a)
+    assert 0.99 not in a
+    assert 1. in a
+    assert 2.09 in a
+    assert 2.1 in a
+    assert np.nextafter(2.1, 3.) not in a
 
 
 @pytest.mark.fast_test
@@ -110,9 +106,9 @@ def test_integer():
     a = Integer(1, 10)
     for i in range(50):
         r = a.rvs(random_state=i)
-        assert_less_equal(1, r)
-        assert_greater_equal(11, r)
-        assert_true(r in a)
+        assert 1 <= r
+        assert 11 >= r
+        assert r in a
 
     random_values = a.rvs(random_state=0, n_samples=10)
     assert_array_equal(random_values.shape, (10))
@@ -270,25 +266,25 @@ def test_space_api():
     assert isinstance(cat_space.dimensions[1], Categorical)
 
     assert_equal(len(space.dimensions), 5)
-    assert_true(isinstance(space.dimensions[0], Real))
-    assert_true(isinstance(space.dimensions[1], Integer))
-    assert_true(isinstance(space.dimensions[2], Categorical))
-    assert_true(isinstance(space.dimensions[3], Real))
-    assert_true(isinstance(space.dimensions[4], Categorical))
+    assert isinstance(space.dimensions[0], Real)
+    assert isinstance(space.dimensions[1], Integer)
+    assert isinstance(space.dimensions[2], Categorical)
+    assert isinstance(space.dimensions[3], Real)
+    assert isinstance(space.dimensions[4], Categorical)
 
     samples = space.rvs(n_samples=10, random_state=0)
     assert_equal(len(samples), 10)
     assert_equal(len(samples[0]), 5)
 
-    assert_true(isinstance(samples, list))
+    assert isinstance(samples, list)
     for n in range(4):
-        assert_true(isinstance(samples[n], list))
+        assert isinstance(samples[n], list)
 
-    assert_true(isinstance(samples[0][0], numbers.Real))
-    assert_true(isinstance(samples[0][1], numbers.Integral))
-    assert_true(isinstance(samples[0][2], str))
-    assert_true(isinstance(samples[0][3], numbers.Real))
-    assert_true(isinstance(samples[0][4], str))
+    assert isinstance(samples[0][0], numbers.Real)
+    assert isinstance(samples[0][1], numbers.Integral)
+    assert isinstance(samples[0][2], str)
+    assert isinstance(samples[0][3], numbers.Real)
+    assert isinstance(samples[0][4], str)
 
     samples_transformed = space.transform(samples)
     assert_equal(samples_transformed.shape[0], len(samples))
@@ -302,11 +298,11 @@ def test_space_api():
         assert space.distance(orig, round_trip) < 1.e-8
 
     samples = space.inverse_transform(samples_transformed)
-    assert_true(isinstance(samples[0][0], numbers.Real))
-    assert_true(isinstance(samples[0][1], numbers.Integral))
-    assert_true(isinstance(samples[0][2], str))
-    assert_true(isinstance(samples[0][3], numbers.Real))
-    assert_true(isinstance(samples[0][4], str))
+    assert isinstance(samples[0][0], numbers.Real)
+    assert isinstance(samples[0][1], numbers.Integral)
+    assert isinstance(samples[0][2], str)
+    assert isinstance(samples[0][3], numbers.Real)
+    assert isinstance(samples[0][4], str)
 
     for b1, b2 in zip(space.bounds,
                       [(0.0, 1.0), (-5, 5),
@@ -342,8 +338,8 @@ def test_normalize():
     X = 28 * (X - X.min()) / (X.max() - X.min()) + 2
 
     # Check transformed values are in [0, 1]
-    assert_true(np.all(a.transform(X) <= np.ones_like(X)))
-    assert_true(np.all(np.zeros_like(X) <= a.transform(X)))
+    assert np.all(a.transform(X) <= np.ones_like(X))
+    assert np.all(np.zeros_like(X) <= a.transform(X))
 
     # Check inverse transform
     assert_array_almost_equal(a.inverse_transform(a.transform(X)), X)
@@ -357,8 +353,8 @@ def test_normalize():
     X = np.clip(10**3 * rng.randn(100), 10**2.0, 10**4.0)
 
     # Check transform
-    assert_true(np.all(a.transform(X) <= np.ones_like(X)))
-    assert_true(np.all(np.zeros_like(X) <= a.transform(X)))
+    assert np.all(a.transform(X) <= np.ones_like(X))
+    assert np.all(np.zeros_like(X) <= a.transform(X))
 
     # Check inverse transform
     assert_array_almost_equal(a.inverse_transform(a.transform(X)), X)
@@ -368,14 +364,14 @@ def test_normalize():
         check_limits(a.rvs(random_state=i), 2, 30)
     assert_array_equal(a.transformed_bounds, (0, 1))
 
-    X = rng.randint(2, 31)
+    X = rng.randint(2, 31, dtype="int64")
     # Check transformed values are in [0, 1]
-    assert_true(np.all(a.transform(X) <= np.ones_like(X)))
-    assert_true(np.all(np.zeros_like(X) <= a.transform(X)))
+    assert np.all(a.transform(X) <= np.ones_like(X))
+    assert np.all(np.zeros_like(X) <= a.transform(X))
 
     # Check inverse transform
     X_orig = a.inverse_transform(a.transform(X))
-    assert_equal(X_orig.dtype, "int64")
+    assert isinstance(X_orig, np.int64)
     assert_array_equal(X_orig, X)
 
 
@@ -405,7 +401,7 @@ def test_categorical_identity():
     categories = ["cat", "dog", "rat"]
     cat = Categorical(categories, transform="identity")
     samples = cat.rvs(100)
-    assert_true(all([t in categories for t in cat.rvs(100)]))
+    assert all([t in categories for t in cat.rvs(100)])
     transformed = cat.transform(samples)
     assert_array_equal(transformed, samples)
     assert_array_equal(samples, cat.inverse_transform(transformed))
@@ -477,7 +473,7 @@ def test_dimension_name_none(dimension):
 
 @pytest.mark.fast_test
 def test_space_from_yaml():
-    with NamedTemporaryFile() as tmp:
+    with NamedTemporaryFile(delete=False) as tmp:
         tmp.write(b"""
         Space:
             - Real:
@@ -510,7 +506,8 @@ def test_space_from_yaml():
 
         space2 = Space.from_yaml(tmp.name)
         assert_equal(space, space2)
-
+        tmp.close()
+        os.unlink(tmp.name)
 
 @pytest.mark.parametrize("name", [1, 1., True])
 def test_dimension_with_invalid_names(name):

--- a/skopt/tests/test_utils.py
+++ b/skopt/tests/test_utils.py
@@ -1,10 +1,8 @@
 import pytest
 import tempfile
 
-from sklearn.utils.testing import assert_array_equal
-from sklearn.utils.testing import assert_equal
-from sklearn.utils.testing import assert_true
-
+from numpy.testing import assert_array_equal
+from numpy.testing import assert_equal
 import numpy as np
 
 from skopt import gp_minimize
@@ -52,7 +50,7 @@ def test_dump_and_load():
         f.seek(0)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
-    assert_true("func" in res_loaded.specs["args"])
+    assert "func" in res_loaded.specs["args"]
 
     # Test dumping without objective function
     with tempfile.TemporaryFile() as f:
@@ -60,7 +58,7 @@ def test_dump_and_load():
         f.seek(0)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
-    assert_true(not ("func" in res_loaded.specs["args"]))
+    assert not ("func" in res_loaded.specs["args"])
 
     # Delete the objective function and dump the modified object
     del res.specs["args"]["func"]
@@ -69,13 +67,13 @@ def test_dump_and_load():
         f.seek(0)
         res_loaded = load(f)
     check_optimization_results_equality(res, res_loaded)
-    assert_true(not ("func" in res_loaded.specs["args"]))
+    assert not ("func" in res_loaded.specs["args"])
 
 
 @pytest.mark.fast_test
 def test_dump_and_load_optimizer():
     base_estimator = ExtraTreesRegressor(random_state=2)
-    opt = Optimizer([(-2.0, 2.0)], base_estimator, n_random_starts=1,
+    opt = Optimizer([(-2.0, 2.0)], base_estimator, n_initial_points=1,
                     acq_optimizer="sampling")
 
     opt.run(bench1, n_iter=3)


### PR DESCRIPTION
* Using collections.abc instead of collections for import
* Using  yaml.safe_load instead of yaml.load
* Replacing sklearn.utils.testing functions by numpy testing functions
* Using assert for assert_greater, assert_less, assert_true, assert_false, assert_greater_equal and assert_less_equal
* Replacing assert_raise_message by pytest.raises
* Replacing assert_warns_message by pytest.warns and assert checks
* Using NamedTemporaryFile(delete=False) with manual delete to fix the Unit test on WIndows
* Replacing from sklearn.metrics.scorer import check_scoring by from sklearn.metrics import check_scoring
* Using pytest.ini to register fast_test and slow_test