### PR TITLE
[ENH] Better use proper parsing of the scikit-learn version numbers.

### DIFF
--- a/skopt/learning/gaussian_process/gpr.py
+++ b/skopt/learning/gaussian_process/gpr.py
@@ -228,7 +228,8 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
         # Fix deprecation warning #462
         sklearn_version = packaging.version.Version(sklearn.__version__)
         if sklearn_version.major == 1 \
-                or (sklearn_version.major == 0 and sklearn_version.minor >= 23):
+                or (sklearn_version.major == 0
+                    and sklearn_version.minor >= 23):
             self.y_train_std_ = self._y_train_std
             self.y_train_mean_ = self._y_train_mean
         elif sklearn_version.major == 0 and sklearn_version.minor >= 19:

--- a/skopt/learning/gaussian_process/gpr.py
+++ b/skopt/learning/gaussian_process/gpr.py
@@ -1,6 +1,8 @@
 import numpy as np
 import warnings
 
+import packaging.version
+
 from scipy.linalg import cho_solve
 from scipy.linalg import solve_triangular
 
@@ -224,10 +226,12 @@ class GaussianProcessRegressor(sk_GaussianProcessRegressor):
         self.K_inv_ = L_inv.dot(L_inv.T)
 
         # Fix deprecation warning #462
-        if sklearn.__version__ >= "0.23":
+        sklearn_version = packaging.version.Version(sklearn.__version__)
+        if sklearn_version.major == 1 \
+                or (sklearn_version.major == 0 and sklearn_version.minor >= 23):
             self.y_train_std_ = self._y_train_std
             self.y_train_mean_ = self._y_train_mean
-        elif sklearn.__version__ >= "0.19":
+        elif sklearn_version.major == 0 and sklearn_version.minor >= 19:
             self.y_train_mean_ = self._y_train_mean
             self.y_train_std_ = 1
         else:


### PR DESCRIPTION
Better tools for compatibility with scikit-learn. The current `GaussianProcessRegressor` uses string comparisons to figure out the version of scikit-learn, and acts on that. It is better to use a proper version string parser, and this pull request uses the `packaging.version` module for that. This is a third-party module, but it is used by `setuptools`, so should be ubiquitous.

Features of PR:
 * Another fix for Issue #1061
 * General and simple solution, that doesn't involve manual string parsing.

Missing:
 * I have not run any tests. If this PR is appreciated, perhaps someone can do that?
 * Is it ok to depend on `packaging`?