### PR TITLE
[MRG]Add hollow iterations early stopper

### DIFF
--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -219,6 +219,25 @@ class DeltaYStopper(EarlyStopper):
             return None
 
 
+class HollowIterationsStopper(EarlyStopper):
+    """
+    Stop the optimization if the improvement over the last n_iterations is too small.
+    """
+
+    def __init__(self, n_iterations, threshold=0):
+        super(HollowIterationsStopper, self).__init__()
+        self.n_iterations = n_iterations
+        self.threshold = abs(threshold)
+
+    def _criterion(self, result):
+
+        if len(result.func_vals) <= self.n_iterations:
+            return False
+
+        cummin = np.minimum.accumulate(result.func_vals)
+        return cummin[-self.n_iterations - 1] - cummin[-1] <= self.threshold
+
+
 class DeadlineStopper(EarlyStopper):
     """
     Stop the optimization before running out of a fixed budget of time.

--- a/skopt/callbacks.py
+++ b/skopt/callbacks.py
@@ -221,7 +221,7 @@ class DeltaYStopper(EarlyStopper):
 
 class HollowIterationsStopper(EarlyStopper):
     """
-    Stop the optimization if the improvement over the last n_iterations is too small.
+    Stop if the improvement over the last n iterations is below a threshold.
     """
 
     def __init__(self, n_iterations, threshold=0):

--- a/skopt/tests/test_callbacks.py
+++ b/skopt/tests/test_callbacks.py
@@ -12,6 +12,7 @@ from skopt.callbacks import TimerCallback
 from skopt.callbacks import DeltaYStopper
 from skopt.callbacks import DeadlineStopper
 from skopt.callbacks import CheckpointSaver
+from skopt.callbacks import HollowIterationsStopper
 
 from skopt.utils import load
 
@@ -45,6 +46,49 @@ def test_deadline_stopper():
     gp_minimize(bench3, [(-1.0, 1.0)], callback=deadline, n_calls=10, random_state=1)
     assert len(deadline.iter_time) == 10
     assert np.sum(deadline.iter_time) < deadline.total_time
+
+
+@pytest.mark.fast_test
+def test_hollow_iterations_stopper():
+    Result = namedtuple("Result", ["func_vals"])
+
+    hollow = HollowIterationsStopper(3, 0)
+    # will run at least n_iterations + 1 times
+    assert not hollow(Result([10, 11, 12]))
+    assert hollow(Result([10, 11, 12, 13]))
+
+    # a tie is not enough
+    assert hollow(Result([10, 11, 12, 10]))
+
+    # every time we make a new min, we then have n_iterations rounds to beat it
+    assert not hollow(Result([10, 9, 8, 7, 7, 7]))
+    assert hollow(Result([10, 9, 8, 7, 7, 7, 7]))
+
+    hollow = HollowIterationsStopper(3, 1.1)
+    assert not hollow(Result([10, 11, 12, 8.89]))
+    assert hollow(Result([10, 11, 12, 8.9]))
+
+    # individual improvement below threshold contribute
+    assert hollow(Result([10, 9.9, 9.8, 9.7]))
+    assert not hollow(Result([10, 9.5, 9, 8.5, 8, 7.5]))
+
+    hollow = HollowIterationsStopper(3, 0)
+    result = gp_minimize(
+        bench3, [(-1.0, 1.0)], callback=hollow, n_calls=100, random_state=1
+    )
+    assert len(result.func_vals) == 10
+
+    hollow = HollowIterationsStopper(3, 0.1)
+    result = gp_minimize(
+        bench3, [(-1.0, 1.0)], callback=hollow, n_calls=100, random_state=1
+    )
+    assert len(result.func_vals) == 5
+
+    hollow = HollowIterationsStopper(3, 0.2)
+    result = gp_minimize(
+        bench3, [(-1.0, 1.0)], callback=hollow, n_calls=100, random_state=1
+    )
+    assert len(result.func_vals) == 4
 
 
 @pytest.mark.fast_test


### PR DESCRIPTION
Stop the optimization if the improvement over the last n iterations is below a threshold.
Similar to, but not quite the same as DeltaY stopper. For instance, if the the search has already found the true minimum, and the 2nd best is more than `delta` away, DeltaY will never kick in.