### PR TITLE
[MRG] Numpy error with transformers.py

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -259,7 +259,7 @@ class Normalize(Transformer):
         if (self.high - self.low) == 0.:
             return X * 0.
         if self.is_int:
-            return (np.round(X).astype(np.int) - self.low) /\
+            return (np.round(X).astype(np.int64) - self.low) /\
                    (self.high - self.low)
         else:
             return (X - self.low) / (self.high - self.low)
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(np.int64)
         return X_orig
 
 


### PR DESCRIPTION
Most recent numpy version works with np.int64 or np.int32 insted of just np.int, thats was generating an error when using class spaces.

#Test
from sklearn.ensemble import GradientBoostingClassifier
from skopt import BayesSearchCV
from skopt.space import Real, Categorical, Integer
from sklearn.datasets import load_iris
from sklearn.model_selection import train_test_split

# Cargar el dataset de iris
iris = load_iris()

# Dividir los datos en entrenamiento y prueba
X_train, X_test, y_train, y_test = train_test_split(iris.data, iris.target, test_size=0.3, random_state=42)

# Definir el modelo de árbol de decisiones
clf = GradientBoostingClassifier()

param_space = {
    'learning_rate': Real(1e-5, 1, prior = 'log-uniform'),
    'n_estimators': Integer(20, 1_500),
    'subsample': Real(0.05, 1),
    'max_depth': Integer(1, 10),
}

# Realizar la búsqueda bayesiana
bayes_dt = BayesSearchCV(clf, param_space, n_iter=50, cv=5, n_jobs=-1)

# Ajustar el modelo
bayes_dt.fit(X_train, y_train)

# Imprimir los mejores hiperparámetros y la puntuación del modelo
print('Mejores hiperparámetros:', bayes_dt.best_params_)
print('Puntuación del modelo:', bayes_dt.best_score_)

#End of test

If you keep using np.int insted of np.int64 or np.int32 thats will show an error saying that numpy has no method called int.

