### PR TITLE
Fix numpy Deprecation errors

### DIFF
--- a/skopt/learning/gaussian_process/kernels.py
+++ b/skopt/learning/gaussian_process/kernels.py
@@ -316,7 +316,7 @@ class DotProduct(Kernel, sk_DotProduct):
 
 class HammingKernel(sk_StationaryKernelMixin, sk_NormalizedKernelMixin,
                     Kernel):
-    """
+    r"""
     The HammingKernel is used to handle categorical inputs.
 
     ``K(x_1, x_2) = exp(\sum_{j=1}^{d} -ls_j * (I(x_1j != x_2j)))``

--- a/skopt/learning/gaussian_process/kernels.py
+++ b/skopt/learning/gaussian_process/kernels.py
@@ -378,7 +378,7 @@ class HammingKernel(sk_StationaryKernelMixin, sk_NormalizedKernelMixin,
 
         if np.iterable(length_scale):
             if len(length_scale) > 1:
-                length_scale = np.asarray(length_scale, dtype=np.float)
+                length_scale = np.asarray(length_scale, dtype=float)
             else:
                 length_scale = float(length_scale[0])
         else:

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -244,13 +244,13 @@ class Real(Dimension):
     name : str or None
         Name associated with the dimension, e.g., "learning rate".
 
-    dtype : str or dtype, default=np.float
+    dtype : str or dtype, default=np.float64
         float type which will be used in inverse_transform,
         can be float.
 
     """
     def __init__(self, low, high, prior="uniform", base=10, transform=None,
-                 name=None, dtype=np.float):
+                 name=None, dtype=float):
         if high <= low:
             raise ValueError("the lower bound {} has to be less than the"
                              " upper bound {}".format(low, high))
@@ -273,8 +273,8 @@ class Real(Dimension):
                              "or 'float64'"
                              " got {}".format(self.dtype))
         elif isinstance(self.dtype, type) and self.dtype\
-                not in [float, np.float, np.float16, np.float32, np.float64]:
-            raise ValueError("dtype must be float, np.float"
+                not in [float, np.float16, np.float32, np.float64]:
+            raise ValueError("dtype must be float, np.float64"
                              " got {}".format(self.dtype))
 
         if transform is None:

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -244,7 +244,7 @@ class Real(Dimension):
     name : str or None
         Name associated with the dimension, e.g., "learning rate".
 
-    dtype : str or dtype, default=np.float64
+    dtype : str or dtype, default=float
         float type which will be used in inverse_transform,
         can be float.
 
@@ -272,8 +272,8 @@ class Real(Dimension):
             raise ValueError("dtype must be 'float', 'float16', 'float32'"
                              "or 'float64'"
                              " got {}".format(self.dtype))
-        elif isinstance(self.dtype, type) and self.dtype\
-                not in [float, np.float16, np.float32, np.float64]:
+        elif isinstance(self.dtype, type) and \
+                np.issubdtype(self.dtype, np.floating):
             raise ValueError("dtype must be float, np.float64"
                              " got {}".format(self.dtype))
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -274,7 +274,7 @@ class Real(Dimension):
                              " got {}".format(self.dtype))
         elif isinstance(self.dtype, type) and \
                 not np.issubdtype(self.dtype, np.floating):
-            raise ValueError("dtype must be a np.floating subtype"
+            raise ValueError("dtype must be a np.floating subtype;"
                              " got {}".format(self.dtype))
 
         if transform is None:

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -273,7 +273,7 @@ class Real(Dimension):
                              "or 'float64'"
                              " got {}".format(self.dtype))
         elif isinstance(self.dtype, type) and \
-                np.issubdtype(self.dtype, np.floating):
+                np.issubdtype(type(self.dtype), np.floating):
             raise ValueError("dtype must be float, np.float64"
                              " got {}".format(self.dtype))
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -273,8 +273,8 @@ class Real(Dimension):
                              "or 'float64'"
                              " got {}".format(self.dtype))
         elif isinstance(self.dtype, type) and \
-                np.issubdtype(type(self.dtype), np.floating):
-            raise ValueError("dtype must be float, np.float64"
+                not np.issubdtype(self.dtype, np.floating):
+            raise ValueError("dtype must be a np.floating subtype"
                              " got {}".format(self.dtype))
 
         if transform is None:

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -89,10 +89,10 @@ class LogN(Transformer):
         self._base = base
 
     def transform(self, X):
-        return np.log10(np.asarray(X, dtype=np.float)) / np.log10(self._base)
+        return np.log10(np.asarray(X, dtype=float)) / np.log10(self._base)
 
     def inverse_transform(self, Xt):
-        return self._base ** np.asarray(Xt, dtype=np.float)
+        return self._base ** np.asarray(Xt, dtype=float)
 
 
 class CategoricalEncoder(Transformer):


### PR DESCRIPTION
This will fix some numpy depreciation errors that appear due to the usage of float.

```
  `np.float` is a deprecated alias for the builtin `float`. To silence this warning, use `float` by itself. Doing this will not modify any behavior and is safe. If you specifically wanted the numpy scalar type, use `np.float64` here.
  Deprecated in NumPy 1.20; for more details and guidance: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations
```

It's also fixing `skopt/learning/gaussian_process/kernels.py:319: DeprecationWarning: invalid escape sequence \s` - although i'm not 100% certain how this fix will come out at the docs.
Unfortunately, i'm uncertain how to build / verify this - as it doesn't seem to be documented.


I'm hoping that CI passes, as i found no way to get `skopt/tests/test_gp_opt.py` to pass all tests (not with master, not with the modifications ...).
