### PR TITLE
Use deepcopy to prevent reference cycles in Optimizer

### DIFF
--- a/skopt/optimizer/base.py
+++ b/skopt/optimizer/base.py
@@ -209,8 +209,8 @@ def base_minimize(func, dimensions, base_estimator,
         For more details related to the OptimizeResult object, refer
         http://docs.scipy.org/doc/scipy/reference/generated/scipy.optimize.OptimizeResult.html
     """
-    specs = {"args": copy.copy(inspect.currentframe().f_locals),
-             "function": inspect.currentframe().f_code.co_name}
+    specs = {"args": copy.deepcopy(locals()),
+             "function": copy.deepcopy(inspect.currentframe().f_code.co_name)}
 
     acq_optimizer_kwargs = {
         "n_points": n_points, "n_restarts_optimizer": n_restarts_optimizer,

--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -3,7 +3,6 @@ import warnings
 from math import log
 from numbers import Number
 import copy
-import inspect
 import numpy as np
 
 from scipy.optimize import fmin_l_bfgs_b
@@ -171,7 +170,7 @@ class Optimizer(object):
                  model_queue_size=None,
                  acq_func_kwargs=None,
                  acq_optimizer_kwargs=None):
-        self.specs = {"args": copy.copy(inspect.currentframe().f_locals),
+        self.specs = {"args": copy.deepcopy(locals()),
                       "function": "Optimizer"}
         self.rng = check_random_state(random_state)
 


### PR DESCRIPTION
Fixes #1028 

@kernc I followed your suggestion to use `locals` but still need a deepcopy or else the reference cycle will still be present. 

