### PR TITLE
Fix issue #1171: np.int deprecated and replace by np.int64

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -259,7 +259,7 @@ class Normalize(Transformer):
         if (self.high - self.low) == 0.:
             return X * 0.
         if self.is_int:
-            return (np.round(X).astype(np.int) - self.low) /\
+            return (np.round(X).astype(np.int64) - self.low) /\
                    (self.high - self.low)
         else:
             return (X - self.low) / (self.high - self.low)
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(np.int64)
         return X_orig
 
 


### PR DESCRIPTION
## References to other Issues or PRs
Fixes issue [#1171](https://github.com/scikit-optimize/scikit-optimize/issues/1171)

## Brief description of what has been fixed
This PR replaces all instances of the deprecated `np.int` with `np.int64`. The recent updates in NumPy have led to `np.int` being deprecated, and this change ensures compatibility with the latest versions and avoids deprecation warnings.

## Release Notes
Replaced deprecated `np.int` with `np.int64` on `space/transformers.py` to eliminate deprecation warnings and maintain forward compatibility with NumPy.

([#1171](https://github.com/scikit-optimize/scikit-optimize/issues/1171) by [@boemer00](https://github.com/boemer00))
