### PR TITLE
[MRG] Test DeltaYStopper with minimize functions fixes #357

### DIFF
--- a/skopt/tests/test_common.py
+++ b/skopt/tests/test_common.py
@@ -21,7 +21,7 @@ from skopt.benchmarks import branin
 from skopt.benchmarks import bench1
 from skopt.benchmarks import bench4
 from skopt.benchmarks import bench5
-from skopt.callbacks import DeltaXStopper
+from skopt.callbacks import DeltaXStopper, DeltaYStopper
 from skopt.space import Space
 
 
@@ -422,6 +422,33 @@ def test_early_stopping_delta_x_empty_result_object(minimizer):
                     n_calls=n_calls,
                     n_initial_points=2, random_state=1)
     assert len(res.x_iters) < n_calls
+
+
+@pytest.mark.fast_test
+@pytest.mark.parametrize("minimizer",
+                         [gp_minimize, forest_minimize, gbrt_minimize])
+def test_early_stopping_delta_y(minimizer):
+    n_calls = 5
+    res = minimizer(lambda x: x[0] / 4,
+                    callback=DeltaYStopper(0.6, 2),
+                    dimensions=[(-1., 1.)],
+                    n_calls=n_calls,
+                    n_initial_points=1, random_state=1)
+    assert len(res.x_iters) == 2
+
+
+@pytest.mark.fast_test
+@pytest.mark.parametrize("minimizer",
+                         [gp_minimize, forest_minimize, gbrt_minimize])
+def test_early_stopping_delta_y_with_x0(minimizer):
+    n_calls = 5
+    res = minimizer(lambda x: x[0] / 4,
+                    callback=DeltaYStopper(0.6, 2),
+                    dimensions=[(-1., 1.)],
+                    x0=[[-0.5], [0.5]],
+                    n_calls=n_calls,
+                    n_initial_points=0, random_state=1)
+    assert len(res.x_iters) == 2
 
 
 @pytest.mark.parametrize("acq_func", ACQ_FUNCS_PS)


### PR DESCRIPTION
Two tests for DeltaYStopper with the *_minimize functions added to test_common.py.

Tests use an objective that always returns values within an interval less than `delta` and asserts the expected number of iterations.