### PR TITLE
Include point in "the objective has been evaluated at this point before" warning

### DIFF
--- a/skopt/optimizer/optimizer.py
+++ b/skopt/optimizer/optimizer.py
@@ -447,7 +447,7 @@ class Optimizer(object):
                                for xi in self.Xi])
             if abs(min_delta_x) <= 1e-8:
                 warnings.warn("The objective has been evaluated "
-                              "at this point before.")
+                              f"at {next_x!r} before.")
 
             # return point computed from last call to tell()
             return next_x


### PR DESCRIPTION
I had a problem where the optimizer was only sampling at integer points.  It would've been easier to figure out if this warning message included the duplicate point.