### PR TITLE
[MRG] Remove deprecated np.int type

### DIFF
--- a/benchmarks/bench_ml.py
+++ b/benchmarks/bench_ml.py
@@ -161,7 +161,7 @@ def load_data_target(name):
             samples = np.array(data)
             data = dict()
             data["data"] = samples[:, :-1]
-            data["target"] = np.array(samples[:, -1], dtype=np.int)
+            data["target"] = np.array(samples[:, -1], dtype=int)
     else:
         raise ValueError("dataset not supported.")
     return data["data"], data["target"]

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -259,7 +259,7 @@ class Normalize(Transformer):
         if (self.high - self.low) == 0.:
             return X * 0.
         if self.is_int:
-            return (np.round(X).astype(np.int) - self.low) /\
+            return (np.round(X).astype(int) - self.low) /\
                    (self.high - self.low)
         else:
             return (X - self.low) / (self.high - self.low)
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(int)
         return X_orig
 
 


### PR DESCRIPTION
np.int was fully removed in numpy 1.24.

See release notes for 1.20: https://numpy.org/doc/stable/release/1.20.0-notes.html