### PR TITLE
Re-add `BayesSearchCV.best_score_` needed by some examples

### DIFF
--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -360,6 +360,12 @@ class BayesSearchCV(BaseSearchCV):
                 "Search space should be provided as a dict or list of dict,"
                 "got %s" % search_space)
 
+    # copied for compatibility with 0.19 sklearn from 0.18 BaseSearchCV
+    @property
+    def best_score_(self):
+        check_is_fitted(self, 'cv_results_')
+        return self.cv_results_['mean_test_score'][self.best_index_]
+
     @property
     def optimizer_results_(self):
         check_is_fitted(self, '_optim_results')


### PR DESCRIPTION
Re-add `BayesSearchCV.best_score_`, needed by _examples/sklearn-gridsearchcv-replacement.py_.

Removed in 9461bfecc12c8cab7ae18a55e44e1d258b3c09c9 (#988), which [broke CircleCI docs build](https://app.circleci.com/pipelines/github/scikit-optimize/scikit-optimize/515/workflows/73a6b7c7-d299-4940-9020-63d6587b7b17/jobs/2840), which for some reason wasn't caught in PR CI.