### PR TITLE
[MRG] Fix plot_gaussian_process not working with ps-acquisition

### DIFF
--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -212,7 +212,14 @@ def plot_gaussian_process(res, **kwargs):
 
     # Plot GP(x) + contours
     if show_mu:
-        y_pred, sigma = model.predict(x_model, return_std=True)
+
+        per_second = acq_func.endswith("ps")
+        if per_second:
+            y_pred, sigma = model.estimators_[0].predict(
+                x_model, return_std=True)
+        else:
+            y_pred, sigma = model.predict(x_model, return_std=True)
+
         ax.plot(x, y_pred, "g--", label=r"$\mu_{GP}(x)$")
         ax.fill(np.concatenate([x, x[::-1]]),
                 np.concatenate([y_pred - 1.9600 * sigma,

--- a/skopt/tests/test_plots.py
+++ b/skopt/tests/test_plots.py
@@ -179,7 +179,9 @@ def test_names_dimensions():
 
 
 @pytest.mark.slow_test
-@pytest.mark.parametrize('acq_func', ['EI', 'EIps', 'PI', 'PIps', 'gp_hedge', 'LCB'])
+@pytest.mark.parametrize(
+    'acq_func',
+    ['EI', 'EIps', 'PI', 'PIps', 'gp_hedge', 'LCB'])
 def test_plot_gaussian_process_works(acq_func):
 
     def objective(x):
@@ -193,7 +195,11 @@ def test_plot_gaussian_process_works(acq_func):
     else:
         obj = objective
 
-    res = gp_minimize(obj, [(-1, 1)], n_calls=2, n_initial_points=2, random_state=1,
+    res = gp_minimize(obj,
+                      [(-1, 1)],
+                      n_calls=2,
+                      n_initial_points=2,
+                      random_state=1,
                       acq_func=acq_func)
 
     plots.plot_gaussian_process(res)

--- a/skopt/tests/test_plots.py
+++ b/skopt/tests/test_plots.py
@@ -176,3 +176,24 @@ def test_names_dimensions():
 
     # Plot results
     plots.plot_objective(res)
+
+
+@pytest.mark.slow_test
+@pytest.mark.parametrize('acq_func', ['EI', 'EIps', 'PI', 'PIps', 'gp_hedge', 'LCB'])
+def test_plot_gaussian_process_works(acq_func):
+
+    def objective(x):
+        return x[0]**2
+
+    def objective_ps(x):
+        return x[0]**2, x[0]+1
+
+    if acq_func.endswith("ps"):
+        obj = objective_ps
+    else:
+        obj = objective
+
+    res = gp_minimize(obj, [(-1, 1)], n_calls=2, n_initial_points=2, random_state=1,
+                      acq_func=acq_func)
+
+    plots.plot_gaussian_process(res)


### PR DESCRIPTION
The `plot_gaussian_process` function fails if a per-second acquisition function (e.g. EIps or PIps) is used.

This is caused by passing the `return_std=True` argument to the `predict` method of the multioutput model.

Failure is reproduced in this example:
```
import numpy as np

from skopt import gp_minimize
from skopt.plots import plot_gaussian_process


def obj(x):
    return np.cos(2*np.pi*x[0])


def obj_ps(x):
    o = obj(x)
    t = 1 + (x[0] > 0)

    return o, t


res_ei = gp_minimize(obj, [(-1., 1.)], n_calls=2, n_initial_points=2, random_state=1, acq_func="EI")
res_pi = gp_minimize(obj, [(-1., 1.)], n_calls=2, n_initial_points=2, random_state=1, acq_func="PI")
res_eips = gp_minimize(obj_ps, [(-1., 1.)], n_calls=2, n_initial_points=2, random_state=1, acq_func="EIps")
res_pips = gp_minimize(obj_ps, [(-1., 1.)], n_calls=2, n_initial_points=2, random_state=1, acq_func="PIps")

plot_gaussian_process(res_ei, show_acq_func=True)  # works
plot_gaussian_process(res_pi, show_acq_func=True)  # works

plot_gaussian_process(res_eips, show_acq_func=True)  # TypeError: predict() got an unexpected keyword argument 'return_std'
plot_gaussian_process(res_pips, show_acq_func=True)  # TypeError: predict() got an unexpected keyword argument 'return_std'

plot_gaussian_process(res_eips, show_acq_func=True, show_mu=False)  # works
plot_gaussian_process(res_pips, show_acq_func=True, show_mu=False)  # works
```
This PR fixes the bug by checking if a per-second acquisition function is used and, if so, calling `predict` for the appropriate submodel.
A test is added to assert that `plot_gaussian_process` works with all available acquisition functions. 