### PR TITLE
Fix tuple index out of range on plot

### DIFF
--- a/skopt/plots.py
+++ b/skopt/plots.py
@@ -1334,7 +1334,10 @@ def _evenly_sample(dim, n_points):
 def _cat_format(dimension, x, _):
     """Categorical axis tick formatter function.  Returns the name of category
     `x` in `dimension`.  Used with `matplotlib.ticker.FuncFormatter`."""
-    return str(dimension.categories[int(x)])
+    if len(dimension.categories) > x:
+        return str(dimension.categories[int(x)])
+    else:
+        return ''
 
 
 def _evaluate_min_params(result, params='result',


### PR DESCRIPTION
When you try to plot results with categories where the categories results are close to bounds you might get this error. The issue is caused by an index out of bounds of a category array during plotting results.