### PR TITLE
ENH: Add space constraint

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -147,6 +147,10 @@ class Optimizer(object):
         Keeps list of models only as long as the argument given. In the
         case of None, the list has no capped length.
 
+    space_constraint: callable
+        Function that takes a list of values (i.e. a point in space) and
+        returns True if the combination of values satisfies the constraint.
+
     Attributes
     ----------
     Xi : list
@@ -169,6 +173,7 @@ class Optimizer(object):
                  acq_optimizer="auto",
                  random_state=None,
                  model_queue_size=None,
+                 space_constraint=None,
                  acq_func_kwargs=None,
                  acq_optimizer_kwargs=None):
         self.specs = {"args": copy.copy(inspect.currentframe().f_locals),
@@ -268,7 +273,7 @@ class Optimizer(object):
         # normalize space if GP regressor
         if isinstance(self.base_estimator_, GaussianProcessRegressor):
             dimensions = normalize_dimensions(dimensions)
-        self.space = Space(dimensions)
+        self.space = Space(dimensions, constraint=space_constraint)
 
         self._initial_samples = None
         self._initial_point_generator = cook_initial_point_generator(


### PR DESCRIPTION
Fixes https://github.com/scikit-optimize/scikit-optimize/issues/355
Fixes https://github.com/scikit-optimize/scikit-optimize/issues/700
Fixes https://github.com/scikit-optimize/scikit-optimize/issues/770
Fixes https://github.com/scikit-optimize/scikit-optimize/issues/108
Probably fixes https://github.com/scikit-optimize/scikit-optimize/issues/730
Probably fixes https://github.com/scikit-optimize/scikit-optimize/issues/371
Probably fixes https://github.com/scikit-optimize/scikit-optimize/issues/457
Closes https://github.com/scikit-optimize/scikit-optimize/pull/836

A proposal for constrained optimization. An alternative to https://github.com/scikit-optimize/scikit-optimize/pull/836 that you might find less invasive and, hopefully, far better designed!

This allows, e.g., to only seek solutions within unit circle:
```py
Optimizer(...
          space_constraint=lambda x: x[0]**2 + x[1]**2 <= 1)
```
The issue with:
```py
def objective(params):
    if invalid(params):
        return np.finfo(float).max  # =np.inf
    return ...
```
is that ["if I set `n_calls` of the optimizer to 20, I want that to be 20 valid calls."](https://github.com/scikit-optimize/scikit-optimize/pull/199#issuecomment-399086652)

Will tidy-up/tests after gotten :ok:. Apparently, this is the number one missing feature here, so feedback strongly appreciated!