### PR TITLE
[MRG] Fix dimension mismatch with gp_minimize in Matern kernel when nu=0.5

### DIFF
--- a/skopt/learning/gaussian_process/kernels.py
+++ b/skopt/learning/gaussian_process/kernels.py
@@ -92,7 +92,7 @@ class RBF(Kernel, sk_RBF):
 
 class Matern(Kernel, sk_Matern):
     def gradient_x(self, x, X_train):
-        x = np.asarray(x)
+        x = np.asarray(x).reshape((-1,))
         X_train = np.asarray(X_train)
         length_scale = np.asarray(self.length_scale)
 


### PR DESCRIPTION
When running `gp_minimize` on a GP using a Matern kernel with `nu=0.5`, there is a shape mismatch with `x`: expects `(n,)` but `gp_minimize` passes `(1, n)`. This is a problem when applying the mask on line 127.