### PR TITLE
fix bug with float and str categories in Categorical space

### DIFF
--- a/skopt/space/space.py
+++ b/skopt/space/space.py
@@ -676,17 +676,6 @@ class Categorical(Dimension):
 
         return "Categorical(categories={}, prior={})".format(cats, prior)
 
-    def inverse_transform(self, Xt):
-        """Inverse transform samples from the warped space back into the
-           original space.
-        """
-        # The concatenation of all transformed dimensions makes Xt to be
-        # of type float, hence the required cast back to int.
-        inv_transform = super(Categorical, self).inverse_transform(Xt)
-        if isinstance(inv_transform, list):
-            inv_transform = np.array(inv_transform)
-        return inv_transform
-
     def rvs(self, n_samples=None, random_state=None):
         choices = self._rvs.rvs(size=n_samples, random_state=random_state)
 

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -166,15 +166,7 @@ class LabelEncoder(Transformer):
         X : array-like, shape=(n_categories,)
             List of categories.
         """
-        X = np.asarray(X)
-        if X.dtype == object:
-            self.mapping_ = {v: i for i, v in enumerate(X)}
-        else:
-            i = 0
-            self.mapping_ = {}
-            for v in np.unique(X):
-                self.mapping_[v] = i
-                i += 1
+        self.mapping_ = {v: i for i, v in enumerate(X)}
         self.inverse_mapping_ = {i: v for v, i in self.mapping_.items()}
         return self
 

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -192,7 +192,6 @@ class LabelEncoder(Transformer):
         Xt : array-like, shape=(n_samples, n_categories)
             The integer categories.
         """
-        X = np.asarray(X)
         return [self.mapping_[v] for v in X]
 
     def inverse_transform(self, Xt):


### PR DESCRIPTION
Fix for #958. The problem arises because a numpy array is forced on the provided input. If the list contains only numbers and strings, the numerical elements are converted to strings. Deleting these lines solves the issue.