### PR TITLE
docs: fix simple typo, stategies -> strategies

### DIFF
--- a/doc/whats_new/v0.4.rst
+++ b/doc/whats_new/v0.4.rst
@@ -8,7 +8,7 @@ New features
 
 * Support early stopping of optimization loop.
 * Benchmarking scripts to evaluate performance of different surrogate models.
-* Support for parallel evaluations of the objective function via several   constant liar stategies.
+* Support for parallel evaluations of the objective function via several   constant liar strategies.
 * BayesSearchCV as a drop in replacement for scikit-learn's GridSearchCV.
 * New acquisition functions "EIps" and "PIps" that takes into account function compute time.
 


### PR DESCRIPTION
There is a small typo in doc/whats_new/v0.4.rst.

Should read `strategies` rather than `stategies`.


Semi-automated pull request generated by
https://github.com/timgates42/meticulous/blob/master/docs/NOTE.md