### PR TITLE
Replace deprecated np.int with int in bench_ml.py and transformers.py

### DIFF
--- a/benchmarks/bench_ml.py
+++ b/benchmarks/bench_ml.py
@@ -161,7 +161,7 @@ def load_data_target(name):
             samples = np.array(data)
             data = dict()
             data["data"] = samples[:, :-1]
-            data["target"] = np.array(samples[:, -1], dtype=np.int)
+            data["target"] = np.array(samples[:, -1], dtype=int)
     else:
         raise ValueError("dataset not supported.")
     return data["data"], data["target"]

--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -259,7 +259,7 @@ class Normalize(Transformer):
         if (self.high - self.low) == 0.:
             return X * 0.
         if self.is_int:
-            return (np.round(X).astype(np.int) - self.low) /\
+            return (np.round(X).astype(int) - self.low) /\
                    (self.high - self.low)
         else:
             return (X - self.low) / (self.high - self.low)
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(int)
         return X_orig
 
 


### PR DESCRIPTION
This pull request addresses the use of the deprecated **np.int** in the **bench_ml.py** and **transformers.py** files.

This change helps maintain compatibility with future versions of Python and NumPy and avoids potential deprecation errors.

Specifically, the changes include:

- In **benchmark/bench_ml.py**, all instances of **np.int** were replaced with **int**.
- In **skopt/space/transformers.py**, all instances of **np.int** were replaced with **int**.

All tests have passed after these modifications. This change does not affect any functionalities or performance.