### PR TITLE
Update transformers.py

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(np.int32)
         return X_orig
 
 


### PR DESCRIPTION
New numpy versions are getting conflicted with the np.int, so i suppose that it was intended to utilize np.int32 than replaced it. I saw that other person has requested some pull, but it was'nt implemented yet. We should see if this one of mine will work or if we need any other modifications in files.