### PR TITLE
Keep order of variables in LabelEncoder

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -172,8 +172,9 @@ class LabelEncoder(Transformer):
         else:
             i = 0
             self.mapping_ = {}
-            for v in np.unique(X):
-                self.mapping_[v] = i
+            _, indexes = np.unique(X, return_index=True)
+            for index in sorted(indexes):
+                self.mapping_[X[index]] = i
                 i += 1
         self.inverse_mapping_ = {i: v for v, i in self.mapping_.items()}
         return self


### PR DESCRIPTION
# The problem
The current behavior of the LabelEncoder is to sort the variables when the mapping is performed. This happens because of the use of `np.unique` which returns a **sorted** array of unique values: See https://github.com/Elementa-Engineering/scikit-optimize/blob/master/skopt/space/transformers.py#L175-L177 and https://numpy.org/doc/stable/reference/generated/numpy.unique.html

For example:

```python
>>> from skopt.space.space import Categorical

>>> c = Categorical(("c", "b", "a"), transform="label")
>>> c.transform(["a", "b", "c"])
[0, 1, 2]
```

Note that the returned labels are 0, 1 and 2 (equivalent to ("a", "b", "c") even if the specified order was ("c", "b", "a")). This can be counter-intuitive, especially when the order of the variable "means" something for the user.

# Implemented Fix
This PR, implements a simple fix, which retains the order of the categorical dimensions. The expected behavior then becomes:

```python
>>> from skopt.space.space import Categorical

>>> c = Categorical(("c", "b", "a"), transform="label")
>>> c.transform(["a", "b", "c"])
[2, 1, 0]
```

The order is conserved.

Same goes for numerical numbers:

```python
from skopt.space.space import Categorical

c = Categorical((10, 30, 20), transform="label")
c.transform([10, 20, 30])
[0, 2, 1]
```

