### PR TITLE
Replace deprecated np.int type, causing warnings.

### DIFF
--- a/skopt/learning/forest.py
+++ b/skopt/learning/forest.py
@@ -435,7 +435,7 @@ class ExtraTreesRegressor(_sk_ExtraTreesRegressor):
         mean = super(ExtraTreesRegressor, self).predict(X)
 
         if return_std:
-            if self.criterion != "mse":
+            if self.criterion not in {"mse", "friedman_mse"}:
                 raise ValueError(
                     "Expected impurity to be 'mse', got %s instead"
                     % self.criterion)

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -259,7 +259,7 @@ class Normalize(Transformer):
         if (self.high - self.low) == 0.:
             return X * 0.
         if self.is_int:
-            return (np.round(X).astype(np.int) - self.low) /\
+            return (np.round(X).astype(np.int64) - self.low) /\
                    (self.high - self.low)
         else:
             return (X - self.low) / (self.high - self.low)
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(np.int64)
         return X_orig
 
 


### PR DESCRIPTION
This small change corrects the following warning: 

DeprecationWarning: `np.int` is a deprecated alias for the builtin `int`. To silence this warning, use 
`int` by itself. Doing this will not modify any behavior and is safe. When replacing `np.int`, you may wish to use e.g. `np.int64` or `np.int32` to specify the precision. If you wish to review your current use, check the release note link for additional information.

There were only two instances of `np.int` in the `space/transformers.py` module, both of which have been changed to `np.int64`; of course, this can be another precision type instead, ex. `np.int32` or `np.int16`. The two instances of `np.int` corrected are shown below.

https://github.com/preritdas/scikit-optimize/blob/bbb7a1da30f7c0ef3763a80fe63142cb8baa7ed9/skopt/space/transformers.py#L262-L275