### PR TITLE
Revert "Re-add `BayesSearchCV.best_score_` needed by some examples"

### DIFF
--- a/examples/sklearn-gridsearchcv-replacement.py
+++ b/examples/sklearn-gridsearchcv-replacement.py
@@ -174,7 +174,7 @@ searchcv = BayesSearchCV(
 
 # callback handler
 def on_step(optim_result):
-    score = searchcv.best_score_
+    score = -optim_result['fun']
     print("best score: %s" % score)
     if score >= 0.98:
         print('Interrupting!')

--- a/skopt/searchcv.py
+++ b/skopt/searchcv.py
@@ -360,12 +360,6 @@ class BayesSearchCV(BaseSearchCV):
                 "Search space should be provided as a dict or list of dict,"
                 "got %s" % search_space)
 
-    # copied for compatibility with 0.19 sklearn from 0.18 BaseSearchCV
-    @property
-    def best_score_(self):
-        check_is_fitted(self, 'cv_results_')
-        return self.cv_results_['mean_test_score'][self.best_index_]
-
     @property
     def optimizer_results_(self):
         check_is_fitted(self, '_optim_results')


### PR DESCRIPTION
This reverts commit c53998816481d150ccc745ffd07d022fdb1fd25d (https://github.com/scikit-optimize/scikit-optimize/pull/1031).

Instead, the fix is not to rely on `BayesSearchCV.best_score_`
in callbacks (i.e. until `BaseSearchCV.fit` computes it).

@glouppe I think this is the simpler fix. :crossed_fingers: 