### PR TITLE
[WIP] Add prior value checks to Real and Integer Dimension

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -273,21 +273,15 @@ class Real(Dimension):
                 not in [float, np.float, np.float16, np.float32, np.float64]:
             raise ValueError("dtype must be float, np.float"
                              " got {}".format(self.dtype))
+            
+        if prior not in ("uniform", "log-uniform"):
+            raise ValueError("prior must be `uniform` or `log-uniform`"
+                             ", got {}".format(prior))
 
         if transform is None:
             transform = "identity"
         self.set_transformer(transform)
         
-        if prior not in ("uniform", "log-uniform"):
-            raise ValueError("prior must be `uniform` or `log-uniform`"
-                             ", got {}".format(prior))
-            
-        if transform not in ("identity", "normalize"):
-            raise ValueError("prior must be `identity` or `normalize`"
-                             ", got {}".format(transform))
-            
-        
-
     def set_transformer(self, transform="identitiy"):
         """Define rvs and transformer spaces.
 
@@ -471,18 +465,14 @@ class Integer(Dimension):
                              "'np.int32', 'np.int64', 'np.uint8',"
                              "'np.uint16', 'np.uint32', or"
                              "'np.uint64', but got {}".format(self.dtype))
+            
+        if prior not in ("uniform", "log-uniform"):
+            raise ValueError("prior must be `uniform` or `log-uniform`"
+                             ", got {}".format(prior))
 
         if transform is None:
             transform = "identity"
         self.set_transformer(transform)
-        
-        if prior not in ("uniform", "log-uniform"):
-            raise ValueError("prior must be `uniform` or `log-uniform`"
-                             ", got {}".format(prior))
-            
-        if transform not in ("identity", "normalize"):
-            raise ValueError("prior must be `identity` or `normalize`"
-                             ", got {}".format(transform))
 
     def set_transformer(self, transform="identitiy"):
         """Define _rvs and transformer spaces.
@@ -631,11 +621,6 @@ class Categorical(Dimension):
         else:
             self.prior_ = prior
         self.set_transformer(transform)
-            
-        if transform not in ("identity", "string", "label", "onehot"):
-            raise ValueError("prior must be `identity`, `string`, "
-                             "`label`, or `onehot`"
-                             ", got {}".format(transform))
 
     def set_transformer(self, transform="onehot"):
         """Define _rvs and transformer spaces.

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -273,7 +273,7 @@ class Real(Dimension):
                 not in [float, np.float, np.float16, np.float32, np.float64]:
             raise ValueError("dtype must be float, np.float"
                              " got {}".format(self.dtype))
-            
+
         if prior not in ("uniform", "log-uniform"):
             raise ValueError("prior must be `uniform` or `log-uniform`"
                              ", got {}".format(prior))
@@ -465,7 +465,7 @@ class Integer(Dimension):
                              "'np.int32', 'np.int64', 'np.uint8',"
                              "'np.uint16', 'np.uint32', or"
                              "'np.uint64', but got {}".format(self.dtype))
-            
+
         if prior not in ("uniform", "log-uniform"):
             raise ValueError("prior must be `uniform` or `log-uniform`"
                              ", got {}".format(prior))

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -277,6 +277,16 @@ class Real(Dimension):
         if transform is None:
             transform = "identity"
         self.set_transformer(transform)
+        
+        if prior not in ("uniform", "log-uniform"):
+            raise ValueError("prior must be `uniform` or `log-uniform`"
+                             ", got {}".format(prior))
+            
+        if transform not in ("identity", "normalize"):
+            raise ValueError("prior must be `identity` or `normalize`"
+                             ", got {}".format(transform))
+            
+        
 
     def set_transformer(self, transform="identitiy"):
         """Define rvs and transformer spaces.
@@ -465,6 +475,14 @@ class Integer(Dimension):
         if transform is None:
             transform = "identity"
         self.set_transformer(transform)
+        
+        if prior not in ("uniform", "log-uniform"):
+            raise ValueError("prior must be `uniform` or `log-uniform`"
+                             ", got {}".format(prior))
+            
+        if transform not in ("identity", "normalize"):
+            raise ValueError("prior must be `identity` or `normalize`"
+                             ", got {}".format(transform))
 
     def set_transformer(self, transform="identitiy"):
         """Define _rvs and transformer spaces.
@@ -613,6 +631,11 @@ class Categorical(Dimension):
         else:
             self.prior_ = prior
         self.set_transformer(transform)
+            
+        if transform not in ("identity", "string", "label", "onehot"):
+            raise ValueError("prior must be `identity`, `string`, "
+                             "`label`, or `onehot`"
+                             ", got {}".format(transform))
 
     def set_transformer(self, transform="onehot"):
         """Define _rvs and transformer spaces.

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -281,7 +281,7 @@ class Real(Dimension):
         if transform is None:
             transform = "identity"
         self.set_transformer(transform)
-        
+
     def set_transformer(self, transform="identitiy"):
         """Define rvs and transformer spaces.
 


### PR DESCRIPTION
The `Real` and `Integer` dimension subclasses accept invalid `prior` arguments in the constructor (e.g. `Real(... prior=None,...)`) and then silently treat these as `log-uniform` priors in `set_transform`.  This can lead to undesirable behavior, and can cause errors if the bounds are invalid in logspace. I just added value checks to their constructors so users know they've made a mistake early.

This may be related to issue #910 -- I was getting a similar cryptic error `ValueError: array must not contain infs or NaNs` when I realized that I was passing an invalid prior of `None`.  When I switched to `uniform` it now works fine.
