### PR TITLE
ENH: Add 'ax' argument to all plotting functions

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,32 +16,11 @@ env:
 
 matrix:
   include:
-    # Linux environment to test scikit-learn against numpy and scipy master
-    # installed from their CI wheels in a virtualenv with the Python
-    # interpreter provided by travis.
-    - name: "Python 3.6 - scikit 0.20.4"
-      python: "3.6"
-      env: DISTRIB="conda" PYTHON_VERSION="3.6"
-           NUMPY_VERSION="1.13.3" SCIPY_VERSION="0.19.1" PYAML_VERSION="16.9.0"
-           SCIKIT_LEARN_VERSION="0.20.4" MATPLOTLIB_VERSION="2.0.0" COVERAGE="false"
-           JOBLIB_VERSION="0.11"
-    - name: "Python 3.6 - scikit 0.21.3"
-      python: "3.6"
-      env: DISTRIB="conda" PYTHON_VERSION="3.6"
-           NUMPY_VERSION="1.14.0" SCIPY_VERSION="1.0.0" PYAML_VERSION="16.12.0"
-           SCIKIT_LEARN_VERSION="0.21.3" MATPLOTLIB_VERSION="2.0.0" COVERAGE="false"
-           JOBLIB_VERSION="0.11"
-    - name: "Python 3.7 - scikit 0.22.1"
+    - name: "Python 3.7  - scikit 0.24.2"
       python: "3.7"
-      env: DISTRIB="conda" PYTHON_VERSION="3.7"
-         NUMPY_VERSION="1.16.0" SCIPY_VERSION="1.2.0" PYAML_VERSION="17.8.0"
-         SCIKIT_LEARN_VERSION="0.22.1" MATPLOTLIB_VERSION="*" COVERAGE="true"
-         JOBLIB_VERSION="0.13"
-    - name: "Python 3.8  - scikit 0.23.2"
-      python: "3.8"
-      env: DISTRIB="conda" PYTHON_VERSION="3.8.1" COVERAGE="false"
+      env: DISTRIB="conda" PYTHON_VERSION="3.7" COVERAGE="false"
            NUMPY_VERSION="1.19.1" SCIPY_VERSION="1.5.2" PYAML_VERSION="20.4.0"
-           SCIKIT_LEARN_VERSION="0.23.2" JOBLIB_VERSION="0.16.0"
+           SCIKIT_LEARN_VERSION="0.24.2" JOBLIB_VERSION="0.16.0"
     - name: "Python 3.7 - sdist check"
       python: "3.7"
       env: DISTRIB="conda" PYTHON_VERSION="3.7"
@@ -64,7 +43,7 @@ deploy:
   on:
     tags: true
     repo: scikit-optimize/scikit-optimize
-    condition: "$PYTHON_VERSION = 3.6"
+    condition: "$PYTHON_VERSION = 3.7"
   skip_cleanup: true
   skip_existing: true
   password:

--- a/build_tools/circle/build_doc.sh
+++ b/build_tools/circle/build_doc.sh
@@ -188,8 +188,15 @@ then
     python build_tools/circle/list_versions.py > doc/versions.rst
 fi
 
+# Install this noise maker on CircleCI to prevent
+# "Too long with no output (exceeded 10m0s): context deadline exceeded"
+while true; do sleep $((60 * 5)); echo -e '\nStill working ...\n'; done &
+noise_maker=$!
+
 # The pipefail is requested to propagate exit code
 set -o pipefail && cd doc && make $make_args 2>&1 | tee ~/log.txt
+
+kill $noise_maker
 
 # Insert the version warning for deployment
 find _build/html/stable -name "*.html" | xargs sed -i '/<\/body>/ i \

--- a/doc/whats_new/v0.9.rst
+++ b/doc/whats_new/v0.9.rst
@@ -6,17 +6,23 @@
 
 Version 0.9.0
 =============
-**In Development**
+**October 2021**
 
-:mod:`skopt.searchcv`
----------------------
+- |Fix| :obj:`skopt.learning.gaussian_process.gpr.GaussianProcessRegressor`
+  for sklearn >= 0.23. :pr:`943`
+- Change `skip=` parameter in :obj:`skopt.sampler.sobol.Sobol`
+  initial point generator. :pr:`955`
+- |Feature| :obj:`skopt.callbacks.HollowIterationsStopper` callback. :pr:`917`
+- |Feature| :obj:`skopt.callbacks.ThresholdStopper` callback. :pr:`1000`
 - |Fix| Fix :obj:`skopt.searchcv.BayesSearchCV` for scikit-learn >= 0.24.
   :pr:`988`
 - |API| Deprecate :class:`skopt.searchcv.BayesSearchCV` parameter `iid=`.
