### PR TITLE
[MRG] add setter for dimension_names in Space

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -798,6 +798,21 @@ class Space(object):
             index += 1
         return names
 
+    @dimension_names.setter
+    def dimension_names(self, names):
+        """Sets the names of all dimension objects via list of names.
+
+        Parameters
+        ----------
+        names : list of str
+            List of names. Must be the same length as self.dimensions.
+        """
+        if len(names) != len(self.dimensions):
+            raise ValueError("`names` must be the same length as "
+                             "`self.dimensions`.")
+        for dim, name in zip(self.dimensions, names):
+            dim.name = name
+
     @property
     def is_real(self):
         """

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -705,6 +705,19 @@ def test_dimension_name():
     assert s[0, 2] == [(0, s.dimensions[0]), (2, s.dimensions[2])]
 
 
+@pytest.mark.fast_test
+def test_dimension_names_setter():
+    s = Space([Real(1, 2, name="a"),
+               Integer(1, 100, name="b"),
+               Categorical(["red, blue"], name="c")])
+    with pytest.raises(ValueError) as exc:
+        s.dimension_names = ["d", "e"]
+        assert("`names` must be the same length as "
+               "`self.dimensions`." == exc.value.args[0])
+    s.dimension_names = ["d", "e", "f"]
+    assert s.dimension_names == ["d", "e", "f"]
+
+
 @pytest.mark.parametrize("dimension",
                          [Real(1, 2), Integer(1, 100), Categorical(["red, blue"])])
 def test_dimension_name_none(dimension):


### PR DESCRIPTION
This is a simple addition for convenience. It follows the setter convention for `names` that `Dimension` has.

```python
s = Space([(1, 2), (1., 100.), ["red", "blue"]])
s.dimension_names = ["a", "b", "c"]
```