### PR TITLE
Protect against underflow warnings/errors in softmax calculations

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -596,7 +596,8 @@ class Optimizer(object):
             if self.acq_func == "gp_hedge":
                 logits = np.array(self.gains_)
                 logits -= np.max(logits)
-                exp_logits = np.exp(self.eta * logits)
+                with np.errstate(under='ignore'):
+                    exp_logits = np.exp(self.eta * logits)
                 probs = exp_logits / np.sum(exp_logits)
                 next_x = self.next_xs_[np.argmax(self.rng.multinomial(1,
                                                                       probs))]


### PR DESCRIPTION
Set temporary 'ignore' treatment for underflow conditions which can happen in the softmax calculations.
Underflow here does not cause any loss of significance of the result or erroneous results.

Underflow can happen when one of the gains is near zero and other is high, for example 10000.