-    :pr:`988`
-
-:mod:`skopt.learning.gaussian_process.gpr`
-------------------------------------------
-- |Fix| Fix :class:`skopt.learning.gaussian_process.gpr.GaussianProcessRegressor`
-  for scikit-learn >= 1.0
-  :pr:`1063`
+  :pr:`988`
+- |Fix| NumPy deprecation errors. :pr:`1023`
+- |Fix| issue with :class:`skopt.optimizer.optimizer.Optimizer` not being
+  garbage-collectable. :pr:`1029`
+- |Fix| version check in
+  :class:`skopt.learning.gaussian_process.gpr.GaussianProcessRegressor`
+  for scikit-learn >= 1.0. :pr:`1063`
+- Minor documentation improvements.
+- Various small bugs and fixes.

--- a/skopt/__init__.py
+++ b/skopt/__init__.py
@@ -29,7 +29,7 @@ except NameError:
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "0.9rc1"
+__version__ = "0.9.0"
 
 if __SKOPT_SETUP__:
     import sys

--- a/skopt/__init__.py
+++ b/skopt/__init__.py
@@ -29,7 +29,7 @@ except NameError:
 # Dev branch marker is: 'X.Y.dev' or 'X.Y.devN' where N is an integer.
 # 'X.Y.dev0' is the canonical version of 'X.Y.dev'
 #
-__version__ = "0.9.dev0"
+__version__ = "0.9rc1"
 
 if __SKOPT_SETUP__:
     import sys

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -39,10 +39,10 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
           plot as well as the average convergence trace
         - if a tuple, the label names the trace(s) and the behavior is as
           specified above.
-    
+
     true_minimum : float, optional
         The true minimum value of the function, if known.
-    
+
     yscale : None or string, optional
         The scale for the y-axis.
 
@@ -84,11 +84,11 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
                     marker=".", markersize=12, lw=2, label=name)
 
         elif (isinstance(arg, Iterable)
-                  and all(isinstance(elem, OptimizeResult) for elem in arg)):
+              and all(isinstance(elem, OptimizeResult) for elem in arg)):
             mins = [[np.min(opt_res.func_vals[:i+1])
-                        for i in range(len(opt_res.x_iters))]
+                     for i in range(len(opt_res.x_iters))]
                     for opt_res in arg]
-            
+
             # graciously handle "ragged" array, i.e. differing length arrays
             max_n_calls = max(len(m) for m in mins)
             mean_arr = np.empty((len(mins), max_n_calls))
@@ -97,14 +97,14 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
             for i, m in enumerate(mins):
                 ax.plot(range(1, 1 + len(m)), m, c=color, alpha=0.2)
                 mean_arr[i, :len(m)] = m
-            
+
             if np.isnan(mean_arr).any():
                 warnings.warn("Inconsistent number of function calls in "
                               f"argument at pos {index}")
 
-            ax.plot(range(1, 1 + max_n_calls), np.nanmean(mins, axis=0), c=color,
-                    marker=".", markersize=12, lw=2, label=name)
-        
+            ax.plot(range(1, 1 + max_n_calls), np.nanmean(mins, axis=0),
+                    c=color, marker=".", markersize=12, lw=2, label=name)
+
         else:
             raise ValueError("Cannot plot convergence trace for "
                              f"{arg.__class__.__name__} object {arg}")
