### PR TITLE
Doc line, logspace call, set_transformer default parameter misstype, …

### DIFF
--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -1,3 +1,4 @@
+# -*- encoding: UTF-8 -*-
 """Plotting functions."""
 import sys
 import numpy as np
@@ -1242,7 +1243,7 @@ def plot_histogram(result, dimension_identifier, bins=20, rotate_labels=0,
         # in which case the histogram can be plotted more easily.
         if dimension.prior == 'log-uniform':
             # Map the number of bins to a log-space for the dimension bounds.
-            bins_mapped = np.logspace(*np.log10(dimension.bounds), bins)
+            bins_mapped = np.logspace(np.log10(dimension.bounds), bins)
         else:
             # Use the original number of bins.
             bins_mapped = bins

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -53,8 +53,7 @@ class BayesSearchCV(BaseSearchCV):
         Either estimator needs to provide a ``score`` function,
         or ``scoring`` must be passed.
 
-    search_spaces : dict, list of dict or list of tuple containing
-        (dict, int).
+    search_spaces : dict, list of dict or list of tuple containing (dict, int).
         One of these cases:
         1. dictionary, where keys are parameter names (strings)
         and values are skopt.space.Dimension instances (Real, Integer

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -278,7 +278,7 @@ class Real(Dimension):
             transform = "identity"
         self.set_transformer(transform)
 
-    def set_transformer(self, transform="identitiy"):
+    def set_transformer(self, transform="identity"):
         """Define rvs and transformer spaces.
 
         Parameters
@@ -466,7 +466,7 @@ class Integer(Dimension):
             transform = "identity"
         self.set_transformer(transform)
 
-    def set_transformer(self, transform="identitiy"):
+    def set_transformer(self, transform="identity"):
         """Define _rvs and transformer spaces.
 
         Parameters

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -20,7 +20,6 @@ from .sampler import Sobol, Lhs, Hammersly, Halton, Grid
 from .sampler import InitialPointGenerator
 from .space import Space, Categorical, Integer, Real, Dimension
 
-
 __all__ = (
     "load",
     "dump",
@@ -593,10 +592,10 @@ def normalize_dimensions(dimensions):
     space = Space(dimensions)
     transformed_dimensions = []
     for dimension in space.dimensions:
-		# check if dimension is of a Dimension instance
+        # check if dimension is of a Dimension instance
         if isinstance(dimension, Dimension):
-			# Change the transformer to normalize
-			# and add it to the new transformed dimensions
+            # Change the transformer to normalize
+            # and add it to the new transformed dimensions
             dimension.set_transformer("normalize")
             transformed_dimensions.append(
                 dimension

--- a/skopt/utils.py
+++ b/skopt/utils.py
@@ -370,7 +370,6 @@ def cook_estimator(base_estimator, space=None, **kwargs):
             space = Space(normalize_dimensions(space.dimensions))
             n_dims = space.transformed_n_dims
             is_cat = space.is_categorical
-
         else:
             raise ValueError("Expected a Space instance, not None.")
 
@@ -594,26 +593,14 @@ def normalize_dimensions(dimensions):
     space = Space(dimensions)
     transformed_dimensions = []
     for dimension in space.dimensions:
-        if isinstance(dimension, Categorical):
-            transformed_dimensions.append(Categorical(dimension.categories,
-                                                      dimension.prior,
-                                                      name=dimension.name,
-                                                      transform="normalize"))
-        # To make sure that GP operates in the [0, 1] space
-        elif isinstance(dimension, Real):
+		# check if dimension is of a Dimension instance
+        if isinstance(dimension, Dimension):
+			# Change the transformer to normalize
+			# and add it to the new transformed dimensions
+            dimension.set_transformer("normalize")
             transformed_dimensions.append(
-                Real(dimension.low, dimension.high, dimension.prior,
-                     name=dimension.name,
-                     transform="normalize",
-                     dtype=dimension.dtype)
-                )
-        elif isinstance(dimension, Integer):
-            transformed_dimensions.append(
-                Integer(dimension.low, dimension.high,
-                        name=dimension.name,
-                        transform="normalize",
-                        dtype=dimension.dtype)
-                )
+                dimension
+            )
         else:
             raise RuntimeError("Unknown dimension type "
                                "(%s)" % type(dimension))
@@ -727,10 +714,10 @@ def use_named_args(dimensions):
     ...                          n_calls=20, base_estimator="ET",
     ...                          random_state=4)
     >>>
-    >>> # Print the best-found results.
-    >>> print("Best fitness:", result.fun)
+    >>> # Print the best-found results in same format as the expected result.
+    >>> print("Best fitness: " + str(result.fun))
     Best fitness: 0.1948080835239698
-    >>> print("Best parameters:", result.x)
+    >>> print("Best parameters: {}".format(result.x))
     Best parameters: [0.44134853091052617, 0.06570954323368307, 0.17586123323419825]
 
     Parameters


### PR DESCRIPTION
Doc line, logspace call, set_transformer default parameter misstype, use_named_args test output fix and dimension normalization change

Starting from the doc fix: 
Reading the docs for the BayesSearchCV parameters description for the acceptable input types for the search_spaces parameter, I noticed that the last acceptable patameter was on a wrong line, leading to some confusion. So, (dict, int) is returned to the previous line.

Running the pytest on the freshly downloaded dev branch, yielded in the following errors (including the fixes I applied):
In plots.py, in the plot_histogram method, np.logspace is called with the * operator for multiple arguments (np.logspace(*np.log10(dimension.bounds), bins)), which threw an error in the call. The parameter is also positioned before another one (which is wrong and if it worked otherwise, it should have been last).
In utils.py, in the use_named_args method, pytest checks if the printed values are the same with the expected ones. If pytest is run with python 2.7, the "print ("Best fitness", result.fun)" command prints the values differently (in a tuple, with the first item being the string and second the result value). This has a result of a false negative test result, specifically the result.fun value is correct, but the printed value is not exactly the same. For this reason I changed both the print commands to work in python 2.7 too.

In space/space.py, the set_transformer method in Integer and Real classes has a misstype in the default transform parameter (should be "identity" instead of "identitiy").

Lastly, with the new set_transformer method in the Dimension class (and the classes that inherit from it), in the normalize_dimensions method (in utils.py), there is not need to check for the type of dimension inside of the space object, to reinitialize the dimension with a different transform. Now, we can just call the set_transformer method of the Dimension object with the new transform type, without the need of multiple type checking.