### PR TITLE
[MRG] Update sklearn-gridsearchcv-replacement.py with missing param

### DIFF
--- a/examples/sklearn-gridsearchcv-replacement.py
+++ b/examples/sklearn-gridsearchcv-replacement.py
@@ -103,7 +103,7 @@ pipe = Pipeline([
 # But that's fine, this is just an example.
 linsvc_search = {
     'model': [LinearSVC(max_iter=1000)],
-    'model__C': (1e-6, 1e+6, 'log-uniform'),
+    'model__C': Real(1e-6, 1e+6, 'log-uniform'),
 }
 
 # explicit dimension classes can be specified like this


### PR DESCRIPTION
Updates an example which seems like it may be a typo. I think the example at sklearn-gridsearchcv-replacement.py may have a typo in the LinearSVC block. This should fix that example by using the Real value sampler since that's what is implied by the rest of the example.

---

The example of using BayesSearchCV seems like it's missing a function call within the LinearSVC section. As-is, it just seems like it's a tuple argument when the SVC example implies that it should be a Real variable sampling function.