### PR TITLE
GPR with noise fix

### DIFF
--- a/skopt/learning/gaussian_process/gpr.py
+++ b/skopt/learning/gaussian_process/gpr.py
@@ -186,12 +186,13 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
         if self.kernel is None:
             self.kernel = ConstantKernel(1.0, constant_value_bounds="fixed") \
                           * RBF(1.0, length_scale_bounds="fixed")
-        if self.noise == "gaussian":
-            self.kernel = self.kernel + WhiteKernel()
-        elif self.noise:
-            self.kernel = self.kernel + WhiteKernel(
-                noise_level=self.noise, noise_level_bounds="fixed"
-            )
+        if self.noise and not _param_for_white_kernel_in_Sum(self.kernel)[0]:
+            if self.noise == "gaussian":
+                self.kernel = self.kernel + WhiteKernel()
+            else:
+                self.kernel = self.kernel + WhiteKernel(
+                    noise_level=self.noise, noise_level_bounds="fixed"
+                )
         super(GaussianProcessRegressor, self).fit(X, y)
 
         self.noise_ = None


### PR DESCRIPTION
## Bug description
Calling multiple times .fit(X, y) whenever self.noise exists causes self.kernel to add new WhiteKernel noise on every call, inefficiently adding kernels if the base kernel is not None.

## Steps to reproduce
```python
from skopt.learning.gaussian_process import gpr, kernels  #gpr is the package with the bug
import numpy as np
np.random.seed(0) # for reproduction

gp = gpr.GaussianProcessRegressor(kernel=kernels.RBF(), alpha=1e-7, noise=0.01)
train_inputs = np.array([0, 0.1, 0.2]).reshape(-1, 1)
train_targets = np.array([1, 1.5, 0.6])
for i in range(10):
    gp.fit(train_inputs, train_targets)
    test_inputs = np.arange(0, 0.25, 0.05).reshape(-1, 1)
    gp.predict(test_inputs)
    print(str(gp.get_params()['kernel__k1']).count("WhiteKernel")) # number of WhiteKernels in self.kernel increases with each .fit
    train_inputs = np.vstack([train_inputs, np.random.rand()])
    train_targets = np.append(train_targets, np.random.rand())
```

## Fix

If, however, we check if a WhiteKernel is present before adding a new one on the .fit function, only one WhiteKernel is added after many .fit() calls
```python
        if self.noise and not _param_for_white_kernel_in_Sum(self.kernel)[0]:
            if self.noise == "gaussian":
                self.kernel = self.kernel + WhiteKernel()
            else:
                self.kernel = self.kernel + WhiteKernel(
                    noise_level=self.noise, noise_level_bounds="fixed"
                )
```