### PR TITLE
[MRG] Deprecationwarning Numpy 1.20

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(int)
         return X_orig
 
 


### PR DESCRIPTION
DeprecationWarning: `np.int` is a deprecated alias for the builtin `int` . Deprecated in Numpy 1.20