### PR TITLE
[MRG] Make Real and Integer raise error when prior is log-uniform and bounds contain zero

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -257,7 +257,7 @@ class Real(Dimension):
         if prior not in ["uniform", "log-uniform"]:
             raise ValueError("prior should be 'uniform' or 'log-uniform'"
                              " got {}".format(prior))
-        if prior == 'log-uniform' and low * high <=0:
+        if prior == 'log-uniform' and low * high <= 0:
             raise ValueError("search space should not contain 0 when"
                              " using log-uniform prior")
 
@@ -446,7 +446,7 @@ class Integer(Dimension):
         if prior not in ["uniform", "log-uniform"]:
             raise ValueError("prior should be 'uniform' or 'log-uniform'"
                              " got {}".format(prior))
-        if prior == 'log-uniform' and low * high <=0:
+        if prior == 'log-uniform' and low * high <= 0:
             raise ValueError("search space should not contain 0"
                              " when using log-uniform prior")
 

--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -257,6 +257,10 @@ class Real(Dimension):
         if prior not in ["uniform", "log-uniform"]:
             raise ValueError("prior should be 'uniform' or 'log-uniform'"
                              " got {}".format(prior))
+        if prior == 'log-uniform' and low * high <=0:
+            raise ValueError("search space should not contain 0 when"
+                             " using log-uniform prior")
+
         self.low = low
         self.high = high
         self.prior = prior
@@ -442,6 +446,10 @@ class Integer(Dimension):
         if prior not in ["uniform", "log-uniform"]:
             raise ValueError("prior should be 'uniform' or 'log-uniform'"
                              " got {}".format(prior))
+        if prior == 'log-uniform' and low * high <=0:
+            raise ValueError("search space should not contain 0"
+                             " when using log-uniform prior")
+
         self.low = low
         self.high = high
         self.prior = prior

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -795,6 +795,7 @@ def test_normalize_bounds():
         y = space.transform(x)
         check_limits(y, 0., 1.)
 
+
 @pytest.mark.parametrize("dimension, bounds", [
     (Real, (-1, 1)), (Integer, (-1, 1)),
     (Real, (0, 1)), (Integer, (0, 1)),
@@ -804,6 +805,8 @@ def test_dimension_loguniform_prior(dimension, bounds):
     # Raise error when Integer and Real dimensions
     # contain 0 but are instantiated with log-uniform prior
     lower, upper = bounds
-    assert_raises_regex(ValueError,
-                        "search space should not contain 0 when using log-uniform prior",
-                        dimension, lower, upper, prior = 'log-uniform')
+    assert_raises_regex(
+        ValueError,
+        "search space should not contain 0 when using log-uniform prior",
+        dimension, lower, upper, prior='log-uniform'
+    )

--- a/skopt/tests/test_space.py
+++ b/skopt/tests/test_space.py
@@ -794,3 +794,16 @@ def test_normalize_bounds():
         check_limits(x[0][0], -999, 189000)
         y = space.transform(x)
         check_limits(y, 0., 1.)
+
+@pytest.mark.parametrize("dimension, bounds", [
+    (Real, (-1, 1)), (Integer, (-1, 1)),
+    (Real, (0, 1)), (Integer, (0, 1)),
+    (Real, (-1, 0)), (Integer, (-1, 0))
+])
+def test_dimension_loguniform_prior(dimension, bounds):
+    # Raise error when Integer and Real dimensions
+    # contain 0 but are instantiated with log-uniform prior
+    lower, upper = bounds
+    assert_raises_regex(ValueError,
+                        "search space should not contain 0 when using log-uniform prior",
+                        dimension, lower, upper, prior = 'log-uniform')


### PR DESCRIPTION
This PR makes Real and Integer dimensions raise ValueError if their lower and upper bounds contains 0 while prior is log-uniform.  I also add a test for this newly added behavior, accordingly.

There has been discussion about this before in #301