@@ -468,7 +468,8 @@ def _format_scatter_plot_axes(ax, space, ylabel, plot_dims,
     return ax
 
 
-def _make_subgrid(ax, n_rows, n_cols=None, fig_kwargs_=None, **gridspec_kwargs):
+def _make_subgrid(ax, n_rows, n_cols=None, fig_kwargs_=None,
+                  **gridspec_kwargs):
     """
     Makes a subgrid inside an existing axis object
     """
@@ -481,7 +482,7 @@ def _make_subgrid(ax, n_rows, n_cols=None, fig_kwargs_=None, **gridspec_kwargs):
         fig = ax.get_figure()
 
     grid_spec = gridspec.GridSpecFromSubplotSpec(n_rows, n_cols,
-                                                 subplot_spec=ax.get_subplotspec(),
+                                                 subplot_spec=ax.get_subplotspec(), # noqa
                                                  **gridspec_kwargs)
     axes = np.empty((n_rows, n_cols), dtype=object)
     for i in range(n_rows):
@@ -706,7 +707,7 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
     cmap: str or Colormap, default = 'viridis_r'
         Color map for contour plots. Passed directly to
         `plt.contourf()`
-    
+
     ax: `Matplotlib.Axes`, default= None
         An axis object in which to plot the dependence plot.
 
@@ -714,7 +715,6 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
     -------
     ax : `Matplotlib.Axes`
         The axes object the plot was drawn in
-
     """
     # Here we define the values for which to plot the red dot (2d plot) and
     # the red dotted line (1d plot).
@@ -753,13 +753,14 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
     else:
         raise ValueError("Valid values for zscale are 'linear' and 'log',"
                          " not '%s'." % zscale)
-    
+
     fig_kwargs = dict(figsize=(size * n_dims, size * n_dims))
-    ax, axes = _make_subgrid(ax, n_dims, fig_kwargs_=fig_kwargs, wspace=0.1, hspace=0.1)
+    ax, axes = _make_subgrid(ax, n_dims, fig_kwargs_=fig_kwargs,
+                             wspace=0.1, hspace=0.1)
 
     for i in range(n_dims):
         for j in range(n_dims):
-            
+
             if i == j:
                 index, _ = plot_dims[i]
                 xi, yi = partial_dependence_1D(space, result.models[-1],
@@ -774,7 +775,6 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
             elif i > j:
                 index1, _ = plot_dims[i]
                 index2, _ = plot_dims[j]
-                #ax_ = ax[i, j]
                 xi, yi, zi = partial_dependence_2D(space, result.models[-1],
                                                    index1, index2,
                                                    samples, n_points)
@@ -828,14 +828,14 @@ def plot_evaluations(result, bins=20, dimensions=None,
         search-space dimensions to be included in the plot.
         If `None` then use all dimensions except constant ones
         from the search-space.
-    
+
     size : float, default=2
         Height (in inches) of each facet.
 
     cmap: str or Colormap, default = 'viridis'
         Color map for scatter plots. Passed directly to
         `plt.scatter()`
-    
+
     ax: `Matplotlib.Axes`, default= None
         An axis object in which to plot the dependence plot.
 
@@ -843,7 +843,6 @@ def plot_evaluations(result, bins=20, dimensions=None,
     -------
     ax : `Matplotlib.Axes`
         Matplotlib axis the plto was drawn in
-
     """
     space = result.space
     # Convert categoricals to integers, so we can ensure consistent ordering.
@@ -868,7 +867,8 @@ def plot_evaluations(result, bins=20, dimensions=None,
         assert len(dimensions) == n_dims
 
     fig_kwargs = dict(figsize=(size * n_dims, size * n_dims))
-    ax, axes = _make_subgrid(ax, n_dims, fig_kwargs_=fig_kwargs, wspace=0.1, hspace=0.1)
+    ax, axes = _make_subgrid(ax, n_dims, fig_kwargs_=fig_kwargs,
+                             wspace=0.1, hspace=0.1)
 
     for i in range(n_dims):
         for j in range(n_dims):

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -34,7 +34,7 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
         of a label and a `OptimizeResult` or an iterable of `OptimizeResult`.
         The result(s) for which to plot the convergence trace.
 
-        - if an `OptimizeResult`, draw the correcponding single trace
+        - if an `OptimizeResult`, draw the corresponding single trace
         - if an iterable of `OptimizeResult`, draw all traces in the same
           plot as well as the average convergence trace
         - if a tuple, the label names the trace(s) and the behavior is as
@@ -120,7 +120,11 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
     return ax
 
 
-def plot_gaussian_process(res, **kwargs):
+def plot_gaussian_process(res, ax=None, n_calls=-1, objective=None,
+                          n_points=1000, noise_level=0, show_legend=True,
+                          show_title=True, show_acq_func=False,
+                          show_next_point=False, show_observations=True,
+                          show_mu=True):
     """Plots the optimization results and the gaussian process
     for 1-D objective functions.
 
@@ -169,17 +173,6 @@ def plot_gaussian_process(res, **kwargs):
     ax : `Axes`
         The matplotlib axes.
     """
-    ax = kwargs.get("ax", None)
-    n_calls = kwargs.get("n_calls", -1)
-    objective = kwargs.get("objective", None)
-    noise_level = kwargs.get("noise_level", 0)
-    show_legend = kwargs.get("show_legend", True)
-    show_title = kwargs.get("show_title", True)
-    show_acq_func = kwargs.get("show_acq_func", False)
-    show_next_point = kwargs.get("show_next_point", False)
-    show_observations = kwargs.get("show_observations", True)
-    show_mu = kwargs.get("show_mu", True)
-    n_points = kwargs.get("n_points", 1000)
 
     if ax is None:
         ax = plt.gca()
@@ -281,7 +274,7 @@ def plot_gaussian_process(res, **kwargs):
     return ax
 
 
-def plot_regret(*args, **kwargs):
+def plot_regret(*args, ax=None, true_minimum=None, yscale=None):
     """Plot one or several cumulative regret traces.
 
     Parameters
@@ -311,10 +304,6 @@ def plot_regret(*args, **kwargs):
     ax : `Axes`
         The matplotlib axes.
     """
-    # <3 legacy python
-    ax = kwargs.get("ax", None)
-    true_minimum = kwargs.get("true_minimum", None)
-    yscale = kwargs.get("yscale", None)
 
     if ax is None:
         ax = plt.gca()
@@ -643,7 +632,7 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
         at each of the `n_points` when `sample_method` is set to 'random'.
 
     size : float, default=2
-        Height (in inches) of each facet.
+        Height (in inches) of each facet. Ignored if ``ax`` is provided.
 
     zscale : str, default='linear'
         Scale to use for the z axis of the contour plots. Either 'linear'
@@ -709,7 +698,9 @@ def plot_objective(result, levels=10, n_points=40, n_samples=250, size=2,
         `plt.contourf()`
 
     ax: `Matplotlib.Axes`, default= None
-        An axis object in which to plot the dependence plot.
+        An axis object in which to plot the dependence plot. If provided,
+        ``size`` is ignored and the caller is responsible for the size of the
+        plot.
 
     Returns
     -------

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -482,7 +482,7 @@ def _make_subgrid(ax, n_rows, n_cols=None, fig_kwargs_=None,
         fig = ax.get_figure()
 
     grid_spec = gridspec.GridSpecFromSubplotSpec(n_rows, n_cols,
-                                                 subplot_spec=ax.get_subplotspec(), # noqa
+                                                 subplot_spec=ax.get_subplotspec(),  # noqa
                                                  **gridspec_kwargs)
     axes = np.empty((n_rows, n_cols), dtype=object)
     for i in range(n_rows):

--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -71,9 +71,9 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
 
     for index, (arg, color) in enumerate(zip(args, colors)):
         if isinstance(arg, tuple):
-            name, opt_res = arg
+            label, arg = arg
         else:
-            name = None
+            label = None
 
         if isinstance(arg, OptimizeResult):
             opt_res = arg
@@ -81,7 +81,7 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
             mins = [np.min(opt_res.func_vals[:i+1])
                     for i in range(n_calls)]
             ax.plot(range(1, n_calls + 1), mins, c=color,
-                    marker=".", markersize=12, lw=2, label=name)
+                    marker=".", markersize=12, lw=2, label=label)
 
         elif (isinstance(arg, Iterable)
               and all(isinstance(elem, OptimizeResult) for elem in arg)):
@@ -103,7 +103,7 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
                               f"argument at pos {index}")
 
             ax.plot(range(1, 1 + max_n_calls), np.nanmean(mins, axis=0),
-                    c=color, marker=".", markersize=12, lw=2, label=name)
+                    c=color, marker=".", markersize=12, lw=2, label=label)
 
         else:
             raise ValueError("Cannot plot convergence trace for "
@@ -114,7 +114,7 @@ def plot_convergence(*args, true_minimum=None, yscale=None, ax=None):
                    color="r", lw=1,
                    label="True minimum")
 
-    if true_minimum or name:
+    if true_minimum or label:
         ax.legend(loc="best")
 
     return ax


### PR DESCRIPTION
This PR adds an 'ax' argument to all plotting functions in `skopt.plots`, using `GridSpec` objects. The return value of the function is also standardized to the `matplotlib.Axes` object the plot was drawn into, even when a subgrid is made.

- Fixes #1070 