### PR TITLE
[WIP] Evaluate random point instead of using point twice

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -446,8 +446,11 @@ class Optimizer(object):
             min_delta_x = min([self.space.distance(next_x, xi)
                                for xi in self.Xi])
             if abs(min_delta_x) <= 1e-8:
-                warnings.warn("The objective has been evaluated "
-                              "at this point before.")
+                next_x_new = self.space.rvs(random_state=self.rng)[0]
+                warnings.warn("The objective has been evaluated at point {} "
+                              "before, using {} instead"
+                              .format(next_x, next_x_new))
+                next_x = next_x_new
 
             # return point computed from last call to tell()
             return next_x


### PR DESCRIPTION
#302 discusses a long standing issue where the ask() function to "Query point or multiple points at which objective should be evaluated" will just repeatedly return the same point(s) to evaluate. In cases where the objective always returns the same results, the solver can even get stuck in a loop.

This PR aims to mitigate the issue. Instead of just warning the user about evaluating a point twice, use a new random point instead (and include this information in the warning).

This is not a good solution. Ideally, the next best point should be evaluated instead, but I do not know how to do that.

Also, in #302 a user said "Usually evaluating the same point multiple times isn't something you want to do, but if you have a (very) noisy objective it makes sense to do so." So the solution presented here might actually cause a problem for users who want the same point to be evaluated multiple times. Since this is up for debate, I am tagging it as [WIP], even though I think it is "complete" in the way that I am intending it to be.

Maybe this just stays here as a reference for users who want a very easy workaround that they can implement themselves.