### PR TITLE
Fix type conversion in Normalize class after Numpy 1.20 update

### DIFF
--- a/skopt/space/transformers.py
+++ b/skopt/space/transformers.py
@@ -259,7 +259,7 @@ class Normalize(Transformer):
         if (self.high - self.low) == 0.:
             return X * 0.
         if self.is_int:
-            return (np.round(X).astype(np.int) - self.low) /\
+            return (np.round(X).astype(int) - self.low) /\
                    (self.high - self.low)
         else:
             return (X - self.low) / (self.high - self.low)
@@ -272,7 +272,7 @@ class Normalize(Transformer):
             raise ValueError("All values should be greater than 0.0")
         X_orig = X * (self.high - self.low) + self.low
         if self.is_int:
-            return np.round(X_orig).astype(np.int)
+            return np.round(X_orig).astype(int)
         return X_orig
 
 


### PR DESCRIPTION


> Using the aliases of builtin types like np.int is deprecated
> For a long time, np.int has been an alias of the builtin int. This is repeatedly a cause of confusion for newcomers, and existed mainly for historic reasons.
> 
> These aliases have been deprecated. The table below shows the full list of deprecated aliases, along with their exact meaning. Replacing uses of items in the first column with the contents of the second column will work identically and silence the deprecation warning.
> 
> The third column lists alternative NumPy names which may occasionally be preferential. See also [Data types](https://numpy.org/devdocs/user/basics.types.html#basics-types) for additional details.

Source: https://numpy.org/devdocs/release/1.20.0-notes.html#deprecations