### PR TITLE
Fix docstring: kappa is only used for LCB acquisition function

### DIFF
--- a/skopt/acquisition.py
+++ b/skopt/acquisition.py
@@ -112,7 +112,7 @@ def gaussian_lcb(X, model, kappa=1.96, return_grad=False):
         exploration over exploitation and vice versa.
         If set to 'inf', the acquisition function will only use the variance
         which is useful in a pure exploration setting.
-        Useless if ``method`` is set to "LCB".
+        Useless if ``method`` is not set to "LCB".
 
     return_grad : boolean, optional
         Whether or not to return the grad. Implemented only for the case where


### PR DESCRIPTION
Description of `gaussian_lcb()` parameter `kappa` is the opposite of what is true. 

See, e.g., https://scikit-optimize.github.io/stable/auto_examples/exploration-vs-exploitation.html?highlight=kappa

> kappa is only used if acq_func is set to “LCB”. xi is used when acq_func is “EI” or “PI”. By default the acqusition function is set to “gp_hedge” which chooses the best of these three. Therefore I recommend not using gp_hedge when tweaking exploration/exploitation, but instead choosing “LCB”, “EI” or “PI.