### PR TITLE
Fixes Grid sampling with border="only"

### DIFF
--- a/skopt/sampler/grid.py
+++ b/skopt/sampler/grid.py
@@ -137,7 +137,7 @@ class Grid(InitialPointGenerator):
                 order = int(np.ceil(n_samples / 2.))
             if order < 2:
                 order = 2
-            h = _create_uniform_grid_exclude_border(n_dim, order)
+            h = _create_uniform_grid_only_border(n_dim, order)
         else:
             raise ValueError("Wrong value for border")
         if np.size(h, 0) > n_samples:


### PR DESCRIPTION
There seems to be a error in the uniform grid method when self.border == "only": 

https://github.com/scikit-optimize/scikit-optimize/blob/a2369ddbc332d16d8ff173b12404b03fea472492/skopt/sampler/grid.py#L133-L140

It should call `_create_uniform_grid_only_border` instead of `_create_uniform_grid_exclude_border`.

This can be demonstrated with this simple example with two dimensions of (0., 0.5, 1.)

```python
>>> from skopt.sampler.grid import Grid
>>> grid = Grid(border="include", append_border="exclude")
>>> samples = grid.generate([(0., 0.5, 1.), ] * 2, 4)
>>> samples
[[0.5, 0.5], [0.5, 0.5], [0.5, 0.5], [0.5, 0.5]]
```
Even though `border` is set to `only`, the interior (0.5) of the space is sampled. Since only 4 samples are requested, only the exterior should be returned.

After applying the PR, the same command shows:
```python
>>> from skopt.sampler.grid import Grid
>>> grid = Grid(border="include", append_border="exclude")
>>> samples = grid.generate([(0., 0.5, 1.), ] * 2, 4)
>>> samples
[[0.0, 0.0], [1.0, 0.0], [1.0, 1.0], [0.0, 1.0]]
```
This time, the exterior of the space is correctly sampled

