### PR TITLE
[MRG] Fix exception when a categorical param is Iterable

### DIFF
--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -1,7 +1,7 @@
 try:
-    from collections.abc import Sized
+    from collections.abc import Sized, Iterable
 except ImportError:
-    from collections import Sized
+    from collections import Sized, Iterable
 from collections import defaultdict
 from functools import partial
 
@@ -564,7 +564,16 @@ class BayesSearchCV(BaseSearchCV):
         params = optimizer.ask(n_points=n_points)
 
         # convert parameters to python native types
-        params = [[np.array(v).item() for v in p] for p in params]
+        # in case we have any Iterable parameters, we want to
+        # stop numpy from coercing them into an np.array
+        def try_convert_to_np(item):
+            if isinstance(item, Iterable):
+                return item
+            try:
+                return np.array(item).item()
+            except:
+                return item
+        params = [[try_convert_to_np(v) for v in p] for p in params]
 
         # make lists into dictionaries
         params_dict = [point_asdict(search_space, p) for p in params]

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -571,7 +571,7 @@ class BayesSearchCV(BaseSearchCV):
                 return item
             try:
                 return np.array(item).item()
-            except:
+            except ValueError:
                 return item
         params = [[try_convert_to_np(v) for v in p] for p in params]
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -688,7 +688,9 @@ class Categorical(Dimension):
             else:
                 # in case we have any Iterable parameters, we want to
                 # stop numpy from coercing them into an np.array
-                inv_transform_array = np.ndarray(len(inv_transform), dtype=object)
+                inv_transform_array = np.ndarray(
+                    len(inv_transform), dtype=object
+                )
 
                 for i, item in enumerate(inv_transform):
                     inv_transform_array[i] = item

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -1,3 +1,8 @@
+try:
+    from collections.abc import Iterable
+except ImportError:
+    from collections import Iterable
+
 import numbers
 import numpy as np
 import yaml
@@ -678,7 +683,16 @@ class Categorical(Dimension):
         # of type float, hence the required cast back to int.
         inv_transform = super(Categorical, self).inverse_transform(Xt)
         if isinstance(inv_transform, list):
-            inv_transform = np.array(inv_transform)
+            if not any(isinstance(x, Iterable) for x in inv_transform):
+                inv_transform = np.array(inv_transform)
+            else:
+                # in case we have any Iterable parameters, we want to
+                # stop numpy from coercing them into an np.array
+                inv_transform_array = np.ndarray(len(inv_transform), dtype=object)
+
+                for i, item in enumerate(inv_transform):
+                    inv_transform_array[i] = item
+                inv_transform = inv_transform_array
         return inv_transform
 
     def rvs(self, n_samples=None, random_state=None):


### PR DESCRIPTION
If the possible categorical params are Iterables (lists, tuples, etc. - for example, `hidden_layer_sizes` in MLPClassifier), BayesSearchCV will fail with an exception. This solves this issue.

I imagine that it is not really necessary to convert the list to a numpy array in Categorical `inverse_transform`, but I kept it for consistency and in case there is some behavior that needs arrays specifically that I don't know of. Still, if possible, I'd just return the normal Python list.

Solves https://github.com/scikit-optimize/scikit-optimize/issues/950