### PR TITLE
Fix maths display in bayesian_optimization doc

### DIFF
--- a/examples/bayesian-optimization.py
+++ b/examples/bayesian-optimization.py
@@ -38,9 +38,9 @@ For :math:`t=1:T`:
    probabilistic model for the objective :math:`f`. Integrate out all
    possible true functions, using Gaussian process regression.
 
-2. optimize a cheap acquisition/utility function $u$ based on the posterior
+2. optimize a cheap acquisition/utility function :math:`u` based on the posterior
    distribution for sampling the next point.
-   .. math::`x_{t+1} = arg \\min_x u(x)`
+   :math:`x_{t+1} = arg \\min_x u(x)`
    Exploit uncertainty to balance exploration against exploitation.
 
 3. Sample the next observation :math:`y_{t+1}` at :math:`x_{t+1}`.

--- a/examples/bayesian-optimization.py
+++ b/examples/bayesian-optimization.py
@@ -38,8 +38,8 @@ For :math:`t=1:T`:
    probabilistic model for the objective :math:`f`. Integrate out all
    possible true functions, using Gaussian process regression.
 
-2. optimize a cheap acquisition/utility function :math:`u` based on the posterior
-   distribution for sampling the next point.
+2. optimize a cheap acquisition/utility function :math:`u` based on the
+   posterior distribution for sampling the next point.
    :math:`x_{t+1} = arg \\min_x u(x)`
    Exploit uncertainty to balance exploration against exploitation.
 


### PR DESCRIPTION
Current:

<img width="873" alt="Screenshot 2020-03-18 at 12 12 28" src="https://user-images.githubusercontent.com/10897531/76955070-cba26700-6911-11ea-807d-172ac8e144df.png">

This PR should fix both expressions