### PR TITLE
[MRG] Add options to plot_objective

### DIFF
--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -717,7 +717,7 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
                 else:
                     ax_ = ax
                 ax_.plot(xi, yi)
-                ax_.axvline(minimum[i], linestyle="--", color="r", lw=1)
+                ax_.axvline(minimum[index], linestyle="--", color="r", lw=1)
 
             # lower triangle
             elif i > j:

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -429,8 +429,9 @@ def _format_scatter_plot_axes(ax, space, ylabel, plot_dims,
 
             else:  # diagonal plots
                 ax_.set_ylim(*diagonal_ylim)
-                low, high = dim_i.bounds
-                ax_.set_xlim(low, high)
+                if not iscat[i]:
+                    low, high = dim_i.bounds
+                    ax_.set_xlim(low, high)
                 ax_.yaxis.tick_right()
                 ax_.yaxis.set_label_position('right')
                 ax_.yaxis.set_ticks_position('both')

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -537,7 +537,8 @@ def partial_dependence(space, model, i, j=None, sample_points=None,
 
 def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
                    zscale='linear', dimensions=None, sample_source='random',
-                   minimum='result', n_minimum_search=None, plot_dims=None):
+                   minimum='result', n_minimum_search=None, plot_dims=None,
+                   show_points=True, cmap='viridis_r'):
     """Plot a 2-d matrix with so-called Partial Dependence plots
     of the objective function. This shows the influence of each
     search-space dimension on the objective function.
@@ -586,7 +587,7 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
 
     levels : int, default=10
         Number of levels to draw on the contour plot, passed directly
-        to `plt.contour()`.
+        to `plt.contourf()`.
 
     n_points : int, default=40
         Number of points at which to evaluate the partial dependence
@@ -653,6 +654,14 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
         'expected_minimum_random'. Parameter is used when
         `sample_source` and/or `minimum` is set to
         'expected_minimum' or 'expected_minimum_random'.
+
+    show_points: bool, default = True
+        Choose whether to show evaluated points in the
+        contour plots.
+
+    cmap: str or Colormap, default = 'viridis_r'
+        Color map for contour plots. Passed directly to
+        `plt.contourf()`
 
     Returns
     -------
@@ -728,9 +737,10 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
                                                    index1, index2,
                                                    samples, n_points)
                 ax_.contourf(xi, yi, zi, levels,
-                             locator=locator, cmap='viridis_r')
-                ax_.scatter(x_samples[:, index2], x_samples[:, index1],
-                            c='k', s=10, lw=0.)
+                             locator=locator, cmap=cmap)
+                if show_points:
+                    ax_.scatter(x_samples[:, index2], x_samples[:, index1],
+                                c='k', s=10, lw=0.)
                 ax_.scatter(minimum[index2], minimum[index1],
                             c=['r'], s=100, lw=0., marker='*')
     ylabel = "Partial dependence"

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -429,6 +429,8 @@ def _format_scatter_plot_axes(ax, space, ylabel, plot_dims,
 
             else:  # diagonal plots
                 ax_.set_ylim(*diagonal_ylim)
+                low, high = dim_i.bounds
+                ax_.set_xlim(low, high)
                 ax_.yaxis.tick_right()
                 ax_.yaxis.set_label_position('right')
                 ax_.yaxis.set_ticks_position('both')


### PR DESCRIPTION
 ### Fixes
 * Fix position of red minimum line when `plot_dims` is something other than the first N dimensions
 * Fix `xlim` of line plots along the diagonal so that the minimum line lines up with the marker in the contour plots below it.

### Enhancements
 * Add `show_points` option to allow user to decide whether to see the evaluated points. When the number of points is large and the plots are not that big, one can barely see the surrogate function behind the points.
 * Add `cmap` option to allow user to choose the color map for the contour plots. If accepted, this should probably be extended to other functions as